### PR TITLE
Change API use to present tense

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -772,7 +772,7 @@
                         "anchor": "other_platforms",
                         "active": true,
                         "textblock": [
-                            "It's not foreseeable at the moment if and when the app will be available in other app stores except Google or Apple. The app will use the Apple and Google Exposure Notification APIs. The community is invited to contribute and use the app for other APIs."
+                            "It's not foreseeable at the moment if and when the app will be available in other app stores except Google or Apple. The app uses the Apple and Google Exposure Notification APIs. The community is invited to contribute and use the app for other APIs."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -775,7 +775,7 @@
                         "anchor": "other_platforms",
                         "active": true,
                         "textblock": [
-                            "Es ist im Moment nicht absehbar, wann und ob wir die App in anderen App Stores außer denen von Google oder Apple zur Verfügung stellen können. Die App wird die Apple und Google Exposure Notification APIs verwenden. Die Community kann sich gerne einbringen und die App für andere APIs übernehmen."
+                            "Es ist im Moment nicht absehbar, wann und ob wir die App in anderen App Stores außer denen von Google oder Apple zur Verfügung stellen können. Die App verwendet die Apple und Google Exposure Notification APIs. Die Community kann sich gerne einbringen und die App für andere APIs übernehmen."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR changes 
https://www.coronawarn.app/en/faq/#other_platforms and
https://www.coronawarn.app/de/faq/#other_platforms.

(EN) "The app will use the Apple and Google Exposure Notification APIs." changes to "The app uses the Apple and Google Exposure Notification APIs."
(DE) "Die App wird die Apple und Google Exposure Notification APIs verwenden." changes to "Die App verwendet die Apple und Google Exposure Notification APIs."

The app has already been using the GAEN APIs for one year since June 2020 and therefore the future tense of the verb is no longer fitting.