### PR TITLE
Correct badge to show all issue count (closes #1285)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following channels are available for discussions, feedback, and support requ
 
 | Type                     | Channel                                                |
 | ------------------------ | ------------------------------------------------------ |
-| **General discussion, issues, bugs**   | <a href="https://github.com/corona-warn-app/cwa-website/issues/new/choose" title="General Discussion"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-website/question.svg?style=flat-square"></a> </a>   |
+| **General discussion, issues, bugs**   | <a href="https://github.com/corona-warn-app/cwa-website/issues/new/choose" title="General Discussion"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-website?style=flat-square"></a> </a>   |
 | **Other requests**    | <a href="mailto:corona-warn-app.opensource@sap.com" title="Email CWA Team"><img src="https://img.shields.io/badge/email-CWA%20team-green?logo=mail.ru&style=flat-square&logoColor=white"></a> |
 
 ## How to contribute


### PR DESCRIPTION
This PR corrects a link in [README.md](https://github.com/corona-warn-app/cwa-website/blob/master/README.md) to show the count of all open issues in the repository, not just the ones with a question label attached to them. The issue was raised in #1285.

![image](https://user-images.githubusercontent.com/66998419/118636078-97a42980-b7d4-11eb-9257-4f442c4f898e.png)


