### PR TITLE
Update scroll menu active item

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -18,6 +18,24 @@ $(document).ready(function(){
         $(this).parents('.js-menu').first().find('a').removeClass('active');
         $(this).addClass('active');
     });
+
+    const anchors = Array.from(document.querySelectorAll('.js-anchor'));
+    document.addEventListener('scroll', () => {
+        const negativeOffsets = anchors
+            .map((anchor) => Math.floor(anchor.getBoundingClientRect().top))
+            .filter(offset => offset <= 0);
+        const current = negativeOffsets.indexOf(Math.max(...negativeOffsets));
+
+        if (current >= 0) {
+            const hash = '#' + anchors[current].id;
+
+            if (location.hash !== hash) {
+                history.replaceState(null, null, hash);
+                window.dispatchEvent(new HashChangeEvent('hashchange'));
+            }
+        }
+    });
+
     $('.js-slider').slick({
         dots: true,
         infinite: true,

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -46,6 +46,10 @@ $(document).ready(function(){
                 newItem.classList.add('active');
             }
         });
+
+        if (location.hash !== '') {
+            window.dispatchEvent(new HashChangeEvent('hashchange'));
+        }
     }
 
     $('.js-slider').slick({

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -36,6 +36,18 @@ $(document).ready(function(){
         }
     });
 
+    const menu = document.querySelector('.js-scroll-navigate');
+    if (menu !== null) {
+        window.addEventListener('hashchange', () => {
+            const oldItem = menu.querySelector('a.active');
+            const newItem = menu.querySelector('a[href="' + location.hash + '"]');
+            if (newItem !== null && oldItem !== null) {
+                oldItem.classList.remove('active');
+                newItem.classList.add('active');
+            }
+        });
+    }
+
     $('.js-slider').slick({
         dots: true,
         infinite: true,

--- a/src/partials/text-component.html
+++ b/src/partials/text-component.html
@@ -1,5 +1,5 @@
 {{#if title}}
-<h4 class="headline"{{#if id}} id="{{id}}"{{/if}}>{{title}}</h4>
+<h4 class="headline{{#if id}} js-anchor{{/if}}"{{#if id}} id="{{id}}"{{/if}}>{{title}}</h4>
 {{/if}}
 {{#if text}}
 <p>{{{text}}}</p>


### PR DESCRIPTION
This resolves #128.

For all headline text elements containing an id, the location hash will be updated once this element reaches the top of the screen when scrolling.

Whenever the location hash changes, whether through the scroll listener or through a click on the FAQ sidebar menu, the active item in the menu will be updated accordingly.

If there is a hash set on page load, an initial 'hashchange' is fired to ensure the menu state is correct.