### PR TITLE
Corrected the title of `qr_scan` (German)

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -100,7 +100,7 @@
                         ]
                     },
                     {
-                        "title": "Beim Einscannen erhalte des QR Codes ich einen Fehler. Was kann ich tun?",
+                        "title": "Beim Einscannen des QR Codes erhalte ich einen Fehler. Was kann ich tun?",
                         "anchor": "qr_scan",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
The title of the FAQ entry https://www.coronawarn.app/de/faq/#qr_scan said:

>Beim Einscannen erhalte des QR Codes ich einen Fehler.'

This is grammatically wrong so I corrected it 😅😀
