### PR TITLE
FAQ (EN+DE): New question about exposure log not being checked

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -53,6 +53,13 @@
                     ]
                 },{
                     "active": true,
+                    "title" : "Apple: In my COVID-19 Exposure Logging settings it says: 'Corona-Warn has checked your log of collected random IDs 0 times over the past 24 hours.' Does this mean that exposure logging isn’t working?",
+                    "anchor": "no_log_check",
+                    "textblock": [
+                        "Exposure logging is working, don’t worry. You can find this iOS note under 'Settings' > 'Privacy' > 'Health' > 'COVID-19 Exposure Logging'. It means that the back-end server has not sent any diagnosis keys to your device yet, so Corona-Warn-App hasn’t received anything to check against the collected random IDs on your phone. As soon as persons diagnosed with COVID-19 have uploaded their diagnosis keys, this check is triggered."
+                    ]
+                },{
+                    "active": true,
                     "title" : "Will the app also be available on tablets, smart watches, and other wearables?",
                     "anchor": "smartwatch",
                     "textblock": [

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -53,6 +53,13 @@
                     ]
                 },{
                     "active": true,
+                    "title" : "Apple: In den Einstellungen für das COVID-19-Kontaktprotokoll steht: 'Corona-Warn hat dein Protokoll mit erfassten zufälligen IDs während der letzten 24 Stunden 0-mal überprüft'. Funktioniert die Risiko-Ermittlung nicht?",
+                    "anchor": "no_log_check",
+                    "textblock": [
+                        "Doch, die Risiko-Ermittlung funktioniert. Dieser Hinweis unter 'Einstellungen' > 'Datenschutz' > 'Health' > 'COVID-19-Kontaktprotokoll' stammt von iOS und bedeutet, dass der Backend-Server noch keine Diagnoseschlüssel (Positivkennungen) an Dein Gerät versendet hat und die Corona-Warn-App damit auch noch keinen Abgleich mit den auf Deinem Gerät gesammelten Zufallscodes durchführen konnte. Sobald Corona-positiv getestete Personen ihren Diagnoseschlüssel (Positivkennung) hochgeladen haben, wird dieser Abgleich ausgelöst."
+                    ]
+                },{
+                    "active": true,
                     "title" : "Wird es die App auch für Tablets, Smartwatches und andere Wearables geben?",
                     "anchor": "smartwatch",
                     "textblock": [


### PR DESCRIPTION
Added new question: "Apple: In den Einstellungen für das COVID-19-Kontaktprotokoll steht: „Corona-Warn hat dein Protokoll mit erfassten zufälligen IDs während der letzten 24 Stunden 0-mal überprüft“. Funktioniert die Risiko-Ermittlung nicht?" / "Apple: In my COVID-19 Exposure Logging settings it says: “Corona-Warn has checked your log of collected random IDs 0 times over the past 24 hours.” Does this mean that exposure logging isn’t working?"