### PR TITLE
Fixed link on main page 

### DIFF
--- a/src/data/index.json
+++ b/src/data/index.json
@@ -44,7 +44,7 @@
             "title": "This is how the app works best",
             "textblock": [
                 "Comissioned by the Robert Koch Institute, we - Deutsche Telekom and SAP - continue to work together with our partners Apple and Google on optimizing the app to make it even more robust. For that purpose we will continue to intensively incorporate the information that we receive via the various channels into our development process. Here we have briefly summarized the most important tips for using the app:",
-                "<ol><li>Download the current version of the app (iOS: 1.3.2 or Android: 1.3.1)</li><li>Keep operating systems up-to-date (iOS 14.0.1 resp. at least iOS 13.5 or at least Android 6 with current Google Play Services)</li><li><a href='faq/#background_updates'>Keep background updates switched on and check them regularly</a></li><li>To be on the safe side, open the app once a day after 24 hours</li></ol>",
+                "<ol><li>Download the current version of the app (iOS: 1.3.2 or Android: 1.3.1)</li><li>Keep operating systems up-to-date (iOS 14.0.1 resp. at least iOS 13.5 or at least Android 6 with current Google Play Services)</li><li><a href='faq/#background'>Keep background updates switched on and check them regularly</a></li><li>To be on the safe side, open the app once a day after 24 hours</li></ol>",
                 "We recommend that you always ensure an adequate power supply.",
                 "You can find further information under <a href='faq/'>Frequently Asked Questions about the Corona-Warn-App</a>."
             ]

--- a/src/data/index_de.json
+++ b/src/data/index_de.json
@@ -45,7 +45,7 @@
             "title": "So funktioniert die App am besten",
             "textblock": [
                 "Im Auftrag des Robert Koch-Instituts arbeiten wir - die Deutsche Telekom und SAP - zusammen mit unseren Partnern Apple und Google weiter an der Optimierung der App, um sie noch robuster zu machen. Dafür werden wir die Hinweise, die wir über die verschiedenen Kanäle erhalten, weiterhin intensiv in unseren Entwicklungsprozess einbeziehen. Hier haben wir die wichtigsten Hinweise für die Nutzung der App kurz zusammengefasst:",
-                "<ol><li>Aktuelle Version der App laden (iOS: 1.3.2 bzw. Android: 1.3.1)</li><li>Betriebssysteme aktuell halten (iOS 14.0.1 bzw. mindestens iOS 13.5 oder mindestens Android 6 mit aktuellen Google Play Services)</li><li><a href='faq/#background_updates'>Hintergrundaktualisierung immer einschalten und kontrollieren</a></li><li>Sicherheitshalber die App täglich nach Ablauf von 24 Stunden einmal öffnen</li></ol>",
+                "<ol><li>Aktuelle Version der App laden (iOS: 1.3.2 bzw. Android: 1.3.1)</li><li>Betriebssysteme aktuell halten (iOS 14.0.1 bzw. mindestens iOS 13.5 oder mindestens Android 6 mit aktuellen Google Play Services)</li><li><a href='faq/#Hintergrund'>Hintergrundaktualisierung immer einschalten und kontrollieren</a></li><li>Sicherheitshalber die App täglich nach Ablauf von 24 Stunden einmal öffnen</li></ol>",
                 "Wir empfehlen grundsätzlich auf ausreichende Stromversorgung zu achten.",
                 "Weitere Informationen haben wir auf der Seite <a href='faq/'>Häufig gestellte Fragen zur Corona-Warn-App</a> zusammengestellt."
             ]


### PR DESCRIPTION
This Link: 
![image](https://user-images.githubusercontent.com/67682506/95603791-0bb86b00-0a57-11eb-9089-d917e3b9aade.png)
opened this FAQ Search:
![image](https://user-images.githubusercontent.com/67682506/95603838-1ecb3b00-0a57-11eb-85d8-b199fa2fdf98.png)
(same behavior in English)

I fixed this by changing `faq/#background_updates` to `faq/#Hintergrund` (in English changed it to `faq/#background`)

Feel free to edit or change something, and if this change is welcome please review and merge the PR @svengabr (cc @mtb77)
Thanks! 