### PR TITLE
Fix typos in `eventregistration` & blog post

### DIFF
--- a/blog/2021-04-23-qr-code-generator-website/index.md
+++ b/blog/2021-04-23-qr-code-generator-website/index.md
@@ -11,7 +11,7 @@ The Corona-Warn-App community has developed a QR code generator for the app's we
 
 <!-- overview -->
 
-The Corona-Warn-App community provided the QR code generator to the project team on GitHub. The development team then reviewed the community's contribution and released the QR code generator in a customized form. We would like to take this opportunity to thank in particular @bastianjoel and all the community members involved for contributing to this new feature. This example shows again very well how useful the open source approach and the publication of the source code of the Corona-Warn-Ap is.
+The Corona-Warn-App community provided the QR code generator to the project team on GitHub. The development team then reviewed the community's contribution and released the QR code generator in a customized form. We would like to take this opportunity to thank in particular @bastianjoel and all the community members involved for contributing to this new feature. This example shows again very well how useful the open source approach and the publication of the source code of the Corona-Warn-App is.
 
 
 <br></br>

--- a/blog/2021-04-23-qr-code-generator-website/index.md
+++ b/blog/2021-04-23-qr-code-generator-website/index.md
@@ -11,7 +11,7 @@ The Corona-Warn-App community has developed a QR code generator for the app's we
 
 <!-- overview -->
 
-The Corona-Warn-App community provided the QR code generator to the project team on GitHub. The development team then reviewed the community's contribution and released the QR code generator in a customized form. We would like to take this opportunity to thank in particular @bastianjoel and all the community members involved for contributing to this new feature. This example shows again very well how useful the open source approach and the publication of the source code of the Corona warning app is.
+The Corona-Warn-App community provided the QR code generator to the project team on GitHub. The development team then reviewed the community's contribution and released the QR code generator in a customized form. We would like to take this opportunity to thank in particular @bastianjoel and all the community members involved for contributing to this new feature. This example shows again very well how useful the open source approach and the publication of the source code of the Corona-Warn-Ap is.
 
 
 <br></br>

--- a/src/data/eventregistration_de.json
+++ b/src/data/eventregistration_de.json
@@ -10,7 +10,7 @@
                 "locationtype": "Ort/Event",
                 "description": "Beschreibung",
                 "address": "Anschrift",
-                "defaultcheckinlength": "Typische Aufentshaltsdauer (Minuten)",
+                "defaultcheckinlength": "Typische Aufenthaltsdauer (Minuten)",
                 "starttime": "Startzeit",
                 "endtime": "Endzeit",
                 "show": "Erstellen",
@@ -19,14 +19,14 @@
             "placeholders": {
                 "description": "z.B. Friseur",
                 "address": "z.B. Musterstr. 12, 12345 Musterstadt",
-                "defaultcheckinlength": "z.b. 45"
+                "defaultcheckinlength": "z.B. 45"
             },
             "errors": {
                 "descriptionrequired": "Es wird eine Beschreibung benötigt",
                 "descriptionmax": "Die Beschreibung darf maximal 100 Zeichen lang sein",
                 "addressrequired": "Es wird eine Adresse benötigt",
                 "addressmax": "Die Adresse darf maximal 100 Zeichen lang sein",
-                "defaultcheckinlengthrequired": "Bitte geben Sie eine typische Aufentshaltsdauer an",
+                "defaultcheckinlengthrequired": "Bitte geben Sie eine typische Aufenthaltsdauer an",
                 "defaultcheckinlengthnumber": "Die Zeit zum Auschecken muss eine Zahl sein",
                 "starttimerequired": "Die Startzeit wird benötigt",
                 "endtimerequired": "Die Endzeit wird benötigt",


### PR DESCRIPTION
This PR fixes some typos discovered by @DerVogel2020 in https://github.com/corona-warn-app/cwa-website/pull/1132#pullrequestreview-643532898.
This PR also changes "Corona warning app" to "Corona-Warn-App" in the English blog post "2021-04-23-qr-code-generator-website".