### PR TITLE
Fix link in `numbers_RKI` (Closes #886)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -801,7 +801,7 @@
                         "anchor": "numbers_RKI",
                         "active": true,
                         "textblock": [
-                            "The Robert Koch Institute provides these and other current numbers <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html;jsessionid=041B1E316F2E11A2FB9036CD0E457343.internet082?nn=13490888' target='_blank' rel='noopener noreferrer'>on their website</a> (in German)."
+                            "The Robert Koch Institute provides these and other current numbers <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html' target='_blank' rel='noopener noreferrer'>on their website</a> (in German)."
                         ]
                     },
                     {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -801,7 +801,7 @@
                         "anchor": "numbers_RKI",
                         "active": true,
                         "textblock": [
-                            "The Robert Koch Institute provides these and other current numbers <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Kennzahlen.pdf?__blob=publicationFile' target='_blank' rel='noopener noreferrer'>on their website</a> (in German)."
+                            "The Robert Koch Institute provides these and other current numbers <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html;jsessionid=041B1E316F2E11A2FB9036CD0E457343.internet082?nn=13490888' target='_blank' rel='noopener noreferrer'>on their website</a> (in German)."
                         ]
                     },
                     {
@@ -885,7 +885,7 @@
                             "Since release of the contact journal function, we continuously received suggestions for changes and improvements. All those ideas will be reviewed technically and together with the client regarding:",
                             "<ul><li>User friendliness of the UI,</li><li>extension by functions (e.g. recording of additional parameters),</li><li>technical feasibility (or the effort required for implementation), and</li><li>Benefit for the health authorities (if the user deceides to share the contact journal and provide this information)</li><li>legal framework and limits</li></ul>",
                             "The number of comments regarding the contact journal confirms the active support of our community. We are pleased this new function is positively received by the app's users.",
-                            "<hr> More information on how to use the contact journal can be found in <a href='https://www.coronawarn.app/en/blog/2020-12-28-corona-warn-app-version-1-10/' target='_blank' rel='noopener noreferrer'>this</a> blog post."
+                            "<hr> More information on how to use the contact journal can be found in <a href='../blog/2020-12-28-corona-warn-app-version-1-10/' target='_blank' rel='noopener noreferrer'>this</a> blog post."
                         ]
                     }
                 ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -803,7 +803,7 @@
                         "anchor": "numbers_RKI",
                         "active": true,
                         "textblock": [
-                            "Diese und weitere aktuelle Zahlen stellt das Robert Koch-Institut <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html;jsessionid=041B1E316F2E11A2FB9036CD0E457343.internet082?nn=13490888' target='_blank' rel='noopener noreferrer'> auf seiner Webseite</a> zur Verfügung."
+                            "Diese und weitere aktuelle Zahlen stellt das Robert Koch-Institut <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html' target='_blank' rel='noopener noreferrer'> auf seiner Webseite</a> zur Verfügung."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -803,7 +803,7 @@
                         "anchor": "numbers_RKI",
                         "active": true,
                         "textblock": [
-                            "Diese und weitere aktuelle Zahlen stellt das Robert Koch-Institut <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Kennzahlen.pdf?__blob=publicationFile' target='_blank' rel='noopener noreferrer'> auf seiner Webseite</a> zur Verfügung."
+                            "Diese und weitere aktuelle Zahlen stellt das Robert Koch-Institut <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html;jsessionid=041B1E316F2E11A2FB9036CD0E457343.internet082?nn=13490888' target='_blank' rel='noopener noreferrer'> auf seiner Webseite</a> zur Verfügung."
                         ]
                     },
                     {
@@ -887,7 +887,7 @@
                             "Seit Einführung des Kontakt-Tagebuchs erhalten wir kontinuierlich Änderungs- und Verbesserungsvorschläge. Alle diese Ideen prüfen wir technisch und gemeinsam mit dem Auftraggeber bezüglich:",
                             "<ul><li>Anwenderfreundlichkeit des UI,</li><li> Erweiterung durch Funktionen (z.B. Erfassen zusätzlicher Parameter),</li><li> technischer Umsetzbarkeit (bzw. der Aufwände für die Implementierung),</li><li> Nutzen für das Gesundheitsamt (sofern die Benutzer*innen der App entscheiden, Einträge des Tagebuchs diesem zur Verfügung zu stellen) sowie</li><li> rechtlicher Rahmenbedingungen und Grenzen.</li></ul>",
                             "Die Menge der Hinweise zum Kontakt-Tagebuch bestätigt die aktive Unterstützung der Community und zeigt, dass diese neue Funktion positiv von den Benutzer*innen der App angenommen wird.",
-                            "<hr> Weitere Informationen zur Bedienung des Kontakt-Tagebuchs finden Sie in <a href='https://www.coronawarn.app/de/blog/2020-12-28-corona-warn-app-version-1-10/' target='_blank' rel='noopener noreferrer'>diesem</a> Blog Post."
+                            "<hr> Weitere Informationen zur Bedienung des Kontakt-Tagebuchs finden Sie in <a href='../blog/2020-12-28-corona-warn-app-version-1-10/' target='_blank' rel='noopener noreferrer'>diesem</a> Blog Post."
                         ]
                     }
                 ]


### PR DESCRIPTION
This PR corrects a link to the RKI in the FAQ article 
https://www.coronawarn.app/de/faq/#numbers_RKI & 
https://www.coronawarn.app/en/faq/#numbers_RKI

This PR also corrects what has been previously [discussed](https://github.com/corona-warn-app/cwa-website/pull/885#issuecomment-778515262) with @dsarkar in #885.

---

Closes #886
