### PR TITLE
Redirect to german page when lang_de is set

### DIFF
--- a/src/assets/js/redirect.js
+++ b/src/assets/js/redirect.js
@@ -1,0 +1,6 @@
+if((navigator.language || navigator.userLanguage).toLowerCase().indexOf('de') >= 0) {
+  window.location.href = "./de/";
+}
+else {
+  window.location.href = "./en/";
+}

--- a/src/layouts/redirect.html
+++ b/src/layouts/redirect.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="description" content="{{#if page-description}}{{page-description}}{{/if}}" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta http-equiv="refresh" content="2; URL=https://www.coronawarn.app/en/">
+    <meta http-equiv="refresh" content="2; URL=https://www.coronawarn.app/{{#unless lang_de}}en{{/unless}}{{#if lang_de}}de{{/if}}/">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {{#if global.favicon}}
     <link
@@ -15,16 +15,8 @@
     />
     {{/if}}
 
-    <link rel="stylesheet" href="{{root}}assets/css/style.css" />
     <title>{{page-title}}</title>
-    <script language="javascript">
-      if((navigator.language || navigator.userLanguage).toLowerCase().indexOf('de') >= 0) {
-        window.location.href = "./de/";
-      }
-      else {
-        window.location.href = "./en/";
-      }
-    </script>
+    <script src="{{root}}assets/js/redirect.js"></script>
   </head>
   <body>
   </body>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,4 +1,5 @@
 ---
+lang_de: true
 layout: redirect
 page-title: Open-Source-Projekt für Corona-Warn-App
 page-description: Website des Open-Source-Projekts für die Corona-Warn-App. Die Corona-Warn-App ist eine App, die hilft, Infektionsketten des Coronavirus in Deutschland nachzuverfolgen.


### PR DESCRIPTION
The inline script is nonsence because of the Content-Security-Policy. It prints out a warning and redirects to the english version via meta at any time. 
`Refused to apply inline style because it violates the following Content Security Policy directive: "default-src 'self' *.coronawarn.app". Either the 'unsafe-inline' keyword, a hash ('sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'style-src' was not explicitly set, so 'default-src' is used as a fallback.`
The javascript did not work on any of my browsers. But of curse, I neither use Safari nor Internet Explorer