### PR TITLE
FAQ: Change spelling "schief gelaufen" to "schiefgelaufen" (closes #795)

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -266,7 +266,7 @@
                             "<h4>Was sollten Sie beachten?</h4> <b>Das Zurücksetzen der Datenbanken hat keine Auswirkung auf die Risiko-Ermittlung und damit auch nicht auf Ihren Risikostatus.</b> Alle aufgezeichneten Begegnungen mit anderen Personen, die die App nutzen, bleiben erhalten. Sie werden weiterhin über Risiko-Begegnungen benachrichtigt und können andere warnen, falls Sie positiv auf COVID-19 getestet wurden.",
                             "<b>Falls Sie aber einen QR-Code für die elektronische Benachrichtigung über einen COVID-19-Test eingelesen haben und Ihnen das Testergebnis bislang noch nicht in der App übermittelt wurde, ist durch das Zurücksetzen der Datenbanken die Registrierung des Tests für die elektronische Übermittlung verloren gegangen. Aus Datenschutzgründen kann der QR-Code leider nicht mehr erneut eingelesen werden. Bitte wenden Sie sich an Ihren Arzt oder das Labor, um Ihr Testergebnis zu erfahren.</b>",
                             "Durch das Zurücksetzen der Daten geht auch die Information verloren, wie lange Ihre App bereits aktiv war (die Anzahl der aktiven Tage wird auf 0 gesetzt). Gegebenenfalls wurden auch Einträge aus der Historie der Begegnungsaufzeichnungen entfernt, die Sie über die Einstellungen zu Ihrem Google-Konto erreichen. (siehe <a href='#exposure_check' target='_blank' rel='noopener noreferrer'>hier</a> und <a href='#keys_matches' target='_blank' rel='noopener noreferrer'>hier</a>) Dies hat jedoch keine Auswirkungen auf die Risiko-Ermittlung und Ihren Risikostatus. Spätestens nach 24 Stunden sollte Ihnen Ihr Risikostatus wieder angezeigt werden und neue Einträge in der Historie der Begegnungsaufzeichnungen sollten erscheinen.",
-                            "<h4>Technischer Hintergrund</h4> Die Corona-Warn-App wurde mit höchsten Ansprüchen an den Datenschutz entwickelt. Dafür werden einerseits Daten verschlüsselt abgespeichert und andererseits der Programmcode der App öffentlich zur Begutachtung zur Verfügung gestellt (<a href='#open-source' target='_blank' rel='noopener noreferrer'>Open-Source-Ansatz</a>). Um eine Datenverschlüsselung für eine App zu realisieren, greifen Entwickler gerne auf in der Vergangenheit bereits gut erprobte Programmmodule zurück, die von anderen Entwicklern ebenfalls als Open-Source zur Verfügung gestellt werden. Auf diese Weise kann Transparenz für sämtliche Bestandteile der Corona-Warn-App gewährleistet werden. Erst kürzlich wurde bekannt, dass ein Verschlüsselungsmodul, das auch von der Corona-Warn-App genutzt wird, fehlerhaft funktioniert, wenn der im Android Betriebssystem integrierte Speicher für Schlüssel oder Passwörter nicht zuverlässig reagiert. Dieser Fehler führt dazu, dass eine verschlüsselte Datenbank nicht mehr geöffnet werden kann. Das wiederum führt dazu, dass einige Nutzer die Meldung „<a href='#cause9002' target='_blank' rel='noopener noreferrer'>Ursache: 9002 Etwas ist schief gelaufen (sqlite)</a>“ sehen oder <a href='#app_crash' target='_blank' rel='noopener noreferrer'>sich die App nicht mehr öffnen lässt</a>. Selbstverständlich wird die Corona-Warn-App vor jeder Veröffentlichung eines Updates gründlich getestet. Allerdings trat dieser Fehler während der Tests nie auf und er lässt sich auch jetzt nur schwer reproduzieren.",
+                            "<h4>Technischer Hintergrund</h4> Die Corona-Warn-App wurde mit höchsten Ansprüchen an den Datenschutz entwickelt. Dafür werden einerseits Daten verschlüsselt abgespeichert und andererseits der Programmcode der App öffentlich zur Begutachtung zur Verfügung gestellt (<a href='#open-source' target='_blank' rel='noopener noreferrer'>Open-Source-Ansatz</a>). Um eine Datenverschlüsselung für eine App zu realisieren, greifen Entwickler gerne auf in der Vergangenheit bereits gut erprobte Programmmodule zurück, die von anderen Entwicklern ebenfalls als Open-Source zur Verfügung gestellt werden. Auf diese Weise kann Transparenz für sämtliche Bestandteile der Corona-Warn-App gewährleistet werden. Erst kürzlich wurde bekannt, dass ein Verschlüsselungsmodul, das auch von der Corona-Warn-App genutzt wird, fehlerhaft funktioniert, wenn der im Android Betriebssystem integrierte Speicher für Schlüssel oder Passwörter nicht zuverlässig reagiert. Dieser Fehler führt dazu, dass eine verschlüsselte Datenbank nicht mehr geöffnet werden kann. Das wiederum führt dazu, dass einige Nutzer die Meldung „<a href='#cause9002' target='_blank' rel='noopener noreferrer'>Ursache: 9002 Etwas ist schiefgelaufen (sqlite)</a>“ sehen oder <a href='#app_crash' target='_blank' rel='noopener noreferrer'>sich die App nicht mehr öffnen lässt</a>. Selbstverständlich wird die Corona-Warn-App vor jeder Veröffentlichung eines Updates gründlich getestet. Allerdings trat dieser Fehler während der Tests nie auf und er lässt sich auch jetzt nur schwer reproduzieren.",
                             "Alle Beteiligten arbeiten gemeinsam an einer möglichst raschen Fehlerbehebung."
                         ]
                     },
