### PR TITLE
Prevent Double Highlighting

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -47,7 +47,6 @@
             {
                 "title": "Common Issues",
                 "id": "most_asked",
-                "active": true,
                 "accordion": [
                    {
                         "title": "An encounter has been reported, but the risk status stays green",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -47,7 +47,6 @@
             {
                 "title": "Häufige Probleme",
                 "id": "most_asked",
-                "active": true,
                 "accordion": [
                   {
                         "title": "Ich habe eine Risikobegegnung, mir wird aber nach wie vor ein niedriges Risiko angezeigt",


### PR DESCRIPTION
Fixing double highlighting on deep links by not activating both top nav entries.

Note to future self: Fix this the right way by altering the scrolling behavior which expects only a single item to be selected at all times ... or by enforcing that only a single item is selected at all times.