### PR TITLE
Fix showing vaccination certificate section as active although it isn't

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -118,7 +118,6 @@
             },
             {
                 "title": "Vaccination Cert.",
-                "id": "vac_cert",
                 "active": true,
                 "accordion": [
                     {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -118,7 +118,7 @@
             },
             {
                 "title": "Vaccination Cert.",
-                "active": true,
+                "id": "vac_cert",
                 "accordion": [
                     {
                         "title": "Questions and answers about the vaccination certificate",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -120,7 +120,6 @@
             {
                 "title": "Impfzertifikat",
                 "id": "vac_cert",
-                "active": true,
                 "accordion": [
                     {
                         "title": "Fragen und Antworten zum Impfzertifikat",


### PR DESCRIPTION
This PR fixes the vaccination certificate section from showing as active section when you open the FAQ page. 