### PR TITLE
Remove "e" from FAQ entry

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -36,7 +36,7 @@
                 "id": "most_asked",
                 "accordion": [
                     {
-                        "title": "URSACHE: 2001, trying to e establish a secure connection to the server",
+                        "title": "URSACHE: 2001, trying to establish a secure connection to the server",
                         "anchor": "cause2001",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
This PR removes the spurious "e" in the `cause2001` FAQ entry.

Closes #790