### PR TITLE
[trivial] Remove superfluous verb from sentence

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -134,7 +134,7 @@
                 {
                     "title": "Wird mein Smartphone-Akku nicht schnell leerlaufen mit der App im Hintergrund?",
                     "textblock": [
-                        "Die Corona-Warn-App nutzt die vorhandene Bluetooth-Technologie der Endgeräte. Da die App die Exposure Notification API von Apple und Google verwendet, unterstützt sie die energieeffiziente Bluetooth-Technologie BLE (Bluetooth Low Energy) verwenden."
+                        "Die Corona-Warn-App nutzt die vorhandene Bluetooth-Technologie der Endgeräte. Da die App die Exposure Notification API von Apple und Google verwendet, unterstützt sie die energieeffiziente Bluetooth-Technologie BLE (Bluetooth Low Energy)."
                     ]
                 },
                 {


### PR DESCRIPTION
The sentence contains two verbs, one of which is probably from a previous version of that sentence:

> ..., unterstützt sie die energieeffiziente Bluetooth-Technologie BLE (Bluetooth Low Energy) ~verwenden~.