### PR TITLE
Fix German title in English FAQ

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -54,7 +54,7 @@
                 "active": true,
                 "accordion": [
                     {
-                        "title": "Information zur bereits von Google geschlossenen Sicherheitlücke im Exposure Notification Framework",
+                        "title": "Information to the vulnerability in the Exposure Notification Framework already fixed by Google",
                         "anchor": "google_security_vulnerability",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
This fixes the German title in the English FAQ entry: https://www.coronawarn.app/en/faq/#google_security_vulnerability

Follow up to #1175