@@ -1034,7 +1034,7 @@
                         ]
                     },
                     {
-                        "title": "[Google/Android]: Ursache: 9002 Etwas ist schief gelaufen (timeout)",
+                        "title": "[Google/Android]: Ursache: 9002 Etwas ist schiefgelaufen (timeout)",
                         "anchor": "cause9002_timeout",
                         "active": true,
                         "textblock": [
@@ -1045,7 +1045,7 @@
                         ]
                     },
                     {
-                        "title": "[Google/Android]: Ursache: 9002 Etwas ist schief gelaufen (sqlite)",
+                        "title": "[Google/Android]: Ursache: 9002 Etwas ist schiefgelaufen (sqlite)",
                         "anchor": "cause9002",
                         "active": true,
                         "textblock": [
@@ -1062,7 +1062,7 @@
                         "active": true,
                         "textblock": [
                             "<b>AKTUELL</b><br/>Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.<br/><hr/>",
-                            "Wenn die Corona-Warn-App durch einen Fehler im Betriebssystem oder durch aggressive Energiesparmaßnahmen des Telefons unerwartet beendet wird, kann es vorkommen, dass bei einem erneuten Start die Corona-Warn-App nicht mehr auf ihre verschlüsselten Datenbanken zugreifen kann. In diesem Fall schließt sie sich sofort wieder. Manchmal wurde vorher der <a href='#cause9002' target='_blank' rel='noopener'>Fehler Ursache: 9002 Etwas ist schief gelaufen (sqlite)</a> angezeigt.",
+                            "Wenn die Corona-Warn-App durch einen Fehler im Betriebssystem oder durch aggressive Energiesparmaßnahmen des Telefons unerwartet beendet wird, kann es vorkommen, dass bei einem erneuten Start die Corona-Warn-App nicht mehr auf ihre verschlüsselten Datenbanken zugreifen kann. In diesem Fall schließt sie sich sofort wieder. Manchmal wurde vorher der <a href='#cause9002' target='_blank' rel='noopener'>Fehler Ursache: 9002 Etwas ist schiefgelaufen (sqlite)</a> angezeigt.",
                             "Wir arbeiten mit Hochdruck an einer Lösung des Problems.",
                             "Die GitHub-Community hat eine Notfall-Lösung erarbeitet, die die Corna-Warn-App ohne Deinstallation wieder zum Laufen bringt. Da hierbei jedoch Daten verloren gehen können (z. B. registrierte COVID-19-Tests zur Online-Abfrage der Testergebnisse), sollten Sie diese Notfall-Lösung nur dann anwenden, wenn keine anderen Maßnahmen (insbesondere Vorschläge von der technischen Telefon-Hotline oder von Betreuern der Corona-Warn-App im Google Play Store) geholfen haben, und Sie die Hinweise zur Notfall-Lösung im GitHub-Issue vollständig zur Kenntnis genommen haben.",
                             "<a href='https://github.com/corona-warn-app/cwa-app-android/issues/1053#issuecomment-690614975' target='_blank' rel='noopener noreferrer'>Hier geht es zur Notfall-Lösung im GitHub-Issue</a>."
@@ -1159,7 +1159,7 @@
                         ]
                     },
                     {
-                        "title": "[Google/Android]: URSACHE 3 – Etwas ist schief gelaufen. Fehler bei Kommunikation mit Google API(10)",
+                        "title": "[Google/Android]: URSACHE 3 – Etwas ist schiefgelaufen. Fehler bei Kommunikation mit Google API(10)",
                         "anchor": "API10",
                         "active": true,
                         "textblock": [
@@ -1205,7 +1205,7 @@
                         ]
                     },
                     {
-                        "title": "[Google/Android]: Ich bekomme beim Einrichten der App folgenden Fehler: URSACHE: 3. Etwas ist schief gelaufen. Fehler bei Kommunikation mit Google API(17). Was bedeutet das?",
+                        "title": "[Google/Android]: Ich bekomme beim Einrichten der App folgenden Fehler: URSACHE: 3. Etwas ist schiefgelaufen. Fehler bei Kommunikation mit Google API(17). Was bedeutet das?",
                         "anchor": "cause_3",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
This PR corrects all spelling of "schief gelaufen" to "schiefgelaufen" in https://www.coronawarn.app/de/faq/ corresponding to the correction in the error message in Android app releases from 1.1.1 (released in July 2020) onwards.

The last release to use the old (incorrect) spelling was version 1.0.5.