### PR TITLE
Allow foreign PCR tests through TAN hotline (closes #555)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -477,7 +477,7 @@
                         "anchor": "test_in_other_country",
                         "active": true,
                         "textblock": [
-                            "Unfortunately not. Every positive test result that you enter in the app must be verified by labs before. The labs make sure that the result is not entered wrongly or on false pretense. At the moment, only labs in Germany are connected for verification. Therefore, you cannot enter a positive result that was tested in another country, for example, the Netherlands."
+                            "If you are in another EU country or in one of <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Tests.html' target='_blank' rel='noopener noreferrer'>these countries</a> and have made a molecular biological test (PCR test) which is positive, you can upload it to the Corona-Warn-App. To do so, it is necessary to verify your identity by calling the hotline +49 800 7540002. You will receive a 10-digit TAN with which the test result can be registered in the app. Attention: The TAN is only valid for one hour!"
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -478,7 +478,7 @@
                         "anchor": "test_in_other_country",
                         "active": true,
                         "textblock": [
-                            "Nein, das ist leider nicht möglich. Jedes positive Test-Ergebnis, das in die App geladen wird, muss zuvor von Laboren überprüft worden sein. Diese stellen sicher, dass kein Missbrauch stattfindet und keine falsche Ergebnisse eingetragen werden. Dazu sind zur Zeit nur Labore in Deutschland angeschlossen. Sie können also kein positives Testergebnis aus anderen Ländern, zum Beispiel aus den Niederlanden, eingeben."
+                            "Wenn Sie sich im EU-Ausland oder in einem <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Tests.html' target='_blank' rel='noopener noreferrer'>dieser Staaten</a> befinden und dort einen molekularbiologischen Test (PCR-Test) gemacht haben, der positiv ist, können Sie diesen in Ihrer Corona-Warn-App hochladen. Dafür müssen Sie sich unter der Hotline +49 800 7540002 verifizieren lassen. Sie erhalten eine 10-stellige TAN, mit der das Testergebnis in der App registriert werden kann. Achtung: Die TAN ist nur eine Stunde gültig!"
                         ]
                     },
                     {


### PR DESCRIPTION
Text from RKI via @loki-cui in https://github.com/corona-warn-app/cwa-website/pull/573#issuecomment-728768274
@svengabr also involved

### ALT
**Kann ich positive Testergebnisse aus anderen Ländern eingeben?**
Nein, das ist leider nicht möglich. Jedes positive Test-Ergebnis, das in die App geladen wird, muss zuvor von Laboren überprüft worden sein. Diese stellen sicher, dass kein Missbrauch stattfindet und keine falsche Ergebnisse eingetragen werden. Dazu sind zur Zeit nur Labore in Deutschland angeschlossen. Sie können also kein positives Testergebnis aus anderen Ländern, zum Beispiel aus den Niederlanden, eingeben.

### NEU
**Kann ich positive Testergebnisse aus anderen Ländern in die Corona-Warn-App eingeben?**
Wenn Sie sich im EU-Ausland oder in einem [dieser Staaten](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Tests.html) befinden und dort einen molekularbiologischen Test (PCR-Test) gemacht haben, der positiv ist, können Sie diesen in Ihrer Corona-Warn-App hochladen. Dafür müssen Sie sich unter der Hotline +49 800 7540002 verifizieren lassen. Sie erhalten eine 10-stellige TAN, mit der das Testergebnis in der App registriert werden kann. Achtung: Die TAN ist nur eine Stunde gültig!

**Can I enter positive test results from other countries into the Corona-Warn-App?**
If you are in another EU country or in one of [these countries](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Tests.html) and have made a molecular biological test (PCR test) which is positive, you can upload it to the Corona-Warn-App. To do so, it is necessary to verify your identity by calling the hotline +49 800 7540002. You will receive a 10-digit TAN with which the test result can be registered in the app. Attention: The TAN is only valid for one hour!

Below screen shots from npm test:

---
Proposed changes to https://www.coronawarn.app/de/faq/#test_in_other_country
![DE foreign PCR test](https://user-images.githubusercontent.com/66998419/99375653-461def00-28c4-11eb-9948-a8cd5ca9d263.jpg)

---
Proposed changes to https://www.coronawarn.app/en/faq/#test_in_other_country
![EN foreign PCR test](https://user-images.githubusercontent.com/66998419/99375970-9bf29700-28c4-11eb-9d1b-3bc0c88e389a.jpg)

