### PR TITLE
accessibility: increase color contrast ratio to >7

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -18,7 +18,7 @@ $gray-700: #495057 !default;
 $black:    #000 !default;
 
 //added
-$blue:       #1294d4 !default;
+$blue:       #006082 !default;
 $blue-light: #80cdec !default;
 $blue-pale:  #d4eaf7 !default;
 $blue-ice:   #edf2f7 !default;


### PR DESCRIPTION
_this fixes #93_ 
and increeses the lighthouse score!

Lighthouse requires a color contrast ration of >7. The current value is 3.38.
I'll changed the clolor `blue` to be above 7 (Level AAA) - and still look good :wink:. 

see [TR/WCAG21#contrast-minimum](https://www.w3.org/TR/WCAG21/#contrast-minimum)

![image](https://user-images.githubusercontent.com/600565/86392898-7a3d9e00-bc9c-11ea-8071-6355069d8456.png)


