### PR TITLE
Add deeplinks for FAQs, resolves #71

### DIFF
--- a/src/helpers/prettyurl.js
+++ b/src/helpers/prettyurl.js
@@ -1,0 +1,3 @@
+module.exports = function(string) {
+    return string.toLowerCase().replace(/[\W_]+/g," ").trim().replace(/\s/g, '-')
+}

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -18,7 +18,7 @@
       <dl class="accordion js-accordion" data-toggle="accordion-header">
       {{#each accordion}}
         <dt class="accordion-header{{#if active}} active{{/if}}">
-          <h4 class="accordion-item-title">{{title}}</h4>
+          <h4 class="accordion-item-title" id="{{prettyurl title}}">{{title}}</h4>
           <span class="accordion-item-icon"></span>
         </dt>
         <dd class="accordion-body">


### PR DESCRIPTION
This PR adds auto-generated deeplinks to the FAQ section, based on the given title. It (partially) resolves #71.

<img width="941" alt="Bildschirmfoto 2020-06-17 um 11 48 44" src="https://user-images.githubusercontent.com/845131/84883198-8d435200-b090-11ea-8b43-fc85804f8802.png">
