### PR TITLE
Replace "on" with "," (Fixes #1201)

### DIFF
--- a/src/services/blog-processor.js
+++ b/src/services/blog-processor.js
@@ -50,7 +50,7 @@ const generateBlogEntry = (blog, content, lang, showButton = false) => {
 
   <div class="blog-entry">
     ${headline}
-    <div class="sub-title"><span class="text">${getAuthors(blog.author)} on ${blog.dateFormatted}</span></div>
+    <div class="sub-title"><span class="text">${getAuthors(blog.author)}, ${blog.dateFormatted}</span></div>
     ${content}
     ${button}
   </div>


### PR DESCRIPTION
This PR fixes what has been described in #1201.

I tried to do it like this: `{{#if lang_de}}am{{else}}on{{/if}}` but this only worked on a individual blog post but not on https://www.coronawarn.app/en/blog/ for some reason, so the simplest solution I saw was to replace "on" with a ",", which works in both languages.