### PR TITLE
Bump current app versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -354,10 +354,10 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.6'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.4'))
+    .pipe(replace('[ios.current-app-version]', '2.4.1'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.4'))
+    .pipe(replace('[android.current-app-version]', '2.4.1'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -357,7 +357,7 @@ function replaceVersionNumbers() {
     .pipe(replace('[ios.current-app-version]', '2.4.1'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.4.1'))
+    .pipe(replace('[android.current-app-version]', '2.4.2'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
This PR bumps the current app versions from 2.4 to 2.4.1.

iOS release: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v2.4.1
Android release: https://github.com/corona-warn-app/cwa-app-android/releases/tag/v2.4.1 