### PR TITLE
Revert "fix CSP"

### DIFF
--- a/src/layouts/default.html
+++ b/src/layouts/default.html
@@ -5,7 +5,7 @@
     <meta name="description" content="{{#if page-description}}{{page-description}}{{/if}}" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' *.coronawarn.app; img-src 'self' *.coronawarn.app data;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' *.coronawarn.app; img-src 'self' *.coronawarn.app data:" />
     <meta name="referrer" content="no-referrer" />
     {{#if global.favicon}}
     {{> favicon favicon=global.favicon}}


### PR DESCRIPTION
Reverts corona-warn-app/cwa-website#43

The previous CSP is valid - at least according to some validators and how I understand https://content-security-policy.com/ and https://www.w3.org/TR/CSP/

#43 changed the directive for img-src from the _scheme_ data: to the URI 'data'. As we have Base64-encoded images on the page, #43 breaks the display of these images. 

Yes, 'data' is absolutely discouraged by W3C (see https://www.w3.org/TR/CSP3/#csp-directives), but as we need Base64 images and we limit it to images, we went for it initially.

Additional PRs to make our CSP more secure are absolutely appreciated, but they shouldn't break the page's UX.