### PR TITLE
fixed regexp errors

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -103,7 +103,7 @@ $(document).ready(function(){
                 // remove double spaces, split by space, and filter out empty strings
                 let searchTerms = searchString.replace(/ +(?= )/g,'').split(" ").filter(x => x.length > 0);
                 // perform the search for each term
-                let allHits = searchTerms.every(term => text.search(term.toLowerCase()) !== -1);
+                let allHits = searchTerms.every(term => text.includes(term.toLowerCase()));
                 // put to hide, if no hit was found
                 if(!allHits) {
                     hide.push(anchorDiv);


### PR DESCRIPTION
Searching a query with one parenthesis led to an uncaught unterminated parenthetical SyntaxError, as JavaScript translates the parameter to RegExp.
> If a non-RegExp object regexp is passed, it is implicitly converted to a RegExp with new RegExp(regexp). [(source)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search)
However, this disables the possibility of using RegExp to filter the items.