### PR TITLE
Bump current iOS version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -352,7 +352,7 @@ function createFaqRedirects() {
 function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html"])
-    .pipe(replace('[ios.latest-os-version]', '14.6'))
+    .pipe(replace('[ios.latest-os-version]', '14.7'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.5.1'))
     .pipe(replace('[android.latest-os-version]', '11'))


### PR DESCRIPTION
This commit bumps the current iOS version form 14.6 to 14.7.

Apple Release: https://developer.apple.com/news/releases/?id=07192021c