### PR TITLE
Remove nbsp from FAQ title

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -407,7 +407,7 @@
                         ]
                     },
                     {
-                        "title": "Wenn ich eine hohe Risikobegegnung in der App angezeigt bekomme, d.&nbsp;h. eine rote Karte/Kachel, sollte ich dann einen Schnelltest oder PCR-Test machen?",
+                        "title": "Wenn ich eine hohe Risikobegegnung in der App angezeigt bekomme, d. h. eine rote Karte/Kachel, sollte ich dann einen Schnelltest oder PCR-Test machen?",
                         "anchor": "rat_red_card_which_test",
                         "active": true,
                         "textblock": [
@@ -419,7 +419,7 @@
                         "anchor": "rat_same_in_cwa",
                         "active": true,
                         "textblock": [
-                            "Der Schnelltest wird von der Corona-Warn-App gleichberechtigt zum PCR-Test behandelt. Wenn Sie sich bei einem Partner der Corona-Warn-App testen lassen, erhalten Sie Ihr Testergebnis per Scnelltest-QR-Code, den sie mit der Corona-Warn-App scannen können. Ein negatives Testergebnis wird dann für 48 Stunden in der Corona-Warn-App angezeigt.",
+                            "Der Schnelltest wird von der Corona-Warn-App gleichberechtigt zum PCR-Test behandelt. Wenn Sie sich bei einem Partner der Corona-Warn-App testen lassen, erhalten Sie Ihr Testergebnis per Schnelltest-QR-Code, den sie mit der Corona-Warn-App scannen können. Ein negatives Testergebnis wird dann für 48 Stunden in der Corona-Warn-App angezeigt.",
                             "Im Falle eines positiven Testergebnisses, können Sie Ihre Mitmenschen innerhalb kürzester Zeit warnen, indem Sie Ihr Ergebnis – wie bei einem PCR-Test auch – teilen und so auf den Server der Corona-Warn-App hochladen. Das positive Testergebnis wird Ihnen so lange in der App angezeigt, bis Sie es teilen. Wenn Sie zuvor über die Event-Registrierung bei einem Event oder an einem Ort eingecheckt waren, können Sie das positive Testergebnis gemeinsam mit Ihrem Check-in teilen."
                         ]
                     },


### PR DESCRIPTION
This PR corrects an issue from PR https://github.com/corona-warn-app/cwa-website/pull/1435 which added `&nbsp;` into German abbreviations.

I noticed that this doesn't work in titles of the https://www.coronawarn.app/de/faq/ sourced from [faq_de.json](https://github.com/corona-warn-app/cwa-website/blob/master/src/data/faq_de.json). Unfortunately I missed one occurrence of this during testing. Sorry about that!

If anybody happens to know how to add a `&nbsp;` into a `"title":`  I would be happy to know. I guess this is being processed by `gulp`.

---
I also corrected an unrelated typo in https://www.coronawarn.app/de/faq/#rat_same_in_cwa, changing
"Scnelltest-QR-Code" to "Schnelltest-QR-Code".

