### PR TITLE
Mention blog post from `#rapid_test` entry (Closes #1040)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -622,6 +622,7 @@
                         "anchor": "rapid_test",
                         "active": true,
                         "textblock": [
+                            "<b>Update</b><br/>It will soon be possible to enter the result from a rapid/quick test into the app. More information can be found in <a href='../blog/2021-03-31-corona-warn-app-test-integration/' target='_blank' rel='noopener noreferrer'>this</a> blog post.<hr/>",
                             "No, entering results from rapid tests is currently not supported by the Corona-Warn-App."
                         ]
                     },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -623,7 +623,7 @@
                         "anchor": "rapid_test",
                         "active": true,
                         "textblock": [
-                            "<b>Update</b><br/>Es wird bald möglich das Testergebnis eines Corona-Schnelltests in die App einzutragen. Weitere Informationen finden Sie in <a href='../blog/2021-03-31-corona-warn-app-test-integration/' target='_blank' rel='noopener noreferrer'>diesem</a> Blog Post.<hr/>",
+                            "<b>Aktuell</b><br/>Es wird bald möglich das Testergebnis eines Corona-Schnelltests in die App einzutragen. Weitere Informationen finden Sie in <a href='../blog/2021-03-31-corona-warn-app-test-integration/' target='_blank' rel='noopener noreferrer'>diesem</a> Blog Post.<hr/>",
                             "Nein, die Eingabe von Schnelltests wird von der Corona-Warn-App zurzeit nicht unterstützt."
                         ]
                     },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -623,6 +623,7 @@
                         "anchor": "rapid_test",
                         "active": true,
                         "textblock": [
+                            "<b>Update</b><br/>Es wird bald möglich das Testergebnis eines Corona-Schnelltests in die App einzutragen. Weitere Informationen finden Sie in <a href='../blog/2021-03-31-corona-warn-app-test-integration/' target='_blank' rel='noopener noreferrer'>diesem</a> Blog Post.<hr/>",
                             "Nein, die Eingabe von Schnelltests wird von der Corona-Warn-App zurzeit nicht unterstützt."
                         ]
                     },


### PR DESCRIPTION
This PR adds a mention of the blog post https://www.coronawarn.app/de/blog/2021-03-31-corona-warn-app-test-integration/ to the FAQ entry "#rapid_test".

<details>
<summary>Screenshots of the changes</summary>

<img width="641" alt="Preview DE" src="https://user-images.githubusercontent.com/67682506/113404819-166e1000-93a9-11eb-8ffc-7e8b12c9b444.png">
<img width="619" alt="Preview EN" src="https://user-images.githubusercontent.com/67682506/113404824-179f3d00-93a9-11eb-8d2f-438065460fc0.png">


</details>

--- 

Closes #1040

