### PR TITLE
Fix margin on GitHub icon in top navigation

### DIFF
--- a/src/assets/scss/_header.scss
+++ b/src/assets/scss/_header.scss
@@ -19,7 +19,7 @@
         top: 0;
         position: sticky;
         z-index: 2;
-        
+
         @media(min-width: $screen-md){
             z-index: auto;
             position: relative;
@@ -280,6 +280,7 @@
             .nav-link-icon {
                 &.icon_github {
                     position: relative;
+                    margin-right: 10px;
                     &:before {
                         content: "";
                         background-image: url("../img/icons/github_white.svg");


### PR DESCRIPTION
GitHub icon in navigation had irregular margin / distance. Added `margin-right`