### PR TITLE
Risk exposure can no longer be activated after updating to iOS 14

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -905,7 +905,7 @@
                         "anchor": "update_faq",
                         "active": true,
                         "textblock": [
-                            "Updated September 23, 2020"
+                            "Updated September 24, 2020"
                         ]
                     }
                 ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -36,6 +36,17 @@
                 "id": "background_updates",
                 "accordion": [
                     {
+                        "title": "[Apple/iOS]: Risk exposure can no longer be activated after updating to iOS 14",
+                        "anchor": "no_risk_update_ios14",
+                        "active": true,
+                        "textblock": [
+                             "After updating to iOS 14, some users report that risk exposure has been disabled and can no longer be turned on.",
+                             "This problem has already been reported to development and they are working on a solution. To be able to use the app to its full extent until the bug is fixed, please follow these steps:",
+                             "Open 'Settings' > 'Exposure notifications' > 'Active region' (Corona-Warn-App) > 'Corona-Warn-App' > Switch 'Share exposure information' off and on again.",
+                             "If the error still occurs although you have performed all steps, you have to reset and reinstall the application once. Your collected random ids will not be lost (<a href='#delete_random_ids'>see also here</a>). However, it will take 24 hours until the app resumes the data collected so."
+                        ]
+                    },
+                    {
                         "title": "[Apple/iOS]: My risk status hasn't been updated for over a day. An internet connection was available, what's wrong?",
                         "anchor": "no_risk_update_ios",
                         "active": true,

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -35,6 +35,17 @@
                 "title": "Hintergrund&shy;aktualisierung",
                 "id": "background_updates",
                 "accordion": [
+                    {
+                        "title": "[Apple/iOS]: Die Risikoermittlung lässt sich nach dem Update auf iOS 14 nicht mehr aktivieren",
+                        "anchor": "no_risk_update_ios14",
+                        "active": true,
+                        "textblock": [
+                             "Nach dem Update auf iOS 14 melden einige Nutzer, dass die Risikoermittlung deaktiviert wurde und nicht mehr eingeschaltet werden kann.",
+                             "Dieses Problem ist bereits der Entwicklung gemeldet und sie arbeiten an einer Lösung. Um die App bis zur Behebung des Fehlers in vollem Umfang nutzen zu können, gehen Sie bitte wie folgt vor:",
+                             "'Einstellungen' > 'Begegnungsüberprüfungen' > 'Aktive Region' (Corona-Warn-App) > 'Corona-Warn-App' > 'Begegnungsinformationen teilen' einmal aus- und wieder einschalten.",
+                             "Wenn der Fehler weiterhin auftritt, obwohl Sie alle Schritte ausgeführt haben, müssen Sie die Anwendung 1x zurücksetzen und neu installieren. Ihre gesammelten Zufallscodes gehen dabei nicht verloren (<a href='#delete_random_ids'>siehe auch hier</a>). Es dauert jedoch 24 Stunden bis die App wieder auf die bisher gesammelten Daten zurückgreift."
+                        ]
+                    },
                    {
                         "title": "[Apple/iOS]: Mein Risikostatus wurde seit über einem Tag nicht mehr aktualisiert. Internet war aber verfügbar, was läuft hier falsch?",
                         "anchor": "no_risk_update_ios",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -907,7 +907,7 @@
                         "anchor": "update_faq",
                         "active": true,
                         "textblock": [
-                            "Stand: 23.09.2020"
+                            "Stand: 24.09.2020"
                         ]
                     }
                 ]


### PR DESCRIPTION
closes #388 
