### PR TITLE
The FAQ search JS code should not care about the language

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -194,9 +194,15 @@ function images_webp() {
     .pipe(gulp.dest(PATHS.dist + '/assets/img'));
 }
 
-function copyFAQs() {
+function copyFAQs(done){
+  copyFAQ("de");
+  copyFAQ("en");
+  done();
+}
+
+function copyFAQ(lang) {
   return gulp
-    .src(["src/data/faq.json", "src/data/faq_de.json"])
+    .src(`src/data/faq${(lang === "en" ? "" : ("_" + lang))}.json`)
     .pipe(jsonTransform(function (data, file) {
       let faq = {}
       data['section-main'].sections.forEach((section) => {
@@ -207,7 +213,8 @@ function copyFAQs() {
       });
       return faq;
     }))
-    .pipe(gulp.dest(PATHS.dist + "/assets/data"));
+    .pipe(rename('faq.json'))
+    .pipe(gulp.dest(PATHS.dist + `/${lang}/faq/`));
 }
 
 function copyFAQRedirects() {

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -145,12 +145,8 @@ $(document).ready(function(){
     let searchField = document.getElementById("faq-search");
     if(searchField !== null){
         let faq = {};
-        // determine the right filename suffix based on the path
-        let lang = window.location.pathname.slice(0,3);
-        let fn = "faq" + (lang === "/de" ? "_de" : "") + ".json";
-
-        // do an AJAX call to get the right FAQ document
-        $.get("/assets/data/" + fn, (data) => {
+        // do an AJAX call to get the searchable FAQ document
+        $.get("faq.json", (data) => {
             faq = data;
             let faqCount = Object.keys(data).length.toString();
             document.getElementById("match-count").innerHTML = faqCount + "/" + faqCount;


### PR DESCRIPTION
Before, the JS would check the url path for the language and then determine which file to download. Now, it only expects an `faq.json` file in its folder and gulp build takes care of creating these files accordingly.