### PR TITLE
Change "Android" to "Apple"

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -333,7 +333,7 @@
                             "For each day, there is an entry for each of the last 14 days, see <a href='#multiple_exposure_checks' target='_blank' rel='noopener noreferrer'>My exposure log shows multiple, simultaneous checks for exposures</a>.",
                             "<b>Provided Key Count</b> (Apple) | <b>Number of keys</b> (Android)",
                             "This is the number of keys related to a positive test result, so called diagnosis keys, that your phone downloaded from the server.",
-                            "<b>Matched Key Count</b> (Android) | <b>Number of matches</b> (Android)",
+                            "<b>Matched Key Count</b> (Apple) | <b>Number of matches</b> (Android)",
                             "This is the number of keys that your phone collected for which there is a matching diagnosis key. If the number is not 0, then you had an exposure. If your risk status stays green, that is, 'Low Risk', find more information at <a href='#encounter_but_green' target='_blank' rel='noopener noreferrer'>An encounter has been reported, but the risk status stays green</a>.",
                             "<b>Timestamp</b>",
                             "Date and time at which the check happened. This is independent of the timestamp of potential exposures since every key stored in the downloaded files, a separate validity timestamp is stored.",


### PR DESCRIPTION
The FAQ mentions Matched Key Count (Android), when Matched Key Count is a term used by iOS.

I would have chosen the word "iOS", but "Apple" is already used in a similar case immediately above for `Provided Key Count`.

Closes #304