### PR TITLE
FAQ: Make hc_prefix_invalid title impersonal

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -127,11 +127,11 @@
                 "id": "eu_dcc",
                 "accordion": [
                     {
-                        "title": "Why do I get the error message 'This QR code is not a valid  certificate. (HC_PREFIX_INVALID)' when I try to scan my QR code?",
+                        "title": "Why do I get the error message 'This QR code is not a valid  certificate. (HC_PREFIX_INVALID)' when I try to scan a QR code?",
                         "anchor": "hc_prefix_invalid",
                         "active": true,
                         "textblock": [
-                            "Under the tab 'Certificates' the app can only  scan '<b>EU Digital </b>COVID  Certificates'.",
+                            "Under the tab 'Certificates' the app can only scan '<b>EU Digital</b> COVID  Certificates'.",
                             "See also the following entry on <a href='#vac_cert_invalid' target='_self' rel='noopener'>invalid vaccination certificates</a>."
                         ]
                     }

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -128,7 +128,7 @@
                 "id": "eu_dcc",
                 "accordion": [
                     {
-                        "title": "Warum bekomme ich die Fehlermeldung 'Dieser QR-Code ist kein gültiges Zertifikat (HC_PREFIX_INVALID)', wenn ich versuche meinen QR-Code zu scannen?",
+                        "title": "Warum bekomme ich die Fehlermeldung 'Dieser QR-Code ist kein gültiges Zertifikat (HC_PREFIX_INVALID)', wenn ich versuche einen QR-Code zu scannen?",
                         "anchor": "hc_prefix_invalid",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
This PR changes the title of

https://www.coronawarn.app/en/faq/#hc_prefix_invalid and
https://www.coronawarn.app/de/faq/#hc_prefix_invalid

to refer to "a QR code" instead of "my QR code" / "einen QR-Code" instead of "meinen QR-Code", since the QR code can be from any person. The app is not restricted to only scanning QR codes from one person any more.

In the English text I also tidied up some whitespace placement.