### PR TITLE
Soft Hyphen to avoid overlapping FAQ section navigation (closes #217)

### DIFF
--- a/src/assets/scss/_nav.scss
+++ b/src/assets/scss/_nav.scss
@@ -27,9 +27,6 @@
     cursor: default;
   }
 
-  .nav-link span.nicebreak {
-    hyphens: manual;
-  }
 }
 
 //

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -11,7 +11,7 @@
         },
         "sections": [
             {
-                "title": "Hintergrundaktualisierung",
+                "title": "Hintergrund&shy;aktualisierung",
                 "active": true,
                 "id": "background_updates",
                 "accordion": [

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -5,7 +5,7 @@
     <ul class="nav flex-column js-scroll-navigate" data-target="main">
       {{#each page-contents.section-main.sections}}
       <li class="nav-item">
-        <a class="nav-link{{#if active}} active{{/if}}"{{#if id}} href="#{{id}}"{{/if}}>{{title}}</a>
+        <a class="nav-link{{#if active}} active{{/if}}"{{#if id}} href="#{{id}}"{{/if}}>{{{title}}}</a>
       </li>
       {{/each}}
     </ul>

--- a/src/partials/text-component.html
+++ b/src/partials/text-component.html
@@ -1,5 +1,5 @@
 {{#if title}}
-<h4 class="headline{{#if id}} js-anchor{{/if}}"{{#if id}} id="{{id}}"{{/if}}>{{title}}</h4>
+<h4 class="headline{{#if id}} js-anchor{{/if}}"{{#if id}} id="{{id}}"{{/if}}>{{{title}}}</h4>
 {{/if}}
 {{#if text}}
 <p>{{{text}}}</p>


### PR DESCRIPTION
Using &shy; at the proper point in the string avoids that it will overlap the real FAQ text on mobile devices.
To render that properly, triple curly brackets needed to be introduced for two strings.