### PR TITLE
Mention different implementation under iOS in `#rat_how_long_valid` (Closes #1330)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -149,12 +149,12 @@
                         ]
                     },
                     {
-                        "title": "How long is a rapid antigen test valid? What does the count-down mean?",
+                        "title": "How long is a rapid antigen test valid?",
                         "anchor": "rat_how_long_valid",
                         "active": true,
                         "textblock": [
-                            "A negative rapid test result is valid for 48 hours after submission and can be used as evidence, if required by law. When you tap on your negative test result on the main screen of the app, you will see a counter that shows you how long your test result has already been available. After 48 hours, your rapid test result will automatically be removed. You can then take another rapid test and register it in the app.",
-                            "There is no limited validity for positive rapid test results, so no counter will be displayed to you in this case. As soon as you receive a positive test result, immediately follow the instructions displayed in the app."
+                            "A negative rapid test result is valid for 48 hours after submission and can be used as evidence, if required by law. When you tap on your negative test result on the main screen of the app, under Android, you will see a counter that shows how long your test result has already been available. Under iOS, the date and time when the test result was issued is shown. After 48 hours, your rapid test result will automatically be removed. You can then take another rapid test and register it in the app.",
+                            "There is no limited validity for positive rapid test results, so no counter or the date of issue will be displayed to you in this case. As soon as you receive a positive test result, immediately follow the instructions displayed in the app."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -150,12 +150,12 @@
                         ]
                     },
                     {
-                        "title": "Wie lange ist ein Schnelltest gültig? Was bedeutet der Countdown?",
+                        "title": "Wie lange ist ein Schnelltest gültig?",
                         "anchor": "rat_how_long_valid",
                         "active": true,
                         "textblock": [
-                            "Ein negatives Schnelltest-Ergebnis ist nach der Übermittlung für 48 Stunden gültig und kann - sofern gesetzlich festgelegt - als Nachweis verwendet werden. Wenn Sie auf dem Hauptbildschirm der App auf Ihr negatives Testergebnis tippen, sehen Sie einen Zähler, welcher Ihnen zeigt, wie lange Ihr Testergebnis bereits zur Verfügung steht. Nach 48 Stunden wird Ihr Schnelltest-Ergebnis automatisch entfernt. Anschließend können Sie einen weiteren Schnelltest machen und in der App registrieren.",
-                            "Für positive Schnelltest-Ergebnisse gibt es keine begrenzte Gültigkeit, deshalb wird Ihnen in diesem Fall kein Zähler angezeigt. Sobald Sie ein positives Testergebnis erhalten, befolgen Sie bitte umgehend die Anweisungen, die Ihnen in der App angezeigt werden. "
+                            "Ein negatives Schnelltest-Ergebnis ist nach der Übermittlung für 48 Stunden gültig und kann - sofern gesetzlich festgelegt - als Nachweis verwendet werden. Wenn Sie auf dem Hauptbildschirm der App auf Ihr negatives Testergebnis tippen, sehen Sie unter Android einen Zähler, welcher Ihnen zeigt, wie lange Ihr Testergebnis bereits zur Verfügung steht. Unter iOS sehen Sie das Datum und die Uhrzeit zu der das Testergebnis ausgestellt wurde. Nach 48 Stunden wird Ihr Schnelltest-Ergebnis automatisch entfernt. Anschließend können Sie einen weiteren Schnelltest machen und in der App registrieren.",
+                            "Für positive Schnelltest-Ergebnisse gibt es keine begrenzte Gültigkeit, deshalb wird Ihnen in diesem Fall kein Zähler bzw. der Austellungszeitpunkt angezeigt. Sobald Sie ein positives Testergebnis erhalten, befolgen Sie bitte umgehend die Anweisungen, die Ihnen in der App angezeigt werden. "
                         ]
                     },
                     {


### PR DESCRIPTION
This PR explains that the implementation is different under iOS in `#rat_how_long_valid`.

<details>
<summary>Preview of the changes</summary>

| English | German |
|---|---|
|<img width="1033" alt="Bildschirmfoto 2021-06-05 um 23 23 22" src="https://user-images.githubusercontent.com/67682506/120905858-4cec3380-c655-11eb-9afd-abf1ab267d42.png">|<img width="1033" alt="Bildschirmfoto 2021-06-05 um 23 22 45" src="https://user-images.githubusercontent.com/67682506/120905856-4b227000-c655-11eb-8867-20c74c232049.png">|

</details>

---

**Closes #1330**