### PR TITLE
Correct gramma Mistake in the German FAQ

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -206,7 +206,7 @@
                         "anchor": "ios_14_beta",
                         "active": true,
                         "textblock": [
-                            "Auch wenn mit iOS 14 Beta 4 das Exposure Notification Framework inzwischen verfügbar ist, unterstützt die Corona-Warn-App die iOS 14 Beta-Versionen nicht. Die Beta-Versionen sind <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>noch in Entwicklung</a> und ist nicht für den Betrieb auf produktiven Geräten vorgesehen. Siehe <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
+                            "Auch wenn mit iOS 14 Beta 4 das Exposure Notification Framework inzwischen verfügbar ist, unterstützt die Corona-Warn-App die iOS 14 Beta-Versionen nicht. Die Beta-Versionen sind <a href='https://developer.apple.com/support/beta-software/' target='_blank' rel='noopener noreferrer'>noch in Entwicklung</a> und sind nicht für den Betrieb auf produktiven Geräten vorgesehen. Siehe <a href='https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-beta-release-notes' target='_blank' rel='noopener noreferrer'>iOS & iPadOS 14 Beta Release Notes</a>."
                         ]
                     },
                     {


### PR DESCRIPTION
closes: #367 

This PR corrects the gramma Mistake in the German FAQ regarding the iOS 14 Beta. Please see #367 for more information.

@mtb77 Could you review and merge it? Thanks!