### PR TITLE
FAQ (EN/DE): remove 'project' from headline title

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1,7 +1,7 @@
 {
     "section-main": {
         "headline": {
-            "title": "Frequently Asked Questions about the Corona-Warn-App project"
+            "title": "Frequently Asked Questions about the Corona-Warn-App"
         },
         "texts": {
             "permalink": "Link to this answer",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1,7 +1,7 @@
 {
     "section-main": {
         "headline": {
-            "title": "Häufig gestellte Fragen zum Corona-Warn-App-Projekt"
+            "title": "Häufig gestellte Fragen zur Corona-Warn-App"
         },
         "texts": {
             "permalink": "Link zu dieser Antwort",


### PR DESCRIPTION
adapting to current content