### PR TITLE
Correct list of Business Rules countries (fixes #1560)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -169,7 +169,7 @@
                         "active": true,
                         "textblock": [
                             "Starting with version 2.6, you can check before travelling whether your certificates (test, recovery and/or vaccination certificate) are valid in a selected country at the time of your trip. The Corona-Warn-App takes into account the applicable entry rules of the selected travel country and compares them with various parameters of the certificate, such as the date and type of test, test center or date of vaccination.",
-                            "Every European country that supports EU digital COVID certificates has the ability to upload rules that the Corona-Warn-App can match for verification. At the start of this new feature, Germany, Spain, the Netherlands, Austria, Luxembourg, and Lithuania have uploaded rules, with more countries to follow in the coming weeks.",
+                            "Every European country that supports EU digital COVID certificates has the ability to upload rules that the Corona-Warn-App can match for verification. At the start of this new feature, Ireland, Lithuania, Luxembourg, the Netherlands, Slovenia and Spain, together with Germany, have uploaded rules, with more countries to follow in the coming weeks.",
                             "If the app shows after checking that there are no entry rules available, you can find out about the rules at <a href='https://reopen.europa.eu/en' target='_blank' rel='noopener noreferrer'>https://reopen.europa.eu/en</a>."
                         ]
                     }

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -170,7 +170,7 @@
                         "active": true,
                         "textblock": [
                             "Sie können ab der Version 2.6 vor einer Reise prüfen, ob Ihre Zertifikate (Test-, Genesenen-, und/oder Impfzertifikat) in einem ausgewählten Land zum Zeitpunkt Ihrer Reise gültig sind. Die Corona-Warn-App berücksichtigt dafür die geltenden Einreiseregeln des ausgewählten Reiselandes und gleicht sie mit verschiedenen Parametern des Zertifikats, wie Datum und Art des Tests, Testzentrum oder Datum einer Impfung, ab.",
-                            "Jedes europäische Land, das digitale COVID-Zertifikate der EU unterstützt, hat die Möglichkeit Regeln hochzuladen, die die Corona-Warn-App zur Überprüfung abgleichen kann. Zum Start der neuen Funktion haben Deutschland, Spanien, die Niederlande, Österreich, Luxemburg und Litauen Regeln hinterlegt, weitere Länder folgen in den kommenden Wochen.",
+                            "Jedes europäische Land, das digitale COVID-Zertifikate der EU unterstützt, hat die Möglichkeit Regeln hochzuladen, die die Corona-Warn-App zur Überprüfung abgleichen kann. Zum Start der neuen Funktion haben Irland, Litauen, Luxemburg, die Niederlande, Slowenien und Spanien, zusammen mit Deutschland, Regeln hinterlegt, weitere Länder folgen in den kommenden Wochen.",
                             "Zeigt die App nach Prüfung an, dass keine Einreiseregeln vorhanden sind, können Sie sich unter <a href='https://reopen.europa.eu/de' target='_blank' rel='noopener noreferrer'>https://reopen.europa.eu/de</a> über die Regeln informieren."
                          ]
                     }


### PR DESCRIPTION
This PR resolves https://github.com/corona-warn-app/cwa-website/issues/1560 by aligning the list of countries providing Business Rules for EU Digital COVID Certificate validation with the blog entry.


https://www.coronawarn.app/en/faq/#cert_eu_travel and
https://www.coronawarn.app/de/faq/#cert_eu_travel
are changed to:

1. Remove Austria / Österreich from the list
2. Add Ireland / Irland to the list
3. Add Slovenia / Slowenien to the list
4. Separate Germany / Deutschland
5. List countries alphabetically

The FAQ entries now agree with the countries listed in 

https://www.coronawarn.app/en/blog/2021-07-28-cwa-version-2-6/ 
(Germany, Spain, the Netherlands, Ireland, Luxembourg, Slovenia and Lithuania)
and

https://www.coronawarn.app/de/blog/2021-07-28-cwa-version-2-6/
(Deutschland, Spanien, die Niederlande, Irland, Luxemburg, Slowenien und Litauen)