### PR TITLE
Updated the FAQ according to #340

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -203,7 +203,7 @@
                         "anchor": "ios_14_beta",
                         "active": true,
                         "textblock": [
-                            "Even though with iOS 14 Beta 4, the Exposure Notification framework is available now, the Corona-Warn-App does not support iOS 14 Beta-Versions. The Beta-Versions are <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>still under development</a> and are not public. The Corona-Warn-App is not yet supported with iOS 14 Beta 4. See the <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
+                            "Even though with iOS 14 Beta 4, the Exposure Notification framework is available now, the Corona-Warn-App does not support iOS 14 Beta-Versions. The Beta-Versions are <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>still under development</a> and are not public. See the <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
                         ]
                     },
                     {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -203,7 +203,7 @@
                         "anchor": "ios_14_beta",
                         "active": true,
                         "textblock": [
-                            "With iOS 14 Beta 4, the Exposure Notification framework is available. But this version is <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>still under development</a> and is not public. The Corona-Warn-App is not yet supported with iOS 14 Beta 4. See the <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
+                            "Even though with iOS 14 Beta 4, the Exposure Notification framework is available now, the Corona-Warn-App does not support iOS 14 Beta-Versions. The Beta-Versions are <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>still under development</a> and are not public. The Corona-Warn-App is not yet supported with iOS 14 Beta 4. See the <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -204,7 +204,7 @@
                         "anchor": "ios_14_beta",
                         "active": true,
                         "textblock": [
-                            "Mit iOS 14 Beta 4 ist das Exposure Notification Framework inzwischen verfügbar. Dennoch ist diese Version <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>noch in Entwicklung</a> und ist nicht für den Betrieb auf produktiven Geräten vorgesehen. Die Corona-Warn-App wird derzeit auf iOS 14 Beta 4 noch nicht unterstützt. Siehe <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
+                            "Auch wenn mit iOS 14 Beta 4 das Exposure Notification Framework inzwischen verfügbar ist, unterstützt die Corona-Warn-App die iOS 14 Beta-Versionen nicht. Die Beta-Versionen sind <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>noch in Entwicklung</a> und ist nicht für den Betrieb auf produktiven Geräten vorgesehen. Die Corona-Warn-App wird derzeit auf iOS 14 Beta noch nicht unterstützt. Siehe <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -204,7 +204,7 @@
                         "anchor": "ios_14_beta",
                         "active": true,
                         "textblock": [
-                            "Auch wenn mit iOS 14 Beta 4 das Exposure Notification Framework inzwischen verfügbar ist, unterstützt die Corona-Warn-App die iOS 14 Beta-Versionen nicht. Die Beta-Versionen sind <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>noch in Entwicklung</a> und ist nicht für den Betrieb auf produktiven Geräten vorgesehen. Die Corona-Warn-App wird derzeit auf iOS 14 Beta noch nicht unterstützt. Siehe <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
+                            "Auch wenn mit iOS 14 Beta 4 das Exposure Notification Framework inzwischen verfügbar ist, unterstützt die Corona-Warn-App die iOS 14 Beta-Versionen nicht. Die Beta-Versionen sind <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>noch in Entwicklung</a> und ist nicht für den Betrieb auf produktiven Geräten vorgesehen. Siehe <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
                         ]
                     },
                     {


### PR DESCRIPTION
Update the FAQ to explain that iOS 14 Beta is not supported, regardless of the Beta version. Further discussion on this topic was on the issue #340 