### PR TITLE
Fix double "kann" in FAQ entry `#hc_prefix_invalid`

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -131,7 +131,7 @@
                         "anchor": "hc_prefix_invalid",
                         "active": true,
                         "textblock": [
-                            "Unter dem Reiter Zertifikate kann die App kann nur '<b>EU Digitale</b> COVID-Zertifikate' scannen.",
+                            "Unter dem Reiter Zertifikate kann die App nur '<b>EU Digitale</b> COVID-Zertifikate' scannen.",
                             "Siehe auch folgenden Eintrag zu <a href='#vac_cert_invalid' target='_self' rel='noopener'>ungültigen Impfzertifikaten</a>."
                          ]
                     }


### PR DESCRIPTION
This PR fixes a gramma issue in the FAQ entry `#hc_prefix_invalid`.