### PR TITLE
Update iOS version to 1.5.2 and Android version to 1.5.1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -314,10 +314,10 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.0.1'))
     .pipe(replace('[ios.minimum-required-os-version]', '13.6'))
-    .pipe(replace('[ios.current-app-version]', '1.5.1'))
+    .pipe(replace('[ios.current-app-version]', '1.5.2'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '1.5'))
+    .pipe(replace('[android.current-app-version]', '1.5.1'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
https://apps.apple.com/de/app/corona-warn-app/id1512595757 lists iOS version 1.5.2 with date Oct 26, 2020.
https://play.google.com/store/apps/details?id=de.rki.coronawarnapp lists Android version 1.5.1 with date Oct 26, 2020.