### PR TITLE
display Mozillas Obersovatory status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 </p>
 
 <hr />
+
+<p align="center">
+    <a href="https://observatory.mozilla.org/analyze/coronawarn.app" title="Latest Results"><img src="https://img.shields.io/mozilla-observatory/grade/coronawarn.app" alt="Mozilla HTTP Observatory Grade"></a>
+</p>
 <p align="center">
     <a href="#about-this-repository">About this Repository</a> • 
     <a href="#development">Development</a> •


### PR DESCRIPTION
This change adds a badge for Mozilla's Observatory status to display the website's security status discussed in #6.

<img width="123" alt="Bildschirmfoto 2020-05-30 um 07 10 53" src="https://user-images.githubusercontent.com/26137398/83320438-e8c7b000-a247-11ea-9fa3-8390a4aab28c.png">
