### PR TITLE
Event date time pickers and select fields for defaultcheckinlength

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -60,6 +60,11 @@ Licensor: Andrea Giammarchi and other contributors
 Website: https://www.npmjs.com/package/uint8-to-base64
 License: ISC
 
+Component: cleave.js
+Licensor: Max Huang
+Website: https://nosir.github.io/cleave.js/
+License: Apache-2.0 License
+
 --------------------------------------------------------------------------------
 Apache License 2.0 (Roboto Font)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3631,6 +3631,11 @@
         }
       }
     },
+    "cleave.js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cleave.js/-/cleave.js-1.6.0.tgz",
+      "integrity": "sha512-ivqesy3j5hQVG3gywPfwKPbi/7ZSftY/UNp5uphnqjr25yI2CP8FS2ODQPzuLXXnNLi29e2+PgPkkiKUXLs/Nw=="
+    },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "autoprefixer": "^9.8.6",
     "babel-loader": "^8.2.2",
     "browser-sync": "^2.26.14",
+    "cleave.js": "^1.6.0",
     "google-protobuf": "^3.15.8",
     "gulp": "^4.0.2",
     "gulp-clean-css": "^4.3.0",

--- a/src/assets/js/eventregistration.js
+++ b/src/assets/js/eventregistration.js
@@ -2,15 +2,38 @@ import QRCode from 'qrcode';
 import { proto } from './lib/trace_location_pb';
 import { encode } from 'uint8-to-base64';
 import moment from 'moment';
