### PR TITLE
Align all `page-title`s & improve `page-description` s (Closes #1331)

### DIFF
--- a/src/pages/de/blog/archiv/index.html
+++ b/src/pages/de/blog/archiv/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: true
-page-title: Open-Source-Projekt für Corona-Warn-App – News
-page-description: Informationen über das Open-Source-Projekt für die Corona-Warn-App. Die Corona-Warn-App ist eine App, die hilft, Infektionsketten des Coronavirus in Deutschland nachzuverfolgen.
+page-title: Open-Source-Projekt Corona-Warn-App – News Archiv
+page-description: Archivierte Informationen zur Entwicklungsarbeit an der Corona-Warn-App.
 page-name: archiv
 page-name_en: archive
 is_blog_detail: true

--- a/src/pages/de/blog/index.html
+++ b/src/pages/de/blog/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: true
-page-title: Aktueller Blog zur Corona-Warn-App
-page-description: Blog zur Corona-Warn-App. Hier bekommst Du aktuelle Informationen zur Entwicklungsarbeit an der Corona-Warn-App und allen wichtigen Updates.
+page-title: Open-Source-Projekt Corona-Warn-App - Blog
+page-description: Blog zur Corona-Warn-App. Hier bekommen Sie aktuelle Informationen zur Entwicklungsarbeit an der Corona-Warn-App und allen wichtigen Updates.
 page-name: blog
 page-name_en: blog
 ---

--- a/src/pages/de/community/index.html
+++ b/src/pages/de/community/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: true
-page-title: Open-Source-Projekt für Corona-Warn-App – Community
-page-description: Informationen über das Open-Source-Projekt für die Corona-Warn-App. Die Corona-Warn-App ist eine App, die hilft, Infektionsketten des Coronavirus in Deutschland nachzuverfolgen.
+page-title: Open-Source-Projekt Corona-Warn-App – Community
+page-description: Informationen über das Open-Source-Projekt für die Corona-Warn-App.
 page-name: community
 ---
 {{> page-community page-contents=community_de}}

--- a/src/pages/de/eventregistration/index.html
+++ b/src/pages/de/eventregistration/index.html
@@ -1,6 +1,6 @@
 ---
 lang_de: true
-page-title: Open-Source-Projekt für Corona-Warn-App – Event QR Code
+page-title: Open-Source-Projekt Corona-Warn-App – Event QR-Code
 page-description: Sie planen ein Event oder haben ein Geschäft? Erstellen Sie einen QR-Code, mit dem sich Ihre Gäste bei Ankunft einchecken können.
 page-name: eventregistration
 eventregistration_js: true

--- a/src/pages/de/faq/index.html
+++ b/src/pages/de/faq/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: true
-page-title: Open-Source-Projekt für Corona-Warn-App – FAQ
-page-description: Antworten auf häufig gestellte Fragen über das Open-Source-Projekt für die Corona-Warn-App. Die Corona-Warn-App ist eine App, die hilft, Infektionsketten des Coronavirus in Deutschland nachzuverfolgen.
+page-title: Open-Source-Projekt Corona-Warn-App – FAQ
+page-description: Antworten auf häufig gestellte Fragen über die Corona-Warn-App.
 page-name: faq
 ---
 {{> page-faq page-contents=faq_de}}

--- a/src/pages/de/imprint/index.html
+++ b/src/pages/de/imprint/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: true
-page-title: Open-Source-Projekt für Corona-Warn-App – Impressum
-page-description: Impressum der Website coronawarn.app zum Open-Source-Projekt für die Corona-Warn-App.
+page-title: Open-Source-Projekt Corona-Warn-App – Impressum
+page-description: Impressum der Webseite coronawarn.app.
 page-name: imprint
 ---
 {{> page-imprint page-contents=imprint_de}}

--- a/src/pages/de/index.html
+++ b/src/pages/de/index.html
@@ -2,7 +2,7 @@
 lang_de: true
 get-app-enabled: true
 homepage: true
-page-title: Open-Source-Projekt für Corona-Warn-App
+page-title: Open-Source-Projekt Corona-Warn-App
 page-description: Website des Open-Source-Projekts für die Corona-Warn-App. Die Corona-Warn-App ist eine App, die hilft, Infektionsketten des Coronavirus in Deutschland nachzuverfolgen.
 ---
 {{> page-index page-contents=index_de}}

--- a/src/pages/de/news/index.html
+++ b/src/pages/de/news/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: true
-page-title: Open-Source-Projekt für Corona-Warn-App – News
-page-description: Blog der Website coronawarn.app zum Open-Source-Projekt für die Corona-Warn-App.
+page-title: Open-Source-Projekt Corona-Warn-App – News
+page-description: News zur Corona-Warn-App finden Sie im Blog.
 page-name: news
 ---
 <!DOCTYPE html>

--- a/src/pages/de/privacy/index.html
+++ b/src/pages/de/privacy/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: true
 page-title: Open-Source-Projekt Corona-Warn-App – Datenschutzerklärung
-page-description: Datenschutzerklärung der Website zum Open-Source-Projekt für die Corona-Warn-App.
+page-description: Datenschutzerklärung der Corona-Warn-App.
 page-name: privacy
 ---
 {{> page-privacy page-contents=privacy_de}}

--- a/src/pages/de/terms-of-use/index.html
+++ b/src/pages/de/terms-of-use/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: true
 page-title: Open-Source-Projekt Corona-Warn-App – Nutzungsbedingungen
-page-description: Nutzungsbedingungen der Website zum Open-Source-Projekt für die Corona-Warn-App.
+page-description: Nutzungsbedingungen der Corona-Warn-App.
 page-name: terms-of-use
 ---
 {{> page-terms-of-use page-contents=terms-of-use_de}}

--- a/src/pages/en/blog/archive/index.html
+++ b/src/pages/en/blog/archive/index.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
-page-title: Open-Source Project Corona-Warn-App – News
-page-description: Stay up-to-date with blog posts on open-source project Corona-Warn-App. The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany.
+page-title: Open-Source Project Corona-Warn-App – News Archive
+page-description: Here you can find all previous important information about the Corona-Warn-App open source project.
 page-name: archiv
 page-name_de: archiv
 is_blog_detail: true

--- a/src/pages/en/blog/index.html
+++ b/src/pages/en/blog/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: false
 page-title: Open-Source Project Corona-Warn-App - Blog
-page-description: Blog for the Corona-Warn-App. Here you get current information about the developmen on the Corona-Warn-App and all important updates.
+page-description: Blog for the Corona-Warn-App. Here you get current information about the development on the Corona-Warn-App and all important updates.
 page-name: blog
 page-name_en: blog
 ---

--- a/src/pages/en/blog/index.html
+++ b/src/pages/en/blog/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: false
-page-title: Current blog about the Corona-Warn-App
-page-description: Stay up-to-date with blog posts on open-source project Corona-Warn-App. The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany.
+page-title: Open-Source Project Corona-Warn-App - Blog
+page-description: Blog for the Corona-Warn-App. Here you get current information about the developmen on the Corona-Warn-App and all important updates.
 page-name: blog
 page-name_en: blog
 ---

--- a/src/pages/en/blog/index.html
+++ b/src/pages/en/blog/index.html
@@ -1,7 +1,7 @@
 ---
 lang_de: false
 page-title: Open-Source Project Corona-Warn-App - Blog
-page-description: Blog for the Corona-Warn-App. Here you get current information about the development on the Corona-Warn-App and all important updates.
+page-description: Blog for the Corona-Warn-App. Here you get current information about the development of the Corona-Warn-App and all important updates.
 page-name: blog
 page-name_en: blog
 ---

--- a/src/pages/en/community/index.html
+++ b/src/pages/en/community/index.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
 page-title: Open-Source Project Corona-Warn-App - Community
-page-description: The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany. Help to prevent the spreading of the corona virus by downloading the app.
+page-description: Information about the open source project for the Corona-Warn-App.
 page-name: community
 ---
 {{> page-community page-contents=community}}

--- a/src/pages/en/faq/index.html
+++ b/src/pages/en/faq/index.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
 page-title: Open-Source Project Corona-Warn-App – FAQ
-page-description: FAQ for the open-source project Corona-Warn-App. The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany.
+page-description: Answers to frequently asked questions about the Corona-Warn-App.
 page-name: faq
 ---
 {{> page-faq page-contents=faq}}

--- a/src/pages/en/imprint/index.html
+++ b/src/pages/en/imprint/index.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
 page-title: Open-Source Project Corona-Warn-App – Legal Notice
-page-description: Legal notice of the Corona-Warn-App open-source project website.
+page-description: Legal notice of the website coronawarn.app.
 page-name: imprint
 ---
 {{> page-imprint page-contents=imprint}}

--- a/src/pages/en/index.html
+++ b/src/pages/en/index.html
@@ -3,6 +3,6 @@ lang_en: true
 get-app-enabled: true
 homepage: true
 page-title: Open-Source Project Corona-Warn-App
-page-description: The website of the open-source project from the Corona-Warn-App. The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany.
+page-description: The website of the open-source project for the Corona-Warn-App. The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany.
 ---
 {{> page-index page-contents=index}}

--- a/src/pages/en/index.html
+++ b/src/pages/en/index.html
@@ -3,6 +3,6 @@ lang_en: true
 get-app-enabled: true
 homepage: true
 page-title: Open-Source Project Corona-Warn-App
-page-description: The website of open-source project Corona-Warn-App. The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany.
+page-description: The website of the open-source project from the Corona-Warn-App. The Corona-Warn-App is an app that helps trace infection chains of COVID-19 in Germany.
 ---
 {{> page-index page-contents=index}}

--- a/src/pages/en/news/index.html
+++ b/src/pages/en/news/index.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
 page-title: Open-Source Project Corona-Warn-App – News
-page-description: Blog of the Corona-Warn-App open-source project website.
+page-description: News about the Corona-Warn-App can be found in the blog.
 page-name: news
 ---
 <!DOCTYPE html>

--- a/src/pages/en/privacy/index.html
+++ b/src/pages/en/privacy/index.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
 page-title: Open-Source Project Corona-Warn-App – Privacy Statement
-page-description: The privacy statement of the Corona-Warn-App open-source project website.
+page-description: The privacy statement of the Corona-Warn-App.
 page-name: privacy
 ---
 {{> page-privacy page-contents=privacy}}

--- a/src/pages/en/screenshots-archive/2-2.html
+++ b/src/pages/en/screenshots-archive/2-2.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
 page-title: Open-Source Project Corona-Warn-App – Screenshots
-page-description: Screenshots of the Corona-Warn-App open-source project website.
+page-description: Screenshots of the Corona-Warn-App.
 page-name: 2-2
 lightbox: true
 screenshots-archive: true

--- a/src/pages/en/screenshots/index.html
+++ b/src/pages/en/screenshots/index.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
 page-title: Open-Source Project Corona-Warn-App – Screenshots
-page-description: Screenshots of the Corona-Warn-App open-source project website.
+page-description: Screenshots of the Corona-Warn-App.
 page-name: screenshots
 lightbox: true
 ---

--- a/src/pages/en/terms-of-use/index.html
+++ b/src/pages/en/terms-of-use/index.html
@@ -1,7 +1,7 @@
 ---
 lang_en: true
 page-title: Open-Source Project Corona-Warn-App – Terms of use
-page-description: Terms of use of the Corona-Warn-App open-source project website.
+page-description: Terms of use of the Corona-Warn-App.
 page-name: terms-of-use
 ---
 {{> page-terms-of-use page-contents=terms-of-use}}

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,6 +1,6 @@
 ---
 lang_de: true
 layout: redirect
-page-title: Open-Source-Projekt für Corona-Warn-App
+page-title: Open-Source-Projekt Corona-Warn-App
 page-description: Website des Open-Source-Projekts für die Corona-Warn-App. Die Corona-Warn-App ist eine App, die hilft, Infektionsketten des Coronavirus in Deutschland nachzuverfolgen.
 ---


### PR DESCRIPTION
### This PR has to be merged **INTO** the `svengabr/screenshot-archive` branch or into `master` **AFTER** #1329.¹

---

This PR introduces #1331. It aligns the `page-title`s on most of the pages and improves their descriptions (`page-description`).

Closes #1331 

---

¹ This is needed because #1329 adds a new site and I wanted to edit this too, so I used `svengabr/screenshot-archive` as the starting branch.

My change is in: https://github.com/corona-warn-app/cwa-website/pull/1332/commits/df977e7028d2b7368989de368510bb5a7294efa5