### PR TITLE
Align German text on main page to English

### DIFF
--- a/src/data/index_de.json
+++ b/src/data/index_de.json
@@ -1,7 +1,7 @@
 {
     "section-main": {
         "headline": {
-            "titlecaption": "Open-Source-Projekt für Corona-Warn-App",
+            "titlecaption": "Corona-Warn-App Open-Source-Projekt",
             "title": "Helft uns, die Corona-Warn-App zu verbessern"
         },
         "content": {


### PR DESCRIPTION
This tiny PR aligns the title on the German main page to the title on the English main page.

What it does:

"Open-Source-Projekt für Corona-Warn-App" -> "Corona-Warn-App Open-Source-Projekt"