### PR TITLE
FAQ: vac_cert_invalid not necessarily my certificate

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -216,7 +216,7 @@
                         ]
                     },
                     {
-                        "title": "Why do I get the error message 'This QR code is not a valid vaccination certificate. (VC_PREFIX_INVALID)' when I try to scan my vaccination QR code?",
+                        "title": "Why do I get the error message 'This QR code is not a valid vaccination certificate. (VC_PREFIX_INVALID)' when I try to scan a vaccination QR code?",
                         "anchor": "vac_cert_invalid",
                         "active": true,
                         "textblock": [

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -217,7 +217,7 @@
                         ]
                     },
                     {
-                        "title": "Warum bekomme ich die Fehlermeldung 'Dieser QR-Code ist kein gültiges Impfzertifikat (VC_PREFIX_INVALID)', wenn ich versuche meinen Impf-QR-Code zu scannen?",
+                        "title": "Warum bekomme ich die Fehlermeldung 'Dieser QR-Code ist kein gültiges Impfzertifikat (VC_PREFIX_INVALID)', wenn ich versuche einen Impf-QR-Code zu scannen?",
                         "anchor": "vac_cert_invalid",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
This PR reflects the change in CWA 2.5 that certificates for different people can be stored, therefore it can no longer be assumed that a scan failure is for "my certificate". Instead it is now referred to a "a certificate".

The title of 
https://www.coronawarn.app/en/faq/#vac_cert_invalid
is now
"Why do I get the error message 'This QR code is not a valid vaccination certificate. (VC_PREFIX_INVALID)' when I try to scan a vaccination QR code?"

and for
https://www.coronawarn.app/de/faq/#vac_cert_invalid
the title is now
"Warum bekomme ich die Fehlermeldung 'Dieser QR-Code ist kein gültiges Impfzertifikat (VC_PREFIX_INVALID)', wenn ich versuche einen Impf-QR-Code zu scannen?"

The PR is one of several to follow which will address issue https://github.com/corona-warn-app/cwa-website/issues/1409.
