### PR TITLE
Remove "other" from QR-Code generator

### DIFF
--- a/src/data/eventregistration.json
+++ b/src/data/eventregistration.json
@@ -49,8 +49,7 @@
                 { "id": 10, "name": "Club activities" },
                 { "id": 11, "name": "Private party" },
                 { "id": 12, "name": "Religious service" },
-                { "id": 2, "name": "Other event" },
-                { "id": 0, "name": "Other" }
+                { "id": 2, "name": "Other event" }
             ]
         }
     }

--- a/src/data/eventregistration_de.json
+++ b/src/data/eventregistration_de.json
@@ -49,8 +49,7 @@
                 { "id": 10, "name": "Vereinsaktivität" },
                 { "id": 11, "name": "private Feier" },
                 { "id": 12, "name": "Gottesdienst" },
-                { "id": 2, "name": "anderes Event" },
-                { "id": 0, "name": "Sonstiges" }
+                { "id": 2, "name": "anderes Event" }
             ]
         }
     }


### PR DESCRIPTION
This PR removes the option to choose "Other" in the QR-Code generator since there is no option for this in the app and thus the app shows an error/unlocalized string.

Related: https://github.com/corona-warn-app/cwa-app-ios/issues/2564