### PR TITLE
Update `[ios.minimum-required-os-version]` in gulpfile.js from 13.6 to 13.7

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -313,7 +313,7 @@ function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.3'))
-    .pipe(replace('[ios.minimum-required-os-version]', '13.6'))
+    .pipe(replace('[ios.minimum-required-os-version]', '13.7'))
     .pipe(replace('[ios.current-app-version]', '1.10.1'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))


### PR DESCRIPTION
This PR updates the `[minimum-required-os-version]` in the gulpfile for iOS (13.6 --> 13.7)

Source for iOS 13.7: https://apps.apple.com/de/app/corona-warn-app/id1512595757