### PR TITLE
Add statement on "Exposure Notifications Region Changed" dialog on iOS to FAQ

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -55,6 +55,13 @@
                     "textblock": [
                         "We don’t plan to implement the app for tablets, smart watches, and other wearables. Our focus is on smart phones, for example because of the availability of the required APIs. If we change this approach, we will of course widely communicate this."
                     ]
+                },{
+                    "active": true,
+                    "title" : "Why do I repeatedly see a dialog saying \"Exposure Notifications Region Changed\" on my iPhone?",
+                    "anchor": "ios135",
+                    "textblock": [
+                        "This alert and a not enough space error comes from the Exposure-Notification-Framework. This is a bug by Apple, already reported to Apple and will be fixed soon. You can ignore this message, as it will not affect the functionality of the app. In the Settings app of your iPhone, you can verify that the protocol is still active under Data \"Protection/Health/COVID-19 Exposure Loggin\"."
+                    ]
                 }
             ]
         },{

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -60,7 +60,7 @@
                     "title" : "Why do I repeatedly see a dialog saying \"Exposure Notifications Region Changed\" on my iPhone?",
                     "anchor": "ios135",
                     "textblock": [
-                        "This alert and a not enough space error comes from the Exposure-Notification-Framework. This is a bug by Apple, already reported to Apple and will be fixed soon. You can ignore this message, as it will not affect the functionality of the app. In the Settings app of your iPhone, you can verify that the protocol is still active under Data \"Protection/Health/COVID-19 Exposure Loggin\"."
+                        "This alert comes from the Exposure-Notification-Framework. This is a bug by Apple, already reported to Apple and will be fixed soon. You can ignore this message, as it will not affect the functionality of the app. In the Settings app of your iPhone, you can verify that the exposure logging protocol is still active under \"Data Protection/Health/COVID-19 Exposure Logging\"."
                     ]
                 }
             ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -55,6 +55,13 @@
                     "textblock": [
                         "Eine Umsetzung auf Tablets, Smartwatches und Wearables ist im Moment nicht geplant. Wir konzentrieren uns – auch aufgrund der Verfügbarkeit der nötigen Schnittstellen – ausschließlich auf Smartphones. Sollte sich daran etwas ändern, werden wir das entsprechend kommunizieren und bewerben."
                     ]
+                },{
+                    "active": true,
+                    "title" : "Warum sehe ich wiederholt einen Dialog mit der Nachricht \"Region für Kontaktermittlung geändert\" auf meinem iPhone?",
+                    "anchor": "ios135",
+                    "textblock": [
+                        "Diese Meldung kommt von Apple's Exposure Notification Framework. Sie basiert auf einem Fehler von Apple, wurde bereits an Apple gemeldet und soll bald behoben werden. Diese Meldung beeinträchtig die Funktion der App nicht und kann ignoriert werden. Sie können sich in der Einstellungen ihres iPhones unter \"Datenschutz/Health/COVID-19-Kontaktprotokoll\" davon versichern, dass das Protokoll weiterhin aktiv ist."
+                    ]
                 }
             ]
         },{


### PR DESCRIPTION
Addresses clarifying the question raised in https://github.com/corona-warn-app/cwa-app-ios/issues/645 by adding the matter to the FAQ