### PR TITLE
Add three-dot icon for access to Google exposure checks (closes #891)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -272,7 +272,7 @@
                         "active": true,
                         "textblock": [
                             "Your phone settings display the exposure checks for the last 14 days:",
-                            "<ul><li><b>iOS:</b> 'Settings' -> 'Exposure Notifications' -> 'Exposure Logging Status' -> 'Exposure Checks'</li><li><b>Android:</b> 'Settings' -> 'Google' -> 'COVID-19 exposure notifications' -> 'Exposure Checks'</li></ul>",
+                            "<ul><li><b>iOS:</b> 'Settings' -> 'Exposure Notifications' -> 'Exposure Logging Status' -> 'Exposure Checks'</li><li><b>Android:</b> 'Settings' -> 'Google' -> 'COVID-19 Exposure Notifications' -> three-dot icon -> 'Exposure Checks'</li></ul>",
                             "When the app was running constantly during the last two weeks, you should see at least one check every day for all of the past 14 days.",
                             "Please note: The log is just the history. After every background update, the exposures of the last 14 days are checked and the risk status calculated. The important thing is that the exposure log shows at least one check for the last 24 hours.",
                             "It might be that entries are displayed for less than 14 days, although exposure was checked correctly. There are several reasons:",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -281,7 +281,7 @@
                         "active": true,
                         "textblock": [
                             "Die Einstellungen Ihres Smartphones zeigen die Begegnungsüberprüfungen der letzten 14 Tage an:",
-                            "<ul><li><b>iOS:</b> 'Einstellungen' -> 'Begegnungsmitteilungen' -> 'Status von Begegnungsaufzeichnungen' -> 'Begegnungsüberprüfungen'</li><li><b>Android:</b> 'Einstellungen' -> 'Google' -> 'COVID-19-Benachrichtigungen' -> 'Überprüfung auf mögliche Begegnungen'</li></ul>",
+                            "<ul><li><b>iOS:</b> 'Einstellungen' -> 'Begegnungsmitteilungen' -> 'Status von Begegnungsaufzeichnungen' -> 'Begegnungsüberprüfungen'</li><li><b>Android:</b> 'Einstellungen' -> 'Google' -> 'COVID-19-Benachrichtigungen' -> drei-Punkte-Icon -> 'Überprüfung auf mögliche Begegnungen'</li></ul>",
                             "Wenn die App in den letzten 2 Wochen dauerhaft aktiv war, sollten Sie mindestens eine Überprüfung für jeden der letzten 14 Tage sehen.",
                             "Bitte beachten Sie: Diese Übersicht zeigt nur die Historie an. Nach jeder Hintergrundaktualisierung werden die Begegnungen der letzten 14 Tage geprüft und das Risiko daraus ermittelt. Wichtig ist also, dass die Übersicht mindestens eine Begegnungsüberprüfung während der letzten 24 Stunden anzeigt.",
                             "Es kann vorkommen, dass hier Einträge für weniger als 14 Tage angezeigt werden, obwohl die Risiko-Ermittlung an jedem der letzten 14 Tagen korrekt durchgeführt wurde. Dafür gibt es mehrere Gründe:",


### PR DESCRIPTION
This PR corrects the FAQ entries:

https://www.coronawarn.app/en/faq/#exposure_check and
**My exposure log shows checks for less than 14 days**

https://www.coronawarn.app/de/faq/#exposure_check
**In den Begegnungsüberprüfungen sind die Aufzeichnungen von weniger als 14 Tagen gespeichert**

to resolve the issue described in https://github.com/corona-warn-app/cwa-website/issues/891.

Google changed the UI and has pushed the exposure checks one level deeper, so that it is now necessary to tap the three-dot overflow menu in order to access exposure checks. The three-dot overflow menu is referred to in the FAQ as "three-dot icon" for better general understanding.

## Changes in this PR

changes are marked up in yellow.

### EN version

![Exposure check EN](https://user-images.githubusercontent.com/66998419/107933890-a124b800-6f7f-11eb-9708-922010791b6e.jpg)

### DE version

![Exposure check DE](https://user-images.githubusercontent.com/66998419/107933909-a7b32f80-6f7f-11eb-90cc-8ddc931923c0.jpg)
