### PR TITLE
Align English to German (QR-Code generator)

### DIFF
--- a/src/data/eventregistration.json
+++ b/src/data/eventregistration.json
@@ -17,7 +17,7 @@
                 "download": "Download"
             },
             "placeholders": {
-                "description": "e.g. Shopping Center",
+                "description": "e.g. Hairdresser",
                 "address": "e.g. Sample Street 12, 12345 Sample City",
                 "defaultcheckinlength": "e.g. 45"
             },


### PR DESCRIPTION
This tiny PR aligns the example for the description to the German one (changed through #1134).

**Changed:**
"Shopping center" -> "Hairdresser"