### PR TITLE
Correct typo in FAQ rooted_devices to gerooteten

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -368,7 +368,7 @@
                         "anchor": "rooted_devices",
                         "active": true,
                         "textblock": [
-                            "Nein, die App wird auf gerooten Geräten nicht unterstützt."
+                            "Nein, die App wird auf gerooteten Geräten nicht unterstützt."
                         ]
                     },
                     {


### PR DESCRIPTION
https://www.coronawarn.app/de/faq/#rooted_devices currently includes the text

"Nein, die App wird auf **gerooten** Geräten nicht unterstützt."

This PR changes the word "gerooten" to "gerooteten" and so corrects the misspelling.

---
Proposed changed version:

![image](https://user-images.githubusercontent.com/66998419/107691547-dabda080-6cab-11eb-8372-4b9f8656f620.png)


