### PR TITLE
FAQ: Capitalize Rapid Antigen Test section title

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -88,7 +88,7 @@
                 ]
             },
             {
-                "title": "Rapid antigen test",
+                "title": "Rapid Antigen Test",
                 "id": "rapid_antigen_test",
                 "active": true,
                 "accordion": [


### PR DESCRIPTION
The FAQ aligns capitalization of the English language FAQ section title "Rapid antigen test" with all other section titles by changing it to "Rapid Antigen Test", since all other section titles are already capitalized.

![RAT capitalization](https://user-images.githubusercontent.com/66998419/117617983-9d16c980-b16d-11eb-8eb8-f3e85e2c5ac7.jpg)
