### PR TITLE
align package.json with the repository license

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "gulp build --production"
   },
   "author": "ZURB <foundation@zurb.com>",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "@babel/core": "^7.8.3",
     "@babel/preset-env": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "gulp build --production"
   },
   "author": "ZURB <foundation@zurb.com>",
-  "license": "MIT",
+  "license": "Apache 2.0",
   "dependencies": {
     "@babel/core": "^7.8.3",
     "@babel/preset-env": "^7.8.3",


### PR DESCRIPTION
The repository is flagged to be licensed under `Apache v2`, but the license in the `package.json` is set to `MIT`. Although the package is not published, this looks quite odd and should be fixed.