### PR TITLE
German Screenshots page: "Check-In" -> "Check-in"

### DIFF
--- a/src/data/screenshots_de.json
+++ b/src/data/screenshots_de.json
@@ -166,7 +166,7 @@
                 ]
             },
             {
-                "title": "Check-In",
+                "title": "Check-in",
                 "anchor": "ios_check_in",
                 "images": [
                     { "filename": "de/ios/iPhone 11 Pro-check_in_host_view_my_qr_codes", "alt": "Check In Bild 1 von 8" },


### PR DESCRIPTION
This PR changes"Check-In" to "Check-in" in the German screenshot page to be consistent with the app.