### PR TITLE
Fix link for all news in slider on German page

### DIFF
--- a/src/data/index_de.json
+++ b/src/data/index_de.json
@@ -85,7 +85,7 @@
             "target": "news",
             "button": {
                 "title": "Alle News",
-                "url": "/de/news/"
+                "url": "/de/aktuelles/"
             },
             "amount": 3
         }


### PR DESCRIPTION
The link for all news is broken in slider on German page. It points to https://www.coronawarn.app/de/news/, but it should be https://www.coronawarn.app/de/aktuelles/.