### PR TITLE
FAQ: Update vac_cert_what for multiple certificates

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -233,7 +233,7 @@
                         "anchor": "vac_cert_what",
                         "active": true,
                         "textblock": [
-                            "Starting with version 2.3 of the Corona-Warn-App (CWA), you can add your digital vaccination certificate to the CWA and thus securely and digitally prove your Corona vaccination status via QR code. The CWA indicates the complete vaccination protection 14 days after the last required vaccination. The digital vaccination certificate is an additional way to document vaccinations. Thereby you are able to digitally store information such as vaccination time and vaccine in a personalized manner on your smartphones. The use of digital certificate of vaccination in the CWA is voluntary. You can also prove your Corona vaccination in a different way."
+                            "Starting with version 2.3 of the Corona-Warn-App (CWA), you can add your digital vaccination certificate to the CWA and thus securely and digitally prove your Corona vaccination status via QR code. Beginning with version 2.5, certificates for more than one person can be stored in the app. The CWA indicates the complete vaccination protection 14 days after the last required vaccination. The digital vaccination certificate is an additional way to document vaccinations. Thereby you are able to digitally store information such as vaccination time and vaccine in a personalized manner on your smartphones. The use of a digital certificate of vaccination in the CWA is voluntary. You can also provide proof of Corona vaccination status in a different way."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -234,7 +234,7 @@
                         "anchor": "vac_cert_what",
                         "active": true,
                         "textblock": [
-                            "Ab Version 2.3 der Corona-Warn-App (CWA) können Sie Ihren digitalen Impfnachweis in der CWA hinzufügen und so per QR-Code Ihren Corona-Impfstatus bei Bedarf sicher und digital nachweisen. Die CWA zeigt den vollständigen Impfschutz 14 Tage nach der letzten benötigten Impfung an. Der digitale Impfnachweis ist eine zusätzliche Möglichkeit, um Impfungen zu dokumentieren. Sie können damit Informationen wie Impfzeitpunkt und Impfstoff personalisiert bequem auf Ihren Smartphones digital speichern. Die Nutzung des digitalen Impfnachweises in der CWA ist freiwillig. Sie können Ihre Corona-Impfung auch auf eine andere Weise nachweisen."
+                            "Ab Version 2.3 der Corona-Warn-App (CWA) können Sie Ihren digitalen Impfnachweis in der CWA hinzufügen und so per QR-Code Ihren Corona-Impfstatus bei Bedarf sicher und digital nachweisen. Ab Version 2.5 der App können digitale Impfnachweise für mehrere Personen in der App gespeichert werden. Die CWA zeigt den vollständigen Impfschutz 14 Tage nach der letzten benötigten Impfung an. Der digitale Impfnachweis ist eine zusätzliche Möglichkeit, um Impfungen zu dokumentieren. Sie können damit Informationen wie Impfzeitpunkt und Impfstoff personalisiert bequem auf Ihren Smartphones digital speichern. Die Nutzung des digitalen Impfnachweises in der CWA ist freiwillig. Sie können eine Corona-Impfung auch auf eine andere Weise nachweisen."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR updates
https://www.coronawarn.app/en/faq/#vac_cert_what and
https://www.coronawarn.app/de/faq/#vac_cert_what

to cover the enhancement in CWA 2.5 that digital certificates for multiple people can be stored in the app. The wording of the article is changed accordingly.

It is one of the PRs to resolve issue https://github.com/corona-warn-app/cwa-website/issues/1409.