### PR TITLE
Fix link  in `various_device_problems` and match German and English text

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -252,10 +252,11 @@
                         "anchor": "various_device_problems",
                         "active": true,
                         "textblock": [
-                           "Since I installed the app, my phone sometimes behaves oddly. Example: There are occasional problems with other apps and devices that use Bluetooth. What can I do?",
+                            "Since I installed the app, my phone sometimes behaves oddly. Example: There are occasional problems with other apps and devices that use Bluetooth. What can I do?",
                             "Some users report that their phones behave differently since they installed Corona-Warn-App. Example: Sometimes the communication between their phones and Bluetooth devices via other apps is interrupted. This affects, for example, smart watches or Bluetooth earphones. We’re investigating these problems, but this is likely a problem with the basic operating system functions, over which we have no control.",
                             "Please try the following: <ul><li>Restart your phone.</li><li>Unpair the other Bluetooth-connected devices and recouple them.</li></ul>",
-                           "If the above does not help, contact your device manufacturer:", "<ul><li>Apple/iOS phones: <a href='https://support.apple.com' target='_blank' rel='noopener noreferrer'>Apple Support</a></li><li>Android phones: <a href='https://support.google.com/android/answer/3094742?hl=en&ref_topic=7313011' target='_blank' rel='noopener noreferrer'>Get help from your device’s manufacturer</a></li></ul>"
+                            "If the above does not help, contact your device manufacturer:", 
+                            "<ul><li>Apple/iPhones: <a href='https://support.apple.com' target='_blank' rel='noopener noreferrer'>Apple Support</a></li><li>Android phones: <a href='https://support.google.com/android/answer/3094742?hl=en&ref_topic=7313011' target='_blank' rel='noopener noreferrer'>Get help from your device’s manufacturer</a></li></ul>"
                         ]
                     }
                 ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -265,7 +265,7 @@
                             "Einige Nutzer melden, dass sich ihr Smartphone manchmal seltsam verhält. Beispiel: Ab und zu bricht die Kommunikation zwischen dem Smartphone und Bluetooth-Geräten über andere Apps ab. Dies betrifft z. B. Smartwatches oder Bluetooth-Ohrhörer. Wir untersuchen diese Probleme, allerdings liegt es vermutlich an grundlegenden Funktionen des Betriebssystems, auf die wir keinen Einfluss haben.", 
                             "Versuchen Sie bitte Folgendes: <ul><li>Starten Sie Ihr Smartphone neu.</li><li>Entkoppeln Sie die anderen über Bluetooth verbundenen Geräte und koppeln Sie sie neu.</li></ul>",
                             "Wenn das nicht weiterhilft, wenden Sie sich an den Hersteller Ihres Geräts:",
-                            "<ul><li[Apple/iOS]: <a href='https://support.apple.com' target='_blank' rel='noopener noreferrer'>Apple-Support</a>.</li><li>[Google/Android]: <a href='https://support.google.com/android/answer/3094742?hl=en&ref_topic=7313011' target='_blank' rel='noopener noreferrer'>Hilfe vom Hersteller Ihres Geräts</a>.</li></ul>"
+                            "<ul><li>Apple/iPhones: <a href='https://support.apple.com' target='_blank' rel='noopener noreferrer'>Apple-Support</a></li><li>Android Geräte: <a href='https://support.google.com/android/answer/3094742?hl=en&ref_topic=7313011' target='_blank' rel='noopener noreferrer'>Hilfe vom Hersteller Ihres Geräts</a>.</li></ul>"
                         ]
                     }
                 ]


### PR DESCRIPTION
This PR matches the German and English text in this https://www.coronawarn.app/en/faq/#various_device_problems / https://www.coronawarn.app/de/faq/#various_device_problems FAQ entry. In the German entry the link to the Apple support was also fixed.