### PR TITLE
Add introduction version info for BLE compatibility check (closes #1274)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -493,10 +493,11 @@
                         "active": true,
                         "textblock": [
                             "If you see such a notice, your device is not able to send any random IDs via Bluetooth. This can be caused by a restriction due to your combination of hardware and software on your device. Because of it, the Corona-Warn-App cannot use Bluetooth Low Energy in its so-called “peripheral mode”.",
-                            "In case you are infected and you decide to warn others, only users who were checked in to the same event or the same location, at the same time as you were, can be warned. Your own risk assesment is <b>not affected</b>. All other features of the app are also not affected.",
+                            "In case you are infected and you decide to warn others, only users who were checked in to the same event or the same location, at the same time as you were, can be warned. Your own risk assessment is <b>not affected</b>. All other features of the app are also not affected.",
                             "Please ensure that you are using the latest version of the operating system available for your smartphone. If the problem persists, please contact your device manufacturer.",
                             "If the card shows that your device is completely incompatible, the cause could be that your device does not contain a Bluetooth chip. Only in this case, you cannot exchange random IDs with others and risk assessment can only base its calculation on locations and events you checked in to.",
-                            "<b>Both Check-in and Contact Journal functionality, as well as retrieving PCR and rapid test results, is fully functional without restriction in any case</b> and only proximity-based ID recording is affected."
+                            "<b>Both Check-in and Contact Journal functionality, as well as retrieving PCR and rapid test results, is fully functional without restriction in any case</b> and only proximity-based ID recording is affected.",
+                            "Bluetooth compatibility checking and warnings were introduced with Android Corona-Warn-App version 2.2."
                         ]
                     }
                 ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -498,7 +498,8 @@
                             "Sollten Sie sich entscheiden, Kontakte im Fall einer Infektion zu warnen, wird diese Benachrichtigung nur Personen erreichen, die gleichzeitig mit Ihnen an einem Ort oder einem Event eingecheckt waren. Ihre eigene Risiko-Ermittlung ist <b>nicht betroffen</b>. Alle anderen Features der App sind ebenfalls nicht betroffen.",
                             "Stellen Sie zunächst sicher, dass Sie die neuste Version des Betriebssystems Ihres Smartphones installiert haben. Wenn das Problem fortbesteht, wenden Sie sich bitte an Ihren Gerätehersteller.",
                             "Falls Ihnen angezeigt wird, dass Ihr Gerät gänzlich inkompatibel ist, dann kann dies daran liegen, dass in Ihrem Gerät kein Bluetooth-Chip verbaut ist. Nur in diesem Fall können Sie keine Zufalls-IDs von anderen empfangen und die Risiko-Berechnung kann nur Orte und Events, bei denen Sie eingecheckt waren, berücksichtigen.",
-                            "<b>Die Funktionalitäten zum Einchecken, zum Abrufen von sowohl PCR- als auch Schnelltestergebnissen sowie das Kontakttagebuch funktionieren in jedem Fall trotz der Warnmeldung ohne Einschränkungen</b> und nur die Funktionen zum Nähe-basierten Austausch von Zufalls-IDs sind betroffen."
+                            "<b>Die Funktionalitäten zum Einchecken, zum Abrufen von sowohl PCR- als auch Schnelltestergebnissen sowie das Kontakttagebuch funktionieren in jedem Fall trotz der Warnmeldung ohne Einschränkungen</b> und nur die Funktionen zum Nähe-basierten Austausch von Zufalls-IDs sind betroffen.",
+                            "Bluetooth-Kompatibilitätsüberprüfungen und -Warnmeldungen wurden mit der Android Corona-Warn-App Version 2.2 eingeführt."
                         ]
                     }
                 ]


### PR DESCRIPTION
This PR adds the information to the FAQ entries
https://www.coronawarn.app/en/faq/#incompatibility_warning and
https://www.coronawarn.app/de/faq/#incompatibility_warning 

that the Bluetooth Low Energy compatibility checks were introduced with version 2.2 of CWA. The PR addresses issue https://github.com/corona-warn-app/cwa-website/issues/1274.

Without this information users may think that there is a bug in the app if they had previous versions of the app installed, have updated and are seeing a warning message for the first time.

Incidentally also one typo in the EN version of the FAQ entry is corrected at the same time.