### PR TITLE
Make labels in QR code generator consistent with app

### DIFF
--- a/src/data/eventregistration.json
+++ b/src/data/eventregistration.json
@@ -9,7 +9,7 @@
             "fields": {
                 "locationtype": "Place/Event",
                 "description": "Description",
-                "address": "Address",
+                "address": "Place",
                 "defaultcheckinlength": "Typical length of stay (minutes)",
                 "starttime": "Start time",
                 "endtime": "End time",

--- a/src/data/eventregistration_de.json
+++ b/src/data/eventregistration_de.json
@@ -8,8 +8,8 @@
         "form": {
             "fields": {
                 "locationtype": "Ort/Event",
-                "description": "Beschreibung",
-                "address": "Anschrift",
+                "description": "Bezeichnung",
+                "address": "Ort",
                 "defaultcheckinlength": "Typische Aufenthaltsdauer (Minuten)",
                 "starttime": "Startzeit",
                 "endtime": "Endzeit",


### PR DESCRIPTION
### Where to find the issue
https://www.coronawarn.app/en/eventregistration/

### Describe the issue
The Place field is called Address. This is inconsistent with the mobile app, where the field is called Place.

In German, the same applies. Additionally, the label is "Beschreibung", not "Bezeichnung" like in the app.

### Additional context

A user was [confused](https://social.tchncs.de/@erAck/106126160685373319) why an Address was required on the website.