### PR TITLE
Remove HTML Tags from searchable FAQ

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -208,7 +208,7 @@ function copyFAQ(lang) {
       data['section-main'].sections.forEach((section) => {
         section.accordion.forEach((faqEntry) => {
           let searchEntry = faqEntry.title + " " + faqEntry.textblock.join(" ");
-          faq[faqEntry.anchor] = searchEntry.toLowerCase();
+          faq[faqEntry.anchor] = searchEntry.toLowerCase().replace( /(<([^>]+)>)/ig, ' ');
         })
       });
       return faq;


### PR DESCRIPTION
Currently, the FAQ texts are completely copied into the json docs that are used to do the search.

This PR removes the html tags from the text. By that, we avoid showing results that do not *visibly* contain the respective search string.