### PR TITLE
Update iOS version in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -314,7 +314,7 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.4'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '1.12'))
+    .pipe(replace('[ios.current-app-version]', '1.12.1'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '1.12'))


### PR DESCRIPTION
The current iOS app version is 1.12.1 and not 1.12

Release: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v1.12.1
