### PR TITLE
Improve eventregistration download button behavior 

### DIFF
--- a/src/assets/js/eventregistration.js
+++ b/src/assets/js/eventregistration.js
@@ -23,6 +23,7 @@ UpdateQRForm();
 document.getElementById('qrform').addEventListener('change', function (e) {
   document.getElementById('eventplaceholder').classList.remove('d-none');
   document.getElementById('eventqrcode').classList.add('d-none');
+  document.getElementById('downloadCode').disabled = true;
 });
 
 document.getElementById('generateQR').addEventListener('click', function (e) {

--- a/src/assets/js/eventregistration.js
+++ b/src/assets/js/eventregistration.js
@@ -31,6 +31,8 @@ document.getElementById('generateQR').addEventListener('click', function (e) {
   if (ValidateQRForm()) {
     GenerateQRCode();
 
+    // Active download button
+    document.getElementById('downloadCode').disabled = false;
     document.getElementById('eventplaceholder').classList.add('d-none');
     let canvas = document.getElementById('eventqrcode');
     canvas.classList.remove('d-none');
@@ -40,14 +42,10 @@ document.getElementById('generateQR').addEventListener('click', function (e) {
 document.getElementById('downloadCode').addEventListener('click', function (e) {
   e.preventDefault();
 
-  if (ValidateQRForm()) {
-    GenerateQRCode();
-
-    let dlLink = document.createElement('a');
-    dlLink.download = document.getElementById('description').value + '.png';
-    dlLink.href = document.getElementById('eventqrcode').toDataURL();
-    dlLink.click();
-  }
+  let dlLink = document.createElement('a');
+  dlLink.download = document.getElementById('description').value + '.png';
+  dlLink.href = document.getElementById('eventqrcode').toDataURL();
+  dlLink.click();
 });
 
 function ValidateQRForm() {

--- a/src/partials/page-eventregistration.html
+++ b/src/partials/page-eventregistration.html
@@ -126,7 +126,6 @@
             <div class="row mt-4">
               <div class="col-12">
                 <button id="generateQR" value="show" class="btn btn-primary">{{page-contents.section-main.form.fields.show}}</button>
-                <button id="downloadCode" value="download" class="btn btn-secondary">{{page-contents.section-main.form.fields.download}}</button>
               </div>
             </div>
           </form>
@@ -140,6 +139,11 @@
           <img src="/assets/img/pt-poster-1.0.0-placeholder.png" id="eventplaceholder" class="img img-fluid w-100 eventqr-preview" />
           {{/if}}
           <canvas id="eventqrcode" class="d-none eventqr-preview"></canvas>
+          <div class="row mt-4">
+            <div class="col-12">
+              <button id="downloadCode" value="download" class="btn btn-secondary" disabled>{{page-contents.section-main.form.fields.download}}</button>
+            </div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
This PR resolves #1144 and also resolves #1136. 

With this PR the download button is initially disabled when accessing the page. The disabled attribute is removed when the "create" button is clicked. 

Also I removed the logic which creates a new qr code when clicking the download button. To make it more clear that the download button only downloads the current banner I've repositioned the button under the banner.