### PR TITLE
Mitigate wrong links in app error message

### DIFF
--- a/src/assets/js/static/faq-redirect.js
+++ b/src/assets/js/static/faq-redirect.js
@@ -1,0 +1,6 @@
+// get the target faq anchor from the script attributes
+const targetFaq = document.currentScript.getAttribute('target-faq');
+// get the current url
+const curPage = window.location.href;
+// replace the part from the last slash to the end of the string with the proper hash
+window.location.href = curPage.replace(/\/[^\/]*$/, '#' + targetFaq);

--- a/src/pages/de/faq/(39508).html
+++ b/src/pages/de/faq/(39508).html
@@ -1,0 +1,7 @@
+---
+lang_de: true
+page-title: Open-Source-Projekt für Corona-Warn-App – FAQ
+page-description: Antworten auf häufig gestellte Fragen über das Open-Source-Projekt für die Corona-Warn-App. Die Corona-Warn-App ist eine App, die hilft, Infektionsketten des Coronavirus in Deutschland nachzuverfolgen.
+page-name: 39508
+---
+{{> faq-redirect target-faq="API39508"}}

--- a/src/pages/en/faq/(39508).html
+++ b/src/pages/en/faq/(39508).html
@@ -1,0 +1,7 @@
+---
+lang_en: true
+page-title: Open-Source Project Corona-Warn-App – FAQ
+page-description: FAQ for the open-source project Corona-Warn-App. The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany.
+page-name: 39508
+---
+{{> faq-redirect target-faq="API39508"}}

--- a/src/partials/faq-redirect.html
+++ b/src/partials/faq-redirect.html
@@ -1,0 +1,3 @@
+{{#if target-faq}}
+<script src="{{root}}assets/js/static/faq-redirect.js" target-faq="{{target-faq}}"></script>
+{{/if}}


### PR DESCRIPTION
It seems the URL for the error message of the 39508 error is wrong within the app (https://github.com/corona-warn-app/cwa-app-android/issues/1021).
This PR **mitigates** that by taking the wrong link and redirecting to the proper FAQ entry. 

## Disclaimer!
This should not be a long-living solution. If the link in the app is fixed, remove the two `(39508).html` files (I'll create a separate issue as a reminder). You can keep the faq-redirect.js and faq-redirect.html files just in case ^^