### PR TITLE
[Minor] Add missing labels to some FAQ entries

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -55,7 +55,7 @@
                 "id": "most_asked",
                 "accordion": [
                     {
-                        "title": "CAUSE: 2001, trying to establish a secure connection to the server",
+                        "title": "[Google/Android]: CAUSE: 2001, trying to establish a secure connection to the server",
                         "anchor": "cause2001",
                         "active": true,
                         "textblock": [
@@ -67,7 +67,7 @@
                         ]
                     },
                     {
-                        "title": "Firewall/Router configuration: CAUSE: 4000, error during web request, HTTP status 901",
+                        "title": "[Google/Android]: Firewall/Router configuration: CAUSE: 4000, error during web request, HTTP status 901",
                         "anchor": "access-list",
                         "active": true,
                         "textblock": [
@@ -353,7 +353,7 @@
                         ]
                     },
                     {
-                        "title": "I am testing a beta version of iOS. Why is the Corona-Warn-App not yet supported?",
+                        "title": "[Apple/iOS]: I am testing a beta version of iOS. Why is the Corona-Warn-App not yet supported?",
                         "anchor": "beta_ios",
                         "active": true,
                         "textblock": [

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -55,7 +55,7 @@
                 "id": "most_asked",
                 "accordion": [
                     {
-                        "title": "URSACHE: 2001, trying to establish a secure connection to the server",
+                        "title": "[Google/Android]: URSACHE: 2001, trying to establish a secure connection to the server",
                         "anchor": "cause2001",
                         "active": true,
                         "textblock": [
@@ -67,7 +67,7 @@
                         ]
                     },
                     {
-                        "title": "Firewall/Router Konfiguration: URSACHE: 4000, error during web request, HTTP status 901",
+                        "title": "[Google/Android]: Firewall/Router Konfiguration: URSACHE: 4000, error during web request, HTTP status 901",
                         "anchor": "access-list",
                         "active": true,
                         "textblock": [
@@ -355,7 +355,7 @@
                         ]
                     },
                     {
-                        "title": "Ich teste eine Beta-Version von iOS. Warum wird die Corona-Warn-App noch nicht unterstützt?",
+                        "title": "[Apple/iOS]: Ich teste eine Beta-Version von iOS. Warum wird die Corona-Warn-App noch nicht unterstützt?",
                         "anchor": "beta_ios",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
Some FAQ entries were missing labels (e.g. `[Apple/iOS]`). So, I've added them.