### PR TITLE
Minor fixes in faq_de.json

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -119,7 +119,7 @@
                     ]
                 },
                 {
-                    "title": "Ist das Offenlegen vom Quellcode mit diesem Open-Source-Ansatz keine Gefahr für die Cybersecurity?",
+                    "title": "Ist das Offenlegen des Quellcodes mit diesem Open-Source-Ansatz keine Gefahr für die Cyber-Security?",
                     "textblock": [
                         "Im Gegenteil: Die Open-Source-Community erhöht die Sicherheit der Software, da der Quellcode offen liegt und alle interessierten Personen den Code herunterladen und Zeile für Zeile überprüfen können.",
 						"Wir glauben daran, dass Sicherheit nicht durch Intransparenz gewährleistet wird. Deshalb verfolgen wir einen Open-Source-Ansatz."


### PR DESCRIPTION
1. Better language
2. Germanization of "cyber security" to "Cyber-Security" analogous to other English double and triple words in this text, such as "GitHub-Repositories", "Corona-Warn-App" etc.