### PR TITLE
Add a question to the FAQ

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -96,6 +96,11 @@
                     "textblock": [
                         "Preliminary versions of the app (independent of the operating system) are currently only available to the Corona-Warn-App project team and our partners (German Federal Government, Robert Koch-Institute, BSI, BfDI etc.)."
                     ]
+                },{
+                    "title" : "Who will operate the backend of the app?",
+                    "textblock": [
+                        "Deutsche Telekom will operate and run the backend for the app in a safe, scalable and stable manner."
+                    ]
                 }
             ]
         },{

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -96,6 +96,11 @@
                     "textblock": [
                         "Vorläufige Versionen der App (unabhängig vom Betriebssystem) stehen derzeit nur dem Projektteam der Corona-Warn-App und unseren Partnern (Bundesregierung, Robert-Koch-Institut, BSI, BfDI etc.) zur Verfügung."
                     ]
+                },{
+                    "title" : "Wer wird das Backend der App betreiben?",
+                    "textblock": [
+                        "Die Deutsche Telekom wird das Backend der App auf eine sichere, skalierbare und stabile Weise betreiben."
+                    ]
                 }
             ]
         },{


### PR DESCRIPTION
The question is about who will operate the backend of the app according to issue [cwa-documentation/173](https://github.com/corona-warn-app/cwa-documentation/issues/173).