### PR TITLE
Include table with links to other repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For more information about how to contribute, the project structure, as well as 
 | [cwa-server]        | Backend implementation for the Apple/Google exposure notification API.|
 | [cwa-verification-server] | Backend implementation of the verification process.             |
 | [cwa-verification-portal] | The portal to interact with the verification server             |
-| [cwa-verification-iam]    | The identy and access management to interact with the verification server |
+| [cwa-verification-iam]    | The identity and access management to interact with the verification server |
 | [cwa-testresult-server]   | Receives the test results from connected laboratories           |
 
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,33 @@ The German government has asked SAP and Deutsche Telekom AG to develop the Coron
 
 For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](./CONTRIBUTING.md). By participating in this project, you agree to abide by its [Code of Conduct](./CODE_OF_CONDUCT.md) at all times.
 
+## Repositories
+
+| Repository          | Description                                                           |
+| ------------------- | --------------------------------------------------------------------- |
+| [cwa-documentation] | Project overview, general documentation, and white papers.            |
+| [cwa-app-ios]       | Native iOS app using the Apple/Google exposure notification API.      |
+| [cwa-app-android]   | Native Android app using the Apple/Google exposure notification API.  |
+| [cwa-wishlist]      | Community feature requests.                                           |
+| [cwa-website]       | The official website for the Corona-Warn-App                          |
+| [cwa-server]        | Backend implementation for the Apple/Google exposure notification API.|
+| [cwa-verification-server] | Backend implementation of the verification process.             |
+| [cwa-verification-portal] | The portal to interact with the verification server             |
+| [cwa-verification-iam]    | The identy and access management to interact with the verification server |
+| [cwa-testresult-server]   | Receives the test results from connected laboratories           |
+
+
+[cwa-documentation]: https://github.com/corona-warn-app/cwa-documentation
+[cwa-app-ios]: https://github.com/corona-warn-app/cwa-app-ios
+[cwa-app-android]: https://github.com/corona-warn-app/cwa-app-android
+[cwa-wishlist]: https://github.com/corona-warn-app/cwa-wishlist
+[cwa-website]: https://github.com/corona-warn-app/cwa-website
+[cwa-server]: https://github.com/corona-warn-app/cwa-server
+[cwa-verification-server]: https://github.com/corona-warn-app/cwa-verification-server
+[cwa-verification-portal]: https://github.com/corona-warn-app/cwa-verification-portal
+[cwa-verification-iam]: https://github.com/corona-warn-app/cwa-verification-iam
+[cwa-testresult-server]: https://github.com/corona-warn-app/cwa-testresult-server
+
 ## Licensing
 
 Copyright (c) 2020 Deutsche Telekom AG and SAP SE or an SAP affiliate company.


### PR DESCRIPTION
This PR adds a table with the links to other repos to the README.md file.
This is already done i.e. in the iOS-Repo: 
https://github.com/corona-warn-app/cwa-app-ios#repositories