### PR TITLE
Add FAQ entry reg. „VC_PREFIX_INVALID“ error

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -138,7 +138,7 @@
                             "There are currently (as of 9 June 2021) no vaccination certificates with QR codes that can be scanned with the app.",
                             "Despite the QR code, any document issued in the past and currently is not a valid digital vaccination certificate, but a vaccination proof that follows the German infection protection act, but not the new coordinated European guidelines for a digital vaccination certificate.",
                             "These new digital vaccination certificates will be issued soon. Such digital certificates can only be issued by authorized bodies via the central interface developed by other partners on behalf of the federal government. The field test is now completed, and the function is now rolled out nationwide.", 
-                            "It has not yet been conclusively clarified who exactly, in addition to the vaccination centres, will be able to issue a vaccination certificate on the basis of proof of vaccination, i.e. the yellow vaccination booklet or the above-mentioned vaccination proof. The network will be gradually expanded."
+                            "It has not yet been conclusively clarified who exactly, in addition to the vaccination centers, will be able to issue a vaccination certificate on the basis of proof of vaccination, i.e. the yellow vaccination booklet or the above-mentioned vaccination proof. The network will be gradually expanded."
                         ]
                     },
                     {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -131,6 +131,17 @@
                         ]
                     },
                     {
+                        "title": "Why do I get the error message 'This QR code is not a valid vaccination certificate. (VC_PREFIX_INVALID)' when I try to scan my vaccination QR code?",
+                        "anchor": "vac_cert_invalid",
+                        "active": true,
+                        "textblock": [
+                            "There are currently (as of 9 June 2021) no vaccination certificates with QR codes that can be scanned with the app.",
+                            "Despite the QR code, the document issued in the past and currently is not a valid digital vaccination certificate, but a vaccination proof that follows the German infection protection act, but not the new coordinated European guidelines for a digital vaccination certificate.",
+                            "These new digital vaccination certificates will be issued soon. Such digital certificates can only be issued by authorized bodies via the central interface developed by other partners on behalf of the federal government. The field test is now completed, and the function is now rolled out nationwide.", 
+                            "It has not yet been conclusively clarified who exactly, in addition to the vaccination centres, will be able to issue a vaccination certificate on the basis of proof of vaccination, i.e. the yellow vaccination booklet or the above-mentioned vaccination proof. The network will be gradually expanded."
+                        ]
+                    },
+                    {
                         "title": "What is the digital certificate of vaccination?",
                         "anchor": "vac_cert_what",
                         "active": true,

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -137,7 +137,7 @@
                         "textblock": [
                             "There are currently (as of 9 June 2021) no vaccination certificates with QR codes that can be scanned with the app.",
                             "Despite the QR code, any document issued in the past and currently is not a valid digital vaccination certificate, but a vaccination proof that follows the German infection protection act, but not the new coordinated European guidelines for a digital vaccination certificate.",
-                            "These new digital vaccination certificates will be issued soon. Such digital certificates can only be issued by authorized bodies via the central interface developed by other partners on behalf of the federal government. The field test is now completed, and the function is now rolled out nationwide.", 
+                            "These new digital vaccination certificates will be issued soon. Such digital certificates can only be issued by authorized bodies via the central interface developed by other partners on behalf of the federal government. The field test is now completed, and the function is now being rolled out nationwide.", 
                             "It has not yet been conclusively clarified who exactly, in addition to the vaccination centers, will be able to issue a vaccination certificate on the basis of proof of vaccination, i.e. the yellow vaccination booklet or the above-mentioned vaccination proof. The network will be gradually expanded."
                         ]
                     },

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -136,7 +136,7 @@
                         "active": true,
                         "textblock": [
                             "There are currently (as of 9 June 2021) no vaccination certificates with QR codes that can be scanned with the app.",
-                            "Despite the QR code, the document issued in the past and currently is not a valid digital vaccination certificate, but a vaccination proof that follows the German infection protection act, but not the new coordinated European guidelines for a digital vaccination certificate.",
+                            "Despite the QR code, any document issued in the past and currently is not a valid digital vaccination certificate, but a vaccination proof that follows the German infection protection act, but not the new coordinated European guidelines for a digital vaccination certificate.",
                             "These new digital vaccination certificates will be issued soon. Such digital certificates can only be issued by authorized bodies via the central interface developed by other partners on behalf of the federal government. The field test is now completed, and the function is now rolled out nationwide.", 
                             "It has not yet been conclusively clarified who exactly, in addition to the vaccination centres, will be able to issue a vaccination certificate on the basis of proof of vaccination, i.e. the yellow vaccination booklet or the above-mentioned vaccination proof. The network will be gradually expanded."
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -133,13 +133,13 @@
                     },
                     {
                         "title": "Warum bekomme ich die Fehlermeldung 'Dieser QR-Code ist kein gültiges Impfzertifikat (VC_PREFIX_INVALID)', wenn ich versuche meinen Impf-QR-Code zu scannen?",
-                        "anchor": "vac_cert_index",
+                        "anchor": "vac_cert_invalid",
                         "active": true,
                         "textblock": [
                             "Es gibt derzeit (Stand: 9 Juni 2021) noch keine Impfzertifikate mit QR-Codes, die mit der App eingescannt werden können.",
                             "Das in der Vergangenheit und momentan ausgestellte Dokument ist trotz des QR-Codes kein gültiges digitales Impfzertifikat, sondern lediglich eine Impfbescheinigung, die dem deutschen Infektionsschutzgesetz folgt, nicht aber den aktuellen neuen abgestimmten europäischen Richtlinien für ein digitales Impfzertifikat.",
                             "Diese neuen digitalen Impfzertifikate werden demnächst ausgestellt. Solche digitalen Zertifikate können nur von autorisierten Stellen über die zentrale Schnittstelle bereitgestellt werden, die im Auftrag der Bunderegierung von anderen Partnern entwickelt wurde. Der Feldtest dafür wurde inzwischen beendet, und die Funktion wird nun flächendeckend ausgerollt.",
-                            "Es ist noch nicht abschließend geklärt, wer genau neben den Impfzentren auch in der Lage sein wird, ein Impfzertifikat auf Basis eines Impfnachweises, d.h. dem gelben Impfbuch bzw. der oben genannten Impfbescheinigung, auszustellen. Das Netz wird stufenweise weiter aufgebaut."
+                            "Es ist noch nicht abschließend geklärt, wer genau neben den Impfzentren auch in der Lage sein wird, ein Impfzertifikat auf Basis eines Impfnachweises, d.h. dem gelben Impfausweis bzw. der oben genannten Impfbescheinigung, auszustellen. Das Netz wird stufenweise weiter aufgebaut."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -137,7 +137,7 @@
                         "active": true,
                         "textblock": [
                             "Es gibt derzeit (Stand: 9 Juni 2021) noch keine Impfzertifikate mit QR-Codes, die mit der App eingescannt werden können.",
-                            "Das in der Vergangenheit und momentan ausgestellte Dokument ist trotz des QR-Codes kein gültiges digitales Impfzertifikat, sondern lediglich eine Impfbescheinigung, die dem deutschen Infektionsschutzgesetz folgt, nicht aber den aktuellen neuen abgestimmten europäischen Richtlinien für ein digitales Impfzertifikat.",
+                            "Ein in der Vergangenheit und momentan ausgestelltes Dokument ist trotz des QR-Codes kein gültiges digitales Impfzertifikat, sondern lediglich eine Impfbescheinigung, die dem deutschen Infektionsschutzgesetz folgt, nicht aber den aktuellen neuen abgestimmten europäischen Richtlinien für ein digitales Impfzertifikat.",
                             "Diese neuen digitalen Impfzertifikate werden demnächst ausgestellt. Solche digitalen Zertifikate können nur von autorisierten Stellen über die zentrale Schnittstelle bereitgestellt werden, die im Auftrag der Bunderegierung von anderen Partnern entwickelt wurde. Der Feldtest dafür wurde inzwischen beendet, und die Funktion wird nun flächendeckend ausgerollt.",
                             "Es ist noch nicht abschließend geklärt, wer genau neben den Impfzentren auch in der Lage sein wird, ein Impfzertifikat auf Basis eines Impfnachweises, d.h. dem gelben Impfausweis bzw. der oben genannten Impfbescheinigung, auszustellen. Das Netz wird stufenweise weiter aufgebaut."
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -132,6 +132,17 @@
                         ]
                     },
                     {
+                        "title": "Warum bekomme ich die Fehlermeldung 'Dieser QR-Code ist kein gültiges Impfzertifikat (VC_PREFIX_INVALID)', wenn ich versuche meinen Impf-QR-Code zu scannen?",
+                        "anchor": "vac_cert_index",
+                        "active": true,
+                        "textblock": [
+                            "Es gibt derzeit (Stand: 9 Juni 2021) noch keine Impfzertifikate mit QR-Codes, die mit der App eingescannt werden können.",
+                            "Das in der Vergangenheit und momentan ausgestellte Dokument ist trotz des QR-Codes kein gültiges digitales Impfzertifikat, sondern lediglich eine Impfbescheinigung, die dem deutschen Infektionsschutzgesetz folgt, nicht aber den aktuellen neuen abgestimmten europäischen Richtlinien für ein digitales Impfzertifikat.",
+                            "Diese neuen digitalen Impfzertifikate werden demnächst ausgestellt. Solche digitalen Zertifikate können nur von autorisierten Stellen über die zentrale Schnittstelle bereitgestellt werden, die im Auftrag der Bunderegierung von anderen Partnern entwickelt wurde. Der Feldtest dafür wurde inzwischen beendet, und die Funktion wird nun flächen-deckend ausgerollt.",
+                            "Es ist noch nicht abschließend geklärt, wer genau neben den Impfzentren auch in der Lage sein wird, ein Impfzertifikat auf Basis eines Impfnachweises, d.h. dem gelben Impfbuch bzw. der oben genannten Impfbescheinigung, auszustellen. Das Netz wird stufenweise weiter aufgebaut."
+                        ]
+                    },
+                    {
                         "title": "Was ist der digitale Impfnachweis?",
                         "anchor": "vac_cert_what",
                         "active": true,

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -138,7 +138,7 @@
                         "textblock": [
                             "Es gibt derzeit (Stand: 9 Juni 2021) noch keine Impfzertifikate mit QR-Codes, die mit der App eingescannt werden können.",
                             "Das in der Vergangenheit und momentan ausgestellte Dokument ist trotz des QR-Codes kein gültiges digitales Impfzertifikat, sondern lediglich eine Impfbescheinigung, die dem deutschen Infektionsschutzgesetz folgt, nicht aber den aktuellen neuen abgestimmten europäischen Richtlinien für ein digitales Impfzertifikat.",
-                            "Diese neuen digitalen Impfzertifikate werden demnächst ausgestellt. Solche digitalen Zertifikate können nur von autorisierten Stellen über die zentrale Schnittstelle bereitgestellt werden, die im Auftrag der Bunderegierung von anderen Partnern entwickelt wurde. Der Feldtest dafür wurde inzwischen beendet, und die Funktion wird nun flächen-deckend ausgerollt.",
+                            "Diese neuen digitalen Impfzertifikate werden demnächst ausgestellt. Solche digitalen Zertifikate können nur von autorisierten Stellen über die zentrale Schnittstelle bereitgestellt werden, die im Auftrag der Bunderegierung von anderen Partnern entwickelt wurde. Der Feldtest dafür wurde inzwischen beendet, und die Funktion wird nun flächendeckend ausgerollt.",
                             "Es ist noch nicht abschließend geklärt, wer genau neben den Impfzentren auch in der Lage sein wird, ein Impfzertifikat auf Basis eines Impfnachweises, d.h. dem gelben Impfbuch bzw. der oben genannten Impfbescheinigung, auszustellen. Das Netz wird stufenweise weiter aufgebaut."
                         ]
                     },


### PR DESCRIPTION
Fixes https://github.com/corona-warn-app/cwa-website/issues/1343

Warum bekomme ich die Fehlermeldung „Dieser QR-Code ist kein gültiges Impfzertifikat (VC_PREFIX_INVALID)“, wenn ich versuche meinen Impf-QR-Code zu scannen?
---

 
Es gibt derzeit (Stand: 9 Juni 2021) noch keine Impfzertifikate mit QR-Codes, die mit der App eingescannt werden können.
 
Das in der Vergangenheit und momentan ausgestellte Dokument ist trotz des QR-Codes kein gültiges digitales Impfzertifikat, sondern lediglich eine Impfbescheinigung, die dem deutschen Infektionsschutzgesetz folgt, nicht aber den aktuellen neuen abgestimmten europäischen Richtlinien für ein digitales Impfzertifikat.
 
Diese neuen digitalen Impfzertifikate werden demnächst ausgestellt. Solche digitalen Zertifikate können nur von autorisierten Stellen über die zentrale Schnittstelle bereitgestellt werden, die im Auftrag der Bunderegierung von anderen Partnern entwickelt wurde. Der Feldtest dafür wurde inzwischen beendet, und die Funktion wird nun flächen-deckend ausgerollt.
 
Es ist noch nicht abschließend geklärt, wer genau neben den Impfzentren auch in der Lage sein wird, ein Impfzertifikat auf Basis eines Impfnachweises, d.h. dem gelben Impfbuch bzw. der oben genannten Impfbescheinigung, auszustellen. Das Netz wird stufenweise weiter aufgebaut.
 

<img width="588" alt="image" src="https://user-images.githubusercontent.com/1409741/121398958-39dbab00-c956-11eb-8f80-f4f35987ee37.png">

<img width="598" alt="image" src="https://user-images.githubusercontent.com/1409741/121398988-43651300-c956-11eb-978e-60440b2ab896.png">


