### PR TITLE
Fixing annoying zoom on mobile devices (closes #287)

### DIFF
--- a/src/assets/scss/_faq.scss
+++ b/src/assets/scss/_faq.scss
@@ -1,0 +1,3 @@
+#faq-search {
+    font-size: 16px;
+}

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -82,3 +82,4 @@ $utilities: map-get-multiple(
 @import "vendor/slick";
 @import "slider";
 @import "blog";
+@import "faq";

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -15,11 +15,13 @@
 
     <form method="get" id="faq-search-form">
       <!-- Actual search box -->
-      <div class="input-group mb-2 mr-sm-2">
-        <div class="input-group-prepend input-group-sm">
-          <div class="input-group-text"><span id="match-count">X / X</span>&nbsp;{{page-contents.section-main.texts.questions}}</div>
+      <div class="input-group input-group-sm">
+        <div class="input-group-text">
+          <span class="input-group-addon">
+            <span id="match-count">X / X</span>&nbsp;{{page-contents.section-main.texts.questions}}
+          </span>
         </div>
-        <input type="text" class="form-control form-control-sm" placeholder="{{page-contents.section-main.texts.search}}" id="faq-search" name="search">
+        <input type="text" class="form-control" placeholder="{{page-contents.section-main.texts.search}}" id="faq-search" name="search">
       </div>
     </form>
     <hr />


### PR DESCRIPTION
Turns out that apple zooms in on inputs that have a font size smaller than 16px
Hence, this PR cleans up the faq-search input and assigns a proper font size. This prevents the annoying zoom-in when entering texts.