### PR TITLE
Add gulp option to skip image compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ npm start
 
 It will automatically use `public` as base directory and watch for file changes. Go to `localhost:8000` to view the website.
 
+If you want to build the website without optimizations, you can do so by running
+
+```bash
+npm run start-fast
+```
+
+This will disable image compression in exchange for faster build times.
+
 ### Changing Things
 
 Manuals for the most common use cases of updating website content are available in the [docs folder](./docs/).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,9 @@ const $ = plugins();
 // Check for --develop or --dev flag
 const PRODUCTION = !(yargs.argv.develop || yargs.argv.dev);
 
+// Check for --skip-compression flag
+const SKIP_COMPRESSION = yargs.argv.skipCompression;
+
 // Load config from config.yml
 const { COMPATIBILITY, PORT, UNCSS_OPTIONS, PATHS } = loadConfig();
 
@@ -204,7 +207,9 @@ function images_minify() {
 function images_webp() {
   return gulp
     .src('src/assets/img/**/*')
-    .pipe(webp())
+    .pipe(
+        $.if(!SKIP_COMPRESSION, webp())
+    )
     .pipe(gulp.dest(PATHS.dist + '/assets/img'));
 }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Corona Warn App website coronawarn.app",
   "main": "gulpfile.js",
   "scripts": {
+    "start-fast": "gulp --skip-compression",
     "start": "gulp",
     "build": "gulp build --production",
     "cypress:open": "cypress open",


### PR DESCRIPTION
This adds a new option `--skip-compression` to the gulpfile which results in a skip over the webp compression for images on the website. It can also be used via npm:

```
npm run start-fast
```

Useful if you want to just look at the website (or specifically the FAQ) without having to wait for the compression to finish.