### PR TITLE
TAN hotline only for PCR tests

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -41,7 +41,7 @@
                             "<b>National:</b> 0800 7540001",
                             "<b>International:</b> +49 30 498 75401",
                             "<b>TAN Hotline</b>",
-                            "The TAN hotline will help you to enter the TAN if you have a positive test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available 24 hours a day, seven days a week.",
+                            "The TAN hotline will help you to enter the TAN if you have a positive PCR test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available 24 hours a day, seven days a week.",
                             "<b>National:</b> 0800 7540002",
                             "<b>International:</b> +49 30 498 75402"
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -42,7 +42,7 @@
                             "<b>National:</b> 0800 7540001",
                             "<b>International:</b> +49 30 498 75401",
                             "<b>TAN-Hotline</b>",
-                            "Die TAN-Hotline hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Die TAN-Hotline ist 24 Stunden täglich an sieben Tagen in der Woche erreichbar.",
+                            "Die TAN-Hotline hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives PCR-Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Die TAN-Hotline ist 24 Stunden täglich an sieben Tagen in der Woche erreichbar.",
                             "<b>National:</b> 0800 7540002",
                             "<b>International:</b> +49 30 498 75402"
                         ]


### PR DESCRIPTION
This PR follows on from the issue https://github.com/corona-warn-app/cwa-website/issues/1238 suggesting that FAQ articles need to be reviewed so that they clearly differentiate between PCR tests and Rapid Antigen Tests (RAT). Many articles were written before  RATs were introduced.

For the FAQ articles 
https://www.coronawarn.app/en/faq/#international_phone_numbers "How to reach us" and
https://www.coronawarn.app/de/faq/#international_phone_numbers "So erreichen Sie uns"

the qualifier "PCR" is added to the term test result / Testergebnis.

Only positive results from PCR tests (not from Rapid Antigen Tests) qualify for a TAN.

The app is clear about this and shows the following text:

![image](https://user-images.githubusercontent.com/66998419/127646181-60331349-475d-4529-af76-f7cd58d4dc2c.png)
