### PR TITLE
Change "Bring me to GitHub" -> "Take me to GitHub"

### DIFF
--- a/src/data/community.json
+++ b/src/data/community.json
@@ -91,7 +91,7 @@
         "headline":{
             "title": "Start contributing!",
             "button": {
-                "title": "Bring me to GitHub",
+                "title": "Take me to GitHub",
                 "url": "https://github.com/corona-warn-app",
                 "icon": "github",
                 "external": true


### PR DESCRIPTION
Minor language tweak. It would be a little strange asking someone to bring you somewhere. Asking someone to take you somewhere makes a little more sense. 

You wouldn't ask a taxi driver to bring you somewhere, for example, but to take you to your destination. 