### PR TITLE
Remove redirects from Blog List

### DIFF
--- a/src/helpers/blogentries.js
+++ b/src/helpers/blogentries.js
@@ -1,5 +1,5 @@
 const { getBlogEntries } = require('../services/blog-processor');
 
 module.exports = (lang) => {
-  return getBlogEntries(lang).map(entry => entry.blogOverview).join('\r\n');
+  return getBlogEntries(lang, true).map(entry => entry.blogOverview).join('\r\n');
 }

--- a/src/helpers/blogentries.js
+++ b/src/helpers/blogentries.js
@@ -1,5 +1,6 @@
 const { getBlogEntries } = require('../services/blog-processor');
 
 module.exports = (lang) => {
-  return getBlogEntries(lang, true).map(entry => entry.blogOverview).join('\r\n');
+  // get only blog entries that are not redirects and for each entry have an overview
+  return getBlogEntries(lang).filter(entry => {return entry.redirect === undefined}).map(entry => entry.blogOverview).join('\r\n');
 }

--- a/src/services/blog-processor.js
+++ b/src/services/blog-processor.js
@@ -68,7 +68,7 @@ const validatePageName = (folderName, name) => {
     }
 }
 
-const getBlogEntries = (lang, skipRedirects = false) => {
+const getBlogEntries = (lang) => {
   return readdirSync(blogMdPath())
     .filter(folderName => hasValidDate(folderName))
     .sort()
@@ -86,9 +86,6 @@ const getBlogEntries = (lang, skipRedirects = false) => {
       const mdData = frontmatter(fileContent);
       return createPageEntry(folderName, mdData, lang)
     })
-    .filter(entry => {
-      return skipRedirects && entry.redirect === undefined
-    });
 }
 
 const createPageEntry =  (folderName, mdData, lang) => {

--- a/src/services/blog-processor.js
+++ b/src/services/blog-processor.js
@@ -85,7 +85,7 @@ const getBlogEntries = (lang) => {
       })();
       const mdData = frontmatter(fileContent);
       return createPageEntry(folderName, mdData, lang)
-    })
+    });
 }
 
 const createPageEntry =  (folderName, mdData, lang) => {

--- a/src/services/blog-processor.js
+++ b/src/services/blog-processor.js
@@ -68,7 +68,7 @@ const validatePageName = (folderName, name) => {
     }
 }
 
-const getBlogEntries = (lang) => {
+const getBlogEntries = (lang, skipRedirects = false) => {
   return readdirSync(blogMdPath())
     .filter(folderName => hasValidDate(folderName))
     .sort()
@@ -85,6 +85,9 @@ const getBlogEntries = (lang) => {
       })();
       const mdData = frontmatter(fileContent);
       return createPageEntry(folderName, mdData, lang)
+    })
+    .filter(entry => {
+      return skipRedirects && entry.redirect === undefined
     });
 }
 


### PR DESCRIPTION
Currently the redirects are represented as "undefined" entries. This PR removes them from the overview while leaving the list intact.