### PR TITLE
Avoid the word "person" in connection with cwa-server 

### DIFF
--- a/src/data/index_de.json
+++ b/src/data/index_de.json
@@ -43,7 +43,7 @@
                 "index": "03.",
                 "image": {"url": "/assets/img/how-it-works-3.svg"},
                 "title": "Liste von Schlüsseln der als infiziert gemeldeten Personen verteilen",
-                "text": "Im Falle eines positiven Testergebnisses werden Personen gebeten, ihre temporären Schlüssel der letzten 14 Tage auf den Server hochzuladen. Um Missbrauch zu verhindern, verifiziert das Backend der Corona-Warn-App zuerst das positive Testergebnis. Bei einer Bestätigung fügt der Server die Schlüssel der Person in die Liste der als infiziert gemeldeten Personen ein, die regelmäßig an alle Apps gesendet wird."
+                "text": "Im Falle eines positiven Testergebnisses werden Personen gebeten, ihre temporären Schlüssel der letzten 14 Tage auf den Server hochzuladen. Um Missbrauch zu verhindern, verifiziert das Backend der Corona-Warn-App zuerst das positive Testergebnis. Bei einer Bestätigung fügt der Server die temporären Schlüssel in eine Liste ein, die regelmäßig an alle Apps gesendet wird."
             },
             {
                 "index": "04.",


### PR DESCRIPTION
Avoid the (incorrect) impression that cwa-server keeps a list of infected _persons_.