### PR TITLE
Correct typos in #test_cert

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -158,11 +158,11 @@
                         "anchor": "test_cert_index",
                         "active": true,
                         "textblock": [
-                            "<ul><li><a href='#test_cert_why'>Wozu dient das digitales COVID-Testzertifikat?</a></li><li><a href='#test_cert_get'>Wie kann ich ein Testzertifikat anfordern?</a></li><li><a href='#test_cert_rat_and_pcr'>Kann ich Testzertifikate für Schnelltests und PCR-Test anfordern?</a></li><li><a href='#test_cert_when_and_where'>Wann erhalte ich mein Testzertifikat und wo finde ich es?</a></li><li><a href='#test_cert_validity'>Wie lange ist mein Testzertifikat gültig?</a></li><li><a href='#test_cert_privacy'>Wie wird meine Privatsphäre geschützt, wenn ich ein Testzertifikat erstelle?</a></li></ul>"
+                            "<ul><li><a href='#test_cert_why'>Wozu dient das digitale COVID-Testzertifikat?</a></li><li><a href='#test_cert_get'>Wie kann ich ein Testzertifikat anfordern?</a></li><li><a href='#test_cert_rat_and_pcr'>Kann ich Testzertifikate für Schnelltests und PCR-Test anfordern?</a></li><li><a href='#test_cert_when_and_where'>Wann erhalte ich mein Testzertifikat und wo finde ich es?</a></li><li><a href='#test_cert_validity'>Wie lange ist mein Testzertifikat gültig?</a></li><li><a href='#test_cert_privacy'>Wie wird meine Privatsphäre geschützt, wenn ich ein Testzertifikat erstelle?</a></li></ul>"
                          ]
                     },
                     {
-                        "title": "Wozu dient das digitales COVID-Testzertifikat?",
+                        "title": "Wozu dient das digitale COVID-Testzertifikat?",
                         "anchor": "test_cert_why",
                         "active": true,
                         "textblock": [
@@ -178,7 +178,7 @@
                         ]
                     },
                     {
-                        "title": "Kann ich Testzertifikate für Schnelltests und PCR-Test anfordern?",
+                        "title": "Kann ich Testzertifikate für Schnelltests und PCR-Tests anfordern?",
                         "anchor": "test_cert_rat_and_pcr",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
This PR corrects two typos in titles in the section
https://www.coronawarn.app/de/faq/#test_cert "Testzertifikat".

In https://www.coronawarn.app/de/faq/#test_cert_why
"Wozu dient das digitales COVID-Testzertifikat?" is corrected to read
"Wozu dient das digitale COVID-Testzertifikat?".

In https://www.coronawarn.app/de/faq/#test_cert_rat_and_pcr
"Kann ich Testzertifikate für Schnelltests und PCR-Test anfordern?" is corrected to read
"Kann ich Testzertifikate für Schnelltests und PCR-Tests anfordern?".


