### PR TITLE
tiny wording improvement in "Can I be identified as COVID-19-positive…

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -303,7 +303,7 @@
                     "anchor": "traffic_monitoring",
                     "textblock": [
                         "State of the art and well-established encryption mechanisms, for example using HTTP over TLS (HTTPS), ensure that messages are not readable for outside viewers. Metadata is removed before processing user data for the transmission of diagnosis keys. This prevents data from being linked together at database level.",
-                        "Furthermore, various additional technical measures will be introduced shortly, for example, by randomly creating and sending false notifications. These false notifications cannot be distinguished from valid notifications and create a type of background noise. The transmission of TANs and upload of infection data cannot be distinguished from this background noise. So, even with monitored network traffic, plausible deniability is still possible."
+                        "Furthermore, various additional technical measures will be introduced shortly, for example, by randomly creating and sending false notifications that will be discarded on the server side. These false notifications cannot be distinguished from valid notifications and create a type of background noise. The transmission of TANs and upload of real infection data cannot be distinguished from this background noise. So, even with monitored network traffic, plausible deniability is still possible."
                     ]
                 },
                 {


### PR DESCRIPTION
… by network traffic monitoring"

Hi, people might get worried by the words "false notifications", 
so my addition mentions that they have no consequences on the server side. 
The diff is a bit difficult to grasp first sight, I added:

... and sending false notifications *that will be discarded on the server side*. 
and
... and upload of *real* infection data cannot be distinguished from this background noise. 

Yours, Steffen