### PR TITLE
FAQ: Correct typos in vac_cert (en)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -220,7 +220,7 @@
                         "anchor": "vac_cert_invalid",
                         "active": true,
                         "textblock": [
-                            "The app can only successfully scan 'EU Digital COVIID Vaccination Certificates' and these are being issued by vaccination centers since 14 June 2021.",
+                            "The app can only successfully scan 'EU Digital COVID Vaccination Certificates' and these are being issued by vaccination centers since 14 June 2021.",
                             "Usually, any document issued before 14 June 2021 will not be a valid digital <b>EU</b> vaccination certificate, but just a vaccination documentation according to §22 of the German Infection Protection Act, that is incompatible with the latest aligned European guidelines for a digital vaccination certificate. Therefore, such a document, as well as the barcodes and QR codes in the yellow vaccination booklet, <b>cannot</b> be scanned with the Corona-Warn-App.",
                             "The new digital certificate statements (that can be scanned) are in the process of being made available by authorized agencies. In some federal states, vaccination centers will automatically send these new digital certificates via mail or they may make them available online. Starting on 14 June 2021, those who have already been vaccinated can have the digital vaccination certificate issued in pharmacies on the basis of a vaccination record (yellow vaccination booklet or vaccination proof), if they do not receive a digital certificate via mail or online. <a href='https://www.mein-apothekenmanager.de/' target='_blank' rel='noopener noreferrer'>Pharmacies search</a>.",
                             "In this news article you will find information about the <b>individual federal states:</b><br><a href='https://www.focus.de/gesundheit/coronavirus/covpass-digitaler-corona-impfpass-fuers-handy-startet-das-ist-der-stand-in-ihrem-bundesland_id_13385519.html' target='_blank' rel='noopener noreferrer'>Digitaler Corona-Impfpass startet - das ist der Stand in Ihrem Bundesland</a>.",
@@ -245,7 +245,7 @@
                         ]
                     },
                     {
-                        "title": "Who can obtain an digital proof of vaccination? How do I get a vaccination certificate? If I already have full vaccination protection, how can I transfer the status to the Corona-Warn-App afterwards?",
+                        "title": "Who can obtain a digital proof of vaccination? How do I get a vaccination certificate? If I already have full vaccination protection, how can I transfer the status to the Corona-Warn-App afterwards?",
                         "anchor": "vac_cert_who",
                         "active": true,
                         "textblock": [
@@ -268,7 +268,7 @@
                         "anchor": "vac_cert_how",
                         "active": true,
                         "textblock": [
-                            "The digital proof of vaccination is generated in the doctor's pratice or in a vaccination center. After entering or transferring the data, a vaccination certificate token (QR code) will be created for you, which you can scan directly with the Corona-Warn-App (CWA) or can be handed to you on a paper printout and later scanned with the CWA.  You can then manage your digital vaccination certificates on your smartphone."
+                            "The digital proof of vaccination is generated in the doctor's practice or in a vaccination center. After entering or transferring the data, a vaccination certificate token (QR code) will be created for you, which you can scan directly with the Corona-Warn-App (CWA) or can be handed to you on a paper printout and later scanned with the CWA.  You can then manage your digital vaccination certificates on your smartphone."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR corrects three typos in https://www.coronawarn.app/en/faq/#vac_cert.