### PR TITLE
remove not necessary declaration

### DIFF
--- a/src/root-assets/robots.txt
+++ b/src/root-assets/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
 Allow: /
-Allow: /sitemap.htm
 Sitemap: https://coronawarn.app/sitemap.xml


### PR DESCRIPTION
Fix the issue #21 (Remove duplicate content from robots.txt)

Remove the not necessary declaration from /sitemap.htm 