### PR TITLE
Correct two typos in faq/#cause2001

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -41,10 +41,10 @@
                         "active": true,
                         "textblock": [
                             "Das Sicherheitszertifikat <b>T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2</b> ist möglicherweise auf Ihrem Gerät deaktiviert. Dies ist eine bekannte Ursache, um folgende Benachrichtigung auszulösen:",
-                            "<b>'URSACHE: 2001 Etwas ist schief gelaufen. An error occurred while trying to establish a secure connection to the server.'</b>",
+                            "<b>'URSACHE: 2001 Etwas ist schiefgelaufen. An error occurred while trying to establish a secure connection to the server.'</b>",
                             "Führen Sie die folgenden Schritte aus, um das Sicherheitszertifikat zu aktivieren (Der genaue Pfad hängt vom Gerät ab).",
                             "<ul><li>Einstellungen > Biometrische Daten und Sicherheit > Andere Sicherheitseinstellungen > Sicherheitszertifikate anzeigen, SYSTEM</li><li>Scrollen Sie nach unten zu <b>T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2</b></li><li>Aktivieren Sie das Zertifikat mit dem Schieberegler</li></ul>",
-                            "Sollten diese Prozedur das Problem nicht beheben, schreiben SIe bitte Ihren Bericht hier: <a href='https://github.com/corona-warn-app/cwa-app-android/issues/968' target='_blank' rel='noopener'>cwa-app-android/issues/968</a>."
+                            "Sollten diese Prozedur das Problem nicht beheben, schreiben Sie bitte Ihren Bericht hier: <a href='https://github.com/corona-warn-app/cwa-app-android/issues/968' target='_blank' rel='noopener'>cwa-app-android/issues/968</a>."
                         ]
                     },
                     {


### PR DESCRIPTION
The first typo is in "Etwas ist schief gelaufen"
The string in the app is `errors_generic_headline` and it reads
"Etwas ist schiefgelaufen."

The second typo is in the word "SIe" which should be "Sie".

(Note the file was edited with the Atom editor.)