### PR TITLE
Bump iOS app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -331,7 +331,7 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.6'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.3.2'))
+    .pipe(replace('[ios.current-app-version]', '2.3.3'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '2.3.2'))


### PR DESCRIPTION
This PR bumps the current iOS app version from 2.3.2 to 2.3.3.￼￼

Release: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v2.3.3