+import Cleave from 'cleave.js';
+
+if (document.getElementById('qrform')) {
+  UpdateQRForm();
+
+  new Cleave('#starttime-date', {
+    date: true,
+    delimiter: '.',
+    datePattern: ['d', 'm', 'Y']
+  });
+
+  new Cleave('#starttime-time', {
+    time: true,
+    timePattern: ['h', 'm']
+  });
+
+  new Cleave('#endtime-date', {
+    date: true,
+    delimiter: '.',
+    datePattern: ['d', 'm', 'Y']
+  });
+
+  new Cleave('#endtime-time', {
+    time: true,
+    timePattern: ['h', 'm']
+  });
+}
 
 document.getElementById('locationtype').addEventListener('input', function (e) {
   UpdateQRForm();
 });
 function UpdateQRForm() {
-  if (!document.getElementById('qrform')) {
-    return;
-  }
-
   let locationtype = +document.getElementById('locationtype').value;
   if (locationtype && (locationtype >= 9 || locationtype === 2)) {
     document.getElementById('event-duration').classList.remove('d-none');
@@ -18,7 +41,6 @@ function UpdateQRForm() {
     document.getElementById('event-duration').classList.add('d-none');
   }
 }
-UpdateQRForm();
 
 document.getElementById('qrform').addEventListener('change', function (e) {
   document.getElementById('eventplaceholder').classList.remove('d-none');

--- a/src/assets/js/eventregistration.js
+++ b/src/assets/js/eventregistration.js
@@ -104,12 +104,10 @@ function ValidateQRForm() {
     errors++;
   }
 
-  let defaultcheckinlength = document.getElementById('defaultcheckinlength').value;
-  if (!defaultcheckinlength) {
+  let defaultcheckinlengthHours = +document.getElementById('defaultcheckinlength-hours').value;
+  let defaultcheckinlengthMinutes = +document.getElementById('defaultcheckinlength-minutes').value;
+  if (!defaultcheckinlengthMinutes && !defaultcheckinlengthHours) {
     document.getElementById('qr-error-defaultcheckinlengthrequired').style.display = 'block';
-    errors++;
-  } else if (isNaN(defaultcheckinlength)) {
-    document.getElementById('qr-error-defaultcheckinlengthnumber').style.display = 'block';
     errors++;
   }
 
@@ -158,13 +156,14 @@ function ValidateQRForm() {
 function GenerateQRCode() {
   let description = document.getElementById('description').value;
   let address = document.getElementById('address').value;
-  let defaultcheckinlength = document.getElementById('defaultcheckinlength').value;
+  let defaultcheckinlengthHours = +document.getElementById('defaultcheckinlength-hours').value;
+  let defaultcheckinlengthMinutes = +document.getElementById('defaultcheckinlength-minutes').value;
   let locationtype = +document.getElementById('locationtype').value;
 
   let locationData = new proto.CWALocationData();
   locationData.setVersion(1);
   locationData.setType(locationtype);
-  locationData.setDefaultcheckinlengthinminutes(+defaultcheckinlength);
+  locationData.setDefaultcheckinlengthinminutes(defaultcheckinlengthHours * 60 + defaultcheckinlengthMinutes);
 
   let crowdNotifierData = new proto.CrowdNotifierData();
   crowdNotifierData.setVersion(1);

--- a/src/assets/scss/vendor/_eventregistration.scss
+++ b/src/assets/scss/vendor/_eventregistration.scss
@@ -2,6 +2,11 @@
 
 .component.qrgenerator {
 
+    .time-sep {
+        font-weight: bold;
+        font-size: 22px;
+    }
+
     .eventqr-preview {
         border: 1px solid #ced4da;
         border-radius: .375rem;

--- a/src/data/eventregistration.json
+++ b/src/data/eventregistration.json
@@ -10,7 +10,7 @@
                 "locationtype": "Place/Event",
                 "description": "Description",
                 "address": "Place",
-                "defaultcheckinlength": "Typical length of stay (minutes)",
+                "defaultcheckinlength": "Typical length of stay (hours)",
                 "starttime": "Start",
                 "endtime": "End",
                 "show": "Create",

--- a/src/data/eventregistration_de.json
+++ b/src/data/eventregistration_de.json
@@ -10,7 +10,7 @@
                 "locationtype": "Ort/Event",
                 "description": "Bezeichnung",
                 "address": "Ort",
-                "defaultcheckinlength": "Typische Aufenthaltsdauer (Minuten)",
+                "defaultcheckinlength": "Typische Aufenthaltsdauer (Stunden)",
                 "starttime": "Beginn",
                 "endtime": "Ende",
                 "show": "Erstellen",

--- a/src/partials/page-eventregistration.html
+++ b/src/partials/page-eventregistration.html
@@ -116,10 +116,10 @@
                 <label for="starttime-date" class="col-12 col-form-label">{{page-contents.section-main.form.fields.starttime}}</label>
                 <div class="col-12">
                   <div class="row">
-                    <div class="col-sm-8">
+                    <div class="col-7 col-sm-8">
                       <input id="starttime-date" class="form-control" type="text" placeholder="{{page-contents.section-main.form.dateplaceholder}}" max="10">
                     </div>
-                    <div class="col-sm-4">
+                    <div class="col-5 col-sm-4">
                       <input id="starttime-time" class="form-control" type="text" placeholder="{{page-contents.section-main.form.timeplaceholder}}" max="5">
                     </div>
                   </div>
@@ -139,10 +139,10 @@
                 <label for="endtime-date" class="col-12 col-form-label">{{page-contents.section-main.form.fields.endtime}}</label>
                 <div class="col-12">
                   <div class="row">
-                    <div class="col-sm-8">
+                    <div class="col-7 col-sm-8">
                       <input id="endtime-date" class="form-control" type="text" placeholder="{{page-contents.section-main.form.dateplaceholder}}" max="10">
                     </div>
-                    <div class="col-sm-4">
+                    <div class="col-5 col-sm-4">
                       <input id="endtime-time" class="form-control" type="text" placeholder="{{page-contents.section-main.form.timeplaceholder}}" max="5">
                     </div>
                   </div>

--- a/src/partials/page-eventregistration.html
+++ b/src/partials/page-eventregistration.html
@@ -61,7 +61,47 @@
             <div class="form-group row mb-2">
               <label for="defaultcheckinlength" class="col-12 col-form-label">{{page-contents.section-main.form.fields.defaultcheckinlength}}</label>
               <div class="col-12">
-                <input id="defaultcheckinlength" class="form-control" type="number" step="15" min="0" max="3600" placeholder="{{page-contents.section-main.form.placeholders.defaultcheckinlength}}" required>
+                <div class="row">
+                  <div class="col-5">
+                    <select id="defaultcheckinlength-hours" class="form-control">
+                      <option value="0">00</option>
+                      <option value="1">01</option>
+                      <option value="2" selected>02</option>
+                      <option value="3">03</option>
+                      <option value="4">04</option>
+                      <option value="5">05</option>
+                      <option value="6">06</option>
+                      <option value="7">07</option>
+                      <option value="8">08</option>
+                      <option value="9">09</option>
+                      <option>10</option>
+                      <option>11</option>
+                      <option>12</option>
+                      <option>13</option>
+                      <option>14</option>
+                      <option>15</option>
+                      <option>16</option>
+                      <option>17</option>
+                      <option>18</option>
+                      <option>19</option>
+                      <option>20</option>
+                      <option>21</option>
+                      <option>22</option>
+                      <option>23</option>
+                    </select>
+                  </div>
+                  <div class="col-2 align-self-center text-center">
+                    <span class="time-sep">:</span>
+                  </div>
+                  <div class="col-5">
+                    <select id="defaultcheckinlength-minutes" class="form-control">
+                      <option>00</option>
+                      <option>15</option>
+                      <option>30</option>
+                      <option>45</option>
+                    </select>
+                  </div>
+                </div>
                 <div id="qr-error-defaultcheckinlengthrequired" class="invalid-feedback">
                   {{page-contents.section-main.form.errors.defaultcheckinlengthrequired}}
                 </div>


### PR DESCRIPTION
This PR adds cleave.js to the date and time fields which forces users to use the given date pattern and adds separators automatically which resolves #1143. 

Also the input field defaultcheckinlength got replaced by two select fields for hours and minutes. This resolves #1192 because with the select fields it is not possible anymore to select more than 3600 minutes. In addition this resolves #1155 because the number input field got replaced by select fields. 