### PR TITLE
Remove "International phone numbers" from the title of "international_phone_numbers"

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -23,7 +23,7 @@
                             "The technical hotline (<a href='#international_phone_numbers' target='_blank' rel='noopener noreferrer'>click here to see the phone numbers</a>) will help you with technical questions about the Corona-Warn-App, for instance if you have problems with exposure logging. You can reach the technical hotline from Monday to Saturday from 7 a.m. to 10 p.m. (except on German national holidays), and it is free of charge for you within Germany.",
                             "The TAN hotline (<a href='#international_phone_numbers' target='_blank' rel='noopener noreferrer'>click here to see the phone numbers</a>) will help you to enter the TAN if you have a positive test result and if you have not received a TAN or document with a QR code. The TAN hotline is available 24 hours a day, seven days a week. The call is free of charge from within Germany.",
                             "If the test result is not available in the Corona-Warn-App, the relevant service personnel, test centre or health authority should be contacted to obtain the test result.  <br/>In order to make it easier for you to find the responsible health authority, the RKI has provided a corresponding tool. By entering the postal code or the city of residence, the responsible health authority (including contact details) is immediately displayed: <a href='https://tools.rki.de/PLZTool/en-GB'>Robert Koch Institute Tool: Health authority by postal code or place</a>",
-                            "Further information on the QR Code procedure can be found in this FAQ entry: <a href='#qr_test'>I have scanned a QR code, but the test result could not be retrieved for days.</a>",
+                            "Further information on the QR Code procedure can be found in this FAQ entry: <a href='#qr_test'>I have scanned a QR code, but the test result could not be retrieved for days</a>.",
                             "The websites of the Federal Government are offering general information and videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch</a>.",
                             "The Robert Koch Institute also provides information on epidemiological aspects: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html'>https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html (German only)</a>.",
                             "As a media representative, please direct your enquiries to <a href='mailto:press@sap.com'>press@sap.com</a>.",
@@ -31,7 +31,7 @@
                         ]
                     },
                     {
-                        "title": "How to reach us - International phone numbers",
+                        "title": "How to reach us",
                         "anchor": "international_phone_numbers",
                         "active": true,
                         "textblock": [

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -23,7 +23,7 @@
                             "Die technische Hotline (<a href='#international_phone_numbers' target='_blank' rel='noopener noreferrer'>klicken Sie hier um zu den Telefonnummern zu gelangen</a>) hilft Ihnen bei technischen Fragen rund um die Corona-Warn-App, zum Beispiel bei Problemen mit der Risiko-Ermittlung. Sie erreichen sie von Montag bis Samstag von 7 bis 22 Uhr (außer an bundesweiten Feiertagen), und sie ist für Sie innerhalb Deutschlands kostenfrei.",
                             "Die TAN-Hotline (<a href='#international_phone_numbers' target='_blank' rel='noopener noreferrer'>klicken Sie hier um zu den Telefonnummern zu gelangen</a>) hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit QR-Code erhalten haben. Die TAN-Hotline ist 24 Stunden täglich an sieben Tagen in der Woche erreichbar. Der Anruf ist innerhalb Deutschlands kostenfrei.",
                             "Falls das Testergebnis nicht in der Corona-Warn-App abrufbar ist, sollte das zuständige Fachpersonal, Testcenter oder Gesundheitsamt kontaktiert werden, um das Testergebnis zu erhalten. <br/>Um Ihnen die Suche nach dem zuständigen Gesundheitsamt zu erleichtern, hat das RKI ein entsprechendes Tool zur Verfügung gestellt. Durch die Angabe der Postleitzahl oder des Wohnortes, wird sofort das zuständige Gesundheitsamt inklusive der Kontaktdaten angezeigt: <a href='https://tools.rki.de/PLZTool'>Robert Koch-Institut Tool: Gesundheitsamt nach Postleitzahl oder Ort</a>",
-                            "Weitere Hinweise zum QR-Code Verfahren finden Sie in diesem FAQ Eintrag: <a href='#qr_test'>Ich habe einen QR Code eingescannt, aber das Testergebnis konnte über Tage nicht abgerufen werden.</a>",
+                            "Weitere Hinweise zum QR-Code Verfahren finden Sie in diesem FAQ Eintrag: <a href='#qr_test'>Ich habe einen QR Code eingescannt, aber das Testergebnis konnte über Tage nicht abgerufen werden</a>.",
                             "Die Webseiten der Bundesregierung bieten allgemeine Informationen und Videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app</a>.",
                             "Das Robert Koch-Institut stellt auch Informationen zu epidemiologischen Aspekten zur Verfügung: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html'>https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html</a>.",
                             "Als Medienvertreter richten Sie bitte Ihre Anfragen an <a href='mailto:press@sap.com'>press@sap.com</a>.",
@@ -31,7 +31,7 @@
                         ]
                     },
                     {
-                        "title": "So erreichen Sie uns - Internationale Telefonnummern",
+                        "title": "So erreichen Sie uns",
                         "anchor": "international_phone_numbers",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
This PR removes "International phone numbers" from the title of the FAQ entry "internation_phone_numbers", since we also store the national phone numbers there.
Also, a "." was moved out of a link in "who_can_help". Instead, the "." is now normal text (;