### PR TITLE
faq: remove unnecessary class name from deeplinks

### DIFF
--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -28,7 +28,7 @@
             <p>{{{.}}}</p>
             {{/each}}
             {{/if}}
-            <p>{{#if anchor}}<a class="nav-link" href="#{{anchor}}">{{../../page-contents.section-main.texts.permalink}}</a>{{/if}}</p>
+            <p>{{#if anchor}}<a href="#{{anchor}}">{{../../page-contents.section-main.texts.permalink}}</a>{{/if}}</p>
           </div>
         </dd>
       {{/each}}


### PR DESCRIPTION
Fixes #130