### PR TITLE
Improve & correct download page

### DIFF
--- a/src/data/download.json
+++ b/src/data/download.json
@@ -1,7 +1,7 @@
 {
     "section-main": {
         "headline": {
-            "title": "Download the Corona Warn App to check in"
+            "title": "Download the Corona-Warn-App to check in"
         },
         "content": {
             "text": "Available for download on Apple App Store and Google Play."

--- a/src/data/download.json
+++ b/src/data/download.json
@@ -9,7 +9,7 @@
         "image": {
             "url": "/assets/img/app-mockup@2x.png",
             "url-webp": "/assets/img/app-mockup@2x.webp",
-            "title": "Corona Warn App",
+            "title": "Corona-Warn-App",
             "alt": "Corona-Warn-App Smartphone"
         }
     }

--- a/src/data/download_de.json
+++ b/src/data/download_de.json
@@ -9,7 +9,7 @@
         "image": {
             "url": "/assets/img/app-mockup@2x.png",
             "url-webp": "/assets/img/app-mockup@2x.webp",
-            "title": "Corona Warn App",
+            "title": "Corona-Warn-App",
             "alt": "Corona-Warn-App Smartphone"
         }
     }

--- a/src/data/download_de.json
+++ b/src/data/download_de.json
@@ -4,7 +4,7 @@
             "title": "Lade die Corona-Warn-App herunter um dich einzuchecken"
         },
         "content": {
-            "text": "Zum Dowload verfügbar im Apple App Store und auf Google Play."
+            "text": "Zum Download verfügbar im Apple App Store und auf Google Play."
         },
         "image": {
             "url": "/assets/img/app-mockup@2x.png",

--- a/src/data/download_de.json
+++ b/src/data/download_de.json
@@ -1,7 +1,7 @@
 {
     "section-main": {
         "headline": {
-            "title": "Lade die Corona Warn App um dich einzuchecken"
+            "title": "Lade die Corona-Warn-App herunter um dich einzuchecken"
         },
         "content": {
             "text": "Zum Dowload verfügbar im Apple App Store und auf Google Play."


### PR DESCRIPTION
This PR improves the wording of the [download page](https://www.coronawarn.app/?target=download).

## Done in this PR:

- [X] add hyphen to "Corona Warn App"
- [X] add "herunter" to write "lade die Corona-Warn-App herunter" instead of "Lade die Corona-Warn-App" 
- [X] correct typo "Dowload" 

## TODO (if wanted):
- [ ] change button order (#1094) - Ready to implement
- [ ] change HTML title (#1094) - Ready to implement
- [ ] change from "Du" to "Sie" (#1093) - Ready to implement

## Current status: 

Waiting on feedback from @svengabr, @heinezen or @dsarkar.