### PR TITLE
Make hc_prefix_invalid bookmarks work

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -126,8 +126,8 @@
                 "id": "eu_dcc",
                 "accordion": [
                     {
-                        "title": "Why do I get the error message 'This QR code is not a valid  certificate. (HC_PREFIX_INVALID)' when I try to scan my vaccination QR code?",
-                        "anchor": "hc_prefix_invalid ",
+                        "title": "Why do I get the error message 'This QR code is not a valid  certificate. (HC_PREFIX_INVALID)' when I try to scan my QR code?",
+                        "anchor": "hc_prefix_invalid",
                         "active": true,
                         "textblock": [
                             "Under the tab 'Certificates' the app can only  scan '<b>EU Digital </b>COVID  Certificates'.",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -128,7 +128,7 @@
                 "accordion": [
                     {
                         "title": "Warum bekomme ich die Fehlermeldung 'Dieser QR-Code ist kein gültiges Zertifikat (HC_PREFIX_INVALID)', wenn ich versuche meinen QR-Code zu scannen?",
-                        "anchor": "hc_prefix_invalid ",
+                        "anchor": "hc_prefix_invalid",
                         "active": true,
                         "textblock": [
                             "Unter dem Reiter Zertifikate kann die App kann nur '<b>EU Digitale</b> COVID-Zertifikate' scannen.",


### PR DESCRIPTION
This PR fixes two issues in
https://www.coronawarn.app/en/faq/#hc_prefix_invalid and
https://www.coronawarn.app/de/faq/#hc_prefix_invalid
(see https://github.com/corona-warn-app/cwa-website/issues/1462#issuecomment-878303906).

1) In the text of https://www.coronawarn.app/en/faq/#hc_prefix_invalid it says:
"Why do I get the error message 'This QR code is not a valid certificate. (HC_PREFIX_INVALID)' when I try to scan my vaccination QR code?"

The word "vaccination" is removed, since the error can refer to vaccination, test or recovery certificates.

2) The URL https://www.coronawarn.app/en/faq/#hc_prefix_invalid does not work correctly, although it does manage to show the article by falling back to search.
The URL https://www.coronawarn.app/de/faq/#hc_prefix_invalid does not work correctly. Instead it shows the Glossar. Due to the search fallback, if the user scrolls down from the Glossar the article can be viewed. 

The trailing space in the anchor is removed for both en and de sources.

`"anchor": "hc_prefix_invalid ",` is changed to
`"anchor": "hc_prefix_invalid",`

which allows the article to be directly displayed via bookmark selection instead of the imprecise way through search. 