### PR TITLE
FAQ website notifications new entry  ExposureDetectionIsAlreadyRunning

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -179,6 +179,14 @@
                 "id": "notification",
                 "accordion": [
                     {
+                        "title": "[Apple/iOS] 'ExposureDetectionIsAlreadyRunning' in CWA version 1.6.1",
+                        "anchor": "ExposureDetectionIsAlreadyRunning",
+                        "active": true,
+                        "textblock": [                            
+                            "The notification <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633'>can be ignored</a>. The CWA is still working correctly and this issue will be solved with a <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510'>future release</a>."
+                        ]
+                    },
+                    {
                         "title": "My exposure log shows multiple, simultaneous checks for exposures. Is that an error?",
                         "anchor": "multiple_exposure_checks",
                         "active": true,

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -179,6 +179,14 @@
                 "id": "notification",
                 "accordion": [
                     {
+                        "title": "[Apple/iOS] 'ExposureDetectionIsAlreadyRunning' in CWA version 1.6.1",
+                        "anchor": "ExposureDetectionIsAlreadyRunning",
+                        "active": true,
+                        "textblock": [                            
+                            "Die Meldung <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633'>kann ignoriert werden</a>. Die CWA funktioniert korrekt und dieses Problem wird in einem <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510'> bevorstehenden Update korrigiert</a>."
+                        ]
+                    },
+                    {
                         "title": "Meine Begegnungsüberprüfung zeigt mehrere zeitgleiche Einträge. Ist das ein Fehler?",
                         "anchor": "multiple_exposure_checks",
                         "active": true,


### PR DESCRIPTION
EN
                   {
                        "title": "[Apple/iOS] 'ExposureDetectionIsAlreadyRunning' in CWA version 1.6.1",
                        "anchor": "ExposureDetectionIsAlreadyRunning",
                        "active": true,
                        "textblock": [
                            "The notification <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633'>can be ignored</a>. The CWA is still working correctly and this issue will be solved with a <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510'>future release</a>."
                        ]
                    },

DE

                   {
                        "title": "[Apple/iOS] 'ExposureDetectionIsAlreadyRunning' in CWA version 1.6.1",
                        "anchor": "ExposureDetectionIsAlreadyRunning",
                        "active": true,
                        "textblock": [
                            "Die Meldung <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633'>kann ignoriert werden</a>. Die CWA funktioniert korrekt und dieses Problem wird in einem <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510'> bevorstehenden Update korrigiert</a>."
                        ]
                    },


![image](https://user-images.githubusercontent.com/1409741/99233252-4601ee80-27f3-11eb-9ff0-9f70e417530c.png)
![image](https://user-images.githubusercontent.com/1409741/99233394-76498d00-27f3-11eb-967a-4b66515a30b4.png)
