### PR TITLE
Update iOS & Android app versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -326,10 +326,10 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.4.2'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '1.15.1'))
+    .pipe(replace('[ios.current-app-version]', '1.15.2'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '1.15.1'))
+    .pipe(replace('[android.current-app-version]', '1.15.2'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
This commit updates the app versions from 1.15.1 -> 1.15.2.

See iOS release: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v1.15.2
See Android release: https://github.com/corona-warn-app/cwa-app-android/releases/tag/v1.15.2