### PR TITLE
fix duplicated span-tag

### DIFF
--- a/src/partials/button-link-component.html
+++ b/src/partials/button-link-component.html
@@ -1,5 +1,5 @@
 {{#if button}}
 <a class="btn btn-link btn-link_narrow btn-link_icon" title="{{#if titleprefix}}{{titleprefix}} {{/if}}{{button.title}}"
     href="{{button.url}}"{{#if button.external}} target="_blank"{{/if}}>{{#if titleprefix}}{{titleprefix}} {{/if}}{{button.title}}<span
-        class="icon {{#if direction}}{{#unless button.direction}}icon_arrow-{{direction}}{{/unless}}{{/if}}{{#if button.direction}}icon_arrow-{{button.direction}}{{/if}}{{#unless direction}}{{#unless button.direction}}icon_arrow-right{{/unless}}{{/unless}}"></span></span></a>
+        class="icon {{#if direction}}{{#unless button.direction}}icon_arrow-{{direction}}{{/unless}}{{/if}}{{#if button.direction}}icon_arrow-{{button.direction}}{{/if}}{{#unless direction}}{{#unless button.direction}}icon_arrow-right{{/unless}}{{/unless}}"></span></a>
 {{/if}}

--- a/src/partials/error-page-content.html
+++ b/src/partials/error-page-content.html
@@ -24,7 +24,7 @@
               {{/if}}
               {{#if button}}
               <a class="btn btn-link btn-link_narrow btn-link_icon" title="{{button.title}}"
-                href="{{button.url}}"{{#if button.external}} target="_blank"{{/if}}>{{button.title}}<span class="icon icon_arrow-right"></span></span></a>
+                href="{{button.url}}"{{#if button.external}} target="_blank"{{/if}}>{{button.title}}<span class="icon icon_arrow-right"></span>/a>
               {{/if}}
             </div>
           </div>


### PR DESCRIPTION
There are duplicated span-tag, which cause errors on w3c validator.

https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.coronawarn.app%2Fde%2F