### PR TITLE
Correct blog link to scan error FAQ (closes #986)

### DIFF
--- a/blog/2020-08-25-notes-qr-codes/index.md
+++ b/blog/2020-08-25-notes-qr-codes/index.md
@@ -10,7 +10,7 @@ layout: blog
 The Corona-Warn-App has been active for a few weeks now and has been downloaded over 17.6 million times. An essential part of the app is the QR code procedure, which allows tested users to report test results to the app pseudonymously. 
 <!-- overview -->
 
-If a tested person receives a QR code, they are required to scan it and thus report the results to the app. In some cases, [error messages](https://www.coronawarn.app/en/faq/#qr_test) appear, in others the [test result cannot be retrieved](https://www.coronawarn.app/en/faq/#qr_test). Why is that and what to do in these cases?
+If a tested person receives a QR code, they are required to scan it and thus report the results to the app. In some cases, [error messages](https://www.coronawarn.app/en/faq/#qr_scan) appear, in others the [test result cannot be retrieved](https://www.coronawarn.app/en/faq/#qr_test). Why is that and what to do in these cases?
 
 Possibility 1: During the test, the physician or test personnel did not indicate the necessary consent for data transfer to the Corona-Warn-App. The tick on the [form](https://github.com/corona-warn-app/cwa-documentation/issues/400#issuecomment-669937832) for "Consent of the insured person to transfer the test result for the purposes of the Corona-Warn-App" is missing. Without this consent, the QR Code cannot be further processed in the relevant laboratory and the test result will not be transferred to the Corona-Warn-App.
 

--- a/blog/2020-08-25-notes-qr-codes/index_de.md
+++ b/blog/2020-08-25-notes-qr-codes/index_de.md
@@ -11,7 +11,7 @@ Die Corona-Warn-App ist nun seit einigen Wochen aktiv und kann bereits über 17,
 <!-- overview -->
 
 
-Erhält eine getestete Personen einen QR-Code, ist sie dazu angehalten, diesen zu scannen und so die Ergebnisse an die App zu übermitteln. In einigen Fällen erscheinen dabei jedoch [Fehlermeldungen](https://www.coronawarn.app/de/faq/#qr_test), in anderen kann das [Testergebnis nicht abgerufen werden](https://www.coronawarn.app/de/faq/#qr_test). Woran kann das liegen und was ist in diesen Fällen zu tun?
+Erhält eine getestete Personen einen QR-Code, ist sie dazu angehalten, diesen zu scannen und so die Ergebnisse an die App zu übermitteln. In einigen Fällen erscheinen dabei jedoch [Fehlermeldungen](https://www.coronawarn.app/de/faq/#qr_scan), in anderen kann das [Testergebnis nicht abgerufen werden](https://www.coronawarn.app/de/faq/#qr_test). Woran kann das liegen und was ist in diesen Fällen zu tun?
 
 Möglichkeit 1: Arzt oder Test-Personal haben beim Test nicht auf die notwendige Einwilligung zur Datenübertragung an die Corona-Warn-App hingewiesen. Der Haken auf dem [Formular](https://github.com/corona-warn-app/cwa-documentation/issues/400#issuecomment-669937832) zum „Einverständnis des Versicherten zum Übermitteln des Testergebnisses für Zwecke der Corona-Warn-App“ fehlt. Ohne diese Einwilligung kann der QR-Code im zuständigen Labor nicht weiterverarbeitet werden und es findet keine Übermittlung des Testergebnisses in die Corona Warn App statt.
 


### PR DESCRIPTION
This PR corrects a linking error described in issue #986.

**QR Code scanned but no test result in the Corona-Warn-App**
https://www.coronawarn.app/en/blog/2020-08-25-notes-qr-codes/
and
**QR-Code gescannt aber kein Testergebnis in der Corona-Warn-App**
https://www.coronawarn.app/de/blog/2020-08-25-notes-qr-codes/

now link to the correct FAQ article.

**EN**
https://www.coronawarn.app/en/blog/2020-08-25-notes-qr-codes/ 
"In some cases, [error messages](https://www.coronawarn.app/en/faq/#qr_test) ..."
links now to [#qr_scan](https://www.coronawarn.app/en/faq/#qr_scan).

**DE**
https://www.coronawarn.app/de/blog/2020-08-25-notes-qr-codes/ 
"In some cases, [error messages](https://www.coronawarn.app/de/faq/#qr_test) ..."
links now to [#qr_scan](https://www.coronawarn.app/de/faq/#qr_scan).