### PR TITLE
Minor typographical errors in faq files (EN & DE) fixed

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -885,7 +885,7 @@
                         "active": true,
                         "textblock": [
                             "Since release of the contact journal function, we continuously received suggestions for changes and improvements. All those ideas will be reviewed technically and together with the client regarding:",
-                            "<ul><li>User friendliness of the UI,</li><li>extension by functions (e.g. recording of additional parameters),</li><li>technical feasibility (or the effort required for implementation), and</li><li>Benefit for the health authorities (if the user deceides to share the contact journal and provide this information)</li><li>legal framework and limits</li></ul>",
+                            "<ul><li>User friendliness of the UI,</li><li>extension by functions (e.g. recording of additional parameters),</li><li>technical feasibility (or the effort required for implementation), and</li><li>Benefit for the health authorities (if the user decides to share the contact journal and provide this information)</li><li>legal framework and limits</li></ul>",
                             "The number of comments regarding the contact journal confirms the active support of our community. We are pleased this new function is positively received by the app's users.",
                             "<hr> More information on how to use the contact journal can be found in <a href='../blog/2020-12-28-corona-warn-app-version-1-10/' target='_blank' rel='noopener noreferrer'>this</a> blog post."
                         ]
@@ -1217,7 +1217,7 @@
                             "When counting the active days, an error is displayed currently: When '14 of 14 active days' is reached, the number of active days doesn't display 14 out of 14, but keeps displaying 13 out of 14 active days or fewer.",
                             "This is only a display error. The Corona-Warn-App continues to work as intended, that means, the IDs are still exchanged and the exposure logging still works. No data is lost. Technically, it is a rounding error that displays when the number of active days of the exposure logging does not increase any more, but stays 14 days. When the exposure logging was inactive in any way, even for a short amount of time, the counter stays at a lower number of days, for example, 13 active days.",
                             "Exposure logging can be deactivated, for example, by the following:",
-                            "<ol><li>Bluetooth or the location service were deactivated, even for a short amount of time</li><li>Background updates for the app where not active, so that exposure logging was not done continously</li><li>Flight mode was active, even for a short amount of time</li><li>The smartphone was turned off</li><li>The smartphone was restarted</li></ol>",
+                            "<ol><li>Bluetooth or the location service were deactivated, even for a short amount of time</li><li>Background updates for the app where not active, so that exposure logging was not done continuously</li><li>Flight mode was active, even for a short amount of time</li><li>The smartphone was turned off</li><li>The smartphone was restarted</li></ol>",
                             "It is planned that this will be resolved with the next release.",
                             "For detailed information, see <a href='https://github.com/corona-warn-app/cwa-app-android/issues/796#issuecomment-653061512' target='_blank' rel='noopener noreferrer'>this comment on GitHub</a>"
                         ]
