### PR TITLE
Fix typo

### DIFF
--- a/src/data/index_de.json
+++ b/src/data/index_de.json
@@ -52,7 +52,7 @@
                 "text": "Nachdem ein mobiles Gerät die Liste aller vorhandenen Schlüssel der Personen heruntergeladen hat, die positiv getestet wurden, leitet das Exposure Notification Framework die jeweiligen IDs ab und prüft lokal, ob diese den lokal gesammelten Rolling Proximity Identifiern entsprechen. Im Kontaktfall wird das Risiko eingeschätzt und die Person erhält entsprechende Handlungsanweisungen.",
                 "button": {"title": "Weitere Infos im Scoping-Dokument", "url": "https://github.com/corona-warn-app/cwa-documentation/blob/master/translations/scoping_document.de.md", "external": true},
                 "links": [{
-                        "title": "Weitere Infos im Architectur-Dokument - EN",
+                        "title": "Weitere Infos im Architektur-Dokument - EN",
                         "url": "https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md",
                         "external": true
                 }]


### PR DESCRIPTION
"Architektur-Dokument" instead of "Architectur-Dokument"