### PR TITLE
Replace deprecated nobr tag by CSS (fix W3C errors)

### DIFF
--- a/src/assets/scss/_type.scss
+++ b/src/assets/scss/_type.scss
@@ -171,3 +171,7 @@ h3,
     margin-top: 1.2rem;
   }
 }
+
+.nobr {
+  white-space: nowrap;
+}

--- a/src/data/index.json
+++ b/src/data/index.json
@@ -250,7 +250,7 @@
             ],
             "headline" : {
                 "title": "Get the App!",
-                "text": "Now available via <nobr>App Store</nobr> and <nobr>Google Play Store</nobr>."
+                "text": "Now available via <span class='nobr'>App Store</span> and <span class='nobr'>Google Play Store</span>."
             }
         }
     },

--- a/src/data/index_de.json
+++ b/src/data/index_de.json
@@ -250,7 +250,7 @@
             ],
             "headline" : {
                 "title": "App mit!",
-                "text": "Jetzt zum Download verfügbar im <nobr>Apple App Store</nobr> und auf <nobr>Google Play</nobr>."
+                "text": "Jetzt zum Download verfügbar im <span class='nobr'>Apple App Store</span> und auf <span class='nobr'>Google Play</span>."
             }
         }
     },


### PR DESCRIPTION
This fixes two errors reported by https://validator.w3.org/.

Signed-off-by: Stefan Weil <sw@weilnetz.de>