### PR TITLE
FAQ website 'Exposure check failed' v1.6.0 fixed in 1.6.1

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -36,14 +36,6 @@
                 "id": "most_asked",
                 "accordion": [
                     {
-                        "title": "[Apple/iOS]: Exposure Check Failed after updating to version 1.6.0",
-                        "anchor": "expcheck_160",
-                        "active": true,
-                        "textblock": [
-                             "After an update to app version 1.6.0, you might get the error 'Exposure Check Failed', even though there was a successful check in the past 24 hours. We are working on a solution for this error. In the meantime, try restarting your app. This helps in most cases."
-                        ]
-                    },
-                    {
                         "title": "[Google/Android]: Battery optimization is not automatically disabled after activating the prioritized background activity",
                         "anchor": "battery_optimization_background",
                         "active": true,
@@ -788,7 +780,16 @@
                 "title": "Resolved",
                 "id": "resolved",
                 "accordion": [
-			 {
+                   {
+                        "title": "[Apple/iOS]: Exposure Check Failed after updating to version 1.6.0",
+                        "anchor": "expcheck_160",
+                        "active": true,
+                        "textblock": [
+                             "<b>UPDATE</b><br/>This issue has been fixed in Version 1.6.1. <hr/>", 
+                             "After an update to app version 1.6.0, you might get the error 'Exposure Check Failed', even though there was a successful check in the past 24 hours. We are working on a solution for this error. In the meantime, try restarting your app. This helps in most cases."
+                        ]
+                    },
+                    {
                         "title": "[Apple/iOS]: Migrating to new phone and backup and restore - app does not work",
                         "anchor": "migration_Apple",
                         "active": true,

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -785,7 +785,7 @@
                         "anchor": "expcheck_160",
                         "active": true,
                         "textblock": [
-                             "<b>UPDATE</b><br/>This issue has been fixed in Version 1.6.1. <hr/>", 
+                             "<b>UPDATE</b><br/>This issue has been fixed in version 1.6.1.<hr/>", 
                              "After an update to app version 1.6.0, you might get the error 'Exposure Check Failed', even though there was a successful check in the past 24 hours. We are working on a solution for this error. In the meantime, try restarting your app. This helps in most cases."
                         ]
                     },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -36,14 +36,6 @@
                 "id": "most_asked",
                 "accordion": [
                     {
-                        "title": "[Apple/iOS]: Risiko-Überprüfung fehlgeschlagen nach dem Update auf Version 1.6.0",
-                        "anchor": "expcheck_160",
-                        "active": true,
-                        "textblock": [
-                             "Nach einem Update auf Version 1.6.0 kann es vorkommen, dass Sie die Nachricht 'Risiko-Überprüfung fehlgeschlagen' erhalten, obwohl die letzte Überprüfung noch keine 24 Stunden her ist. Wir arbeiten gerade an einer Behebung dieses Problems. Bis das Update zur Verfügung steht, können Sie das Problem in den meisten Fällen mit einem Neustart Ihrer App beheben."
-                        ]
-                    },
-                    {
                         "title": "[Google/Android]: Batterieoptimierung wird nicht automatisch abgeschaltet nachdem die priorisierte Hintergrundaktivität aktiviert wurde",
                         "anchor": "battery_optimization_background",
                         "active": true,
@@ -789,6 +781,15 @@
                 "id": "resolved",
                 "title": "Geklärt",
                 "accordion": [
+                    {
+                        "title": "[Apple/iOS]: Risiko-Überprüfung fehlgeschlagen nach dem Update auf Version 1.6.0",
+                        "anchor": "expcheck_160",
+                        "active": true,
+                        "textblock": [
+                             "<b>AKTUELL</b><br/>Das Problem ist in Version 1.6.1 behoben worden.<hr/>",
+                             "Nach einem Update auf Version 1.6.0 kann es vorkommen, dass Sie die Nachricht 'Risiko-Überprüfung fehlgeschlagen' erhalten, obwohl die letzte Überprüfung noch keine 24 Stunden her ist. Wir arbeiten gerade an einer Behebung dieses Problems. Bis das Update zur Verfügung steht, können Sie das Problem in den meisten Fällen mit einem Neustart Ihrer App beheben."
+                        ]
+                    },
                     {
                         "title": "[Apple/iOS]: Migration auf neues Gerät bzw. Backup/Restore - App funktioniert nicht",
                         "anchor": "migration_Apple",


### PR DESCRIPTION
move FAQ to resolved and add text:

EN: "<b>UPDATE</b><br/>This issue has been fixed in Version 1.6.1. <hr/>"

DE: "<b>AKTUELL</b><br/>Das Problem ist in Version 1.6.1 behoben worden.<hr/>"