@@ -1247,7 +1247,7 @@
                         "anchor": "ENError11",
                         "active": true,
                         "textblock": [
-                            "UPDATE: Although Apple stated that this Issue has been fixed with iOS 13.6, it's currently appearing again on devices which run iOS 14 or higher. To fix it please open the iOS settings and go to 'Exposure Notification', scroll down to the bottom and click 'Turn Off Exosure Notifications' and turn it back on again.",
+                            "UPDATE: Although Apple stated that this Issue has been fixed with iOS 13.6, it's currently appearing again on devices which run iOS 14 or higher. To fix it please open the iOS settings and go to 'Exposure Notification', scroll down to the bottom and click 'Turn Off Exposure Notifications' and turn it back on again.",
                             "The ENErrorDomain 11 error is thrown by Apple's Exposure Notification System, which is used by the Corona-Warn-App."
                         ]
                     },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -213,7 +213,7 @@
                         "anchor": "ios_power_save",
                         "active": true,
                         "textblock": [
-                            "Wenn Sie auf Ihrem Gerät iOS Version 13.6.1 oder höher verwenden, ist die Funktion der Corona-Warn-App im Stromsparmodus nicht beeinträchtigt. Auf Geräten mit einer früheren iOS Version kann es zu Poblemen mit der Hintergrundaktualisierung kommen. <b>Wir bitten Sie daher, die iOS Version Ihres Geräts auf 13.6.1 oder höher zu aktualisieren, falls Sie den Stromsparmodus verwenden wollen.</b>"
+                            "Wenn Sie auf Ihrem Gerät iOS Version 13.6.1 oder höher verwenden, ist die Funktion der Corona-Warn-App im Stromsparmodus nicht beeinträchtigt. Auf Geräten mit einer früheren iOS Version kann es zu Problemen mit der Hintergrundaktualisierung kommen. <b>Wir bitten Sie daher, die iOS Version Ihres Geräts auf 13.6.1 oder höher zu aktualisieren, falls Sie den Stromsparmodus verwenden wollen.</b>"
                         ]
                     },
                     {
@@ -511,7 +511,7 @@
                         "anchor": "days_last_risk_encounter",
                         "active": true,
                         "textblock": [
-                            "Die Anzahl der Tage werden normal numerisch gezählt - '1 Tag seit der letzten Begegnung' heisst somit 'gestern', '2' demnach 'vorgestern'. Die Details zur technischen Implementation <a href='https://developer.apple.com/documentation/exposurenotification/enexposuredetectionsummary/3583708-dayssincelastexposure'>erklärt Apple hier.</a>"
+                            "Die Anzahl der Tage werden normal numerisch gezählt - '1 Tag seit der letzten Begegnung' heißt somit 'gestern', '2' demnach 'vorgestern'. Die Details zur technischen Implementation <a href='https://developer.apple.com/documentation/exposurenotification/enexposuredetectionsummary/3583708-dayssincelastexposure'>erklärt Apple hier.</a>"
                         ]
                     },
                     {
@@ -862,7 +862,7 @@
                         "anchor": "central_entity",
                         "active": true,
                         "textblock": [
-                            "Die App selbst speichert keinerlei Informationen über einzelne potenzielle Begegnungsereignisse. Das Exposure Notification System, auf dem die App aufbaut, speichert in sicherer Form die sichtbaren Rolling Proximity Identifiers (RPIs) auf den Smartphones ab, die sich innerhalb eines bestimmten Zeitraums in nächster Nähe aufgehalten haben. Selbst wenn die zentrale Infrastruktur kompromittiert wird, kann diese Information nicht zu einem Smartphone zurückverfolgt werden, wenn nicht ohnehin schon Zugriff auf das Smartphone besteht. Selbst dann kann die App selbst nicht auf die RPIs zugreifen. Auf die Diagnoseschlüssel ('Positivkennungen') kann nur mit Zustimmung der nutzenden Person zugegriffen werden, und auch dies ist nur für einen kurzen Zeitraum möglich. Vor der Verarbeitung der Daten werden die Informationen entfernt, die die Poisitivkennung und die Verbindungsmetadaten miteinander verknüpfen."
+                            "Die App selbst speichert keinerlei Informationen über einzelne potenzielle Begegnungsereignisse. Das Exposure Notification System, auf dem die App aufbaut, speichert in sicherer Form die sichtbaren Rolling Proximity Identifiers (RPIs) auf den Smartphones ab, die sich innerhalb eines bestimmten Zeitraums in nächster Nähe aufgehalten haben. Selbst wenn die zentrale Infrastruktur kompromittiert wird, kann diese Information nicht zu einem Smartphone zurückverfolgt werden, wenn nicht ohnehin schon Zugriff auf das Smartphone besteht. Selbst dann kann die App selbst nicht auf die RPIs zugreifen. Auf die Diagnoseschlüssel ('Positivkennungen') kann nur mit Zustimmung der nutzenden Person zugegriffen werden, und auch dies ist nur für einen kurzen Zeitraum möglich. Vor der Verarbeitung der Daten werden die Informationen entfernt, die die Positivkennung und die Verbindungsmetadaten miteinander verknüpfen."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR fixes minor typographical errors in the website files faq.json and faq_de.json.

**EN**
deceides => decides 
continously => continuously
Exosure => Exposure

**DE**
Poblemen => Problemen 
heisst => heißt 
Poisitivkennung => Positivkennung 