### PR TITLE
FAQ EN: small typo

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -227,7 +227,7 @@
                     ]
                 },
                 {
-                    "title": "Which data will be saved und who can access this data through Bluetooth?",
+                    "title": "Which data will be saved and who can access this data through Bluetooth?",
                     "textblock": [
                         "Bluetooth will be used to send constantly changing random IDs from other devices that have installed the app. No personal, geo-location, or other location data will be sent or stored.",
                         "Through use of the Exposure Notification API from Google and Apple, the random IDs will remain in a secure area of the device's operating system. The matching, which determines whether someone has been exposed to an infected person, is performed on the local device. The device will not send any data for matching.",


### PR DESCRIPTION
"und" has been changed to "and" in one of the questions