### PR TITLE
Update hotline telephone numbers in cypress test

### DIFF
--- a/cypress/integration/hotline_spec.js
+++ b/cypress/integration/hotline_spec.js
@@ -5,9 +5,11 @@ describe('Test Hotline phone number', () => {
 
   it('Verify App and TAN Hotline', () => {
     cy.get('body').find('[data-e2e="hotline-app"]').contains('Hotline App')
-    cy.get('body').find('[data-e2e="hotline-app"]').contains('+49 800 7540001')
+    cy.get('body').find('[data-e2e="hotline-app"]').contains('0800 7540001')
+    cy.get('body').find('[data-e2e="hotline-app"]').contains('+49 30 498 75401')
 
     cy.get('body').find('[data-e2e="hotline-tan"]').contains('Hotline TAN')
-    cy.get('body').find('[data-e2e="hotline-tan"]').contains('+49 800 7540002')
+    cy.get('body').find('[data-e2e="hotline-tan"]').contains('0800 7540002')
+    cy.get('body').find('[data-e2e="hotline-tan"]').contains('+49 30 498 75402')
   })
 })


### PR DESCRIPTION
This PR fixes the failing cypress test [hotline_spec.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/hotline_spec.js) mentioned in issue #1282.

The test was broken by changes to [global.json](https://github.com/corona-warn-app/cwa-website/blob/master/src/data/global.json) in PR https://github.com/corona-warn-app/cwa-website/pull/757 which removed the "+49" prefix from the "Hotline App" and the "Hotline TAN" phone numbers.

## Verification

```
npm run test:prepare
npn run test
```

produces output including the following:

```
  Running:  hotline_spec.js                                                                 (3 of 3)


  Test Hotline phone number
    √ Verify App and TAN Hotline (778ms)


  1 passing (832ms)

```