### PR TITLE
fix: check if screenshot-tabs exists before updating from hash

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -275,6 +275,10 @@ $(document).ready(function(){
             scrollTo(hash)
         }
     }
-    checkHashAndChangeTab()
+
+    // update the tab selection for an existing hash if the screenshot page is loaded
+    if (document.getElementById('screenshot-tabs')) {
+      checkHashAndChangeTab()
+    }
 
 });

--- a/src/partials/page-screenshots.html
+++ b/src/partials/page-screenshots.html
@@ -27,12 +27,12 @@
             </div>
             
             <nav>
-                <div class="nav nav-tabs" id="nav-tab" role="tablist">
+                <div class="nav nav-tabs" id="screenshot-tabs" role="tablist">
                     <a class="nav-item nav-link active" href="#android_screenshots">{{page-contents.android-screnshots.tab-title}}</a>
                     <a class="nav-item nav-link" href="#ios_screenshots">{{page-contents.ios-screnshots.tab-title}}</a>
                 </div>
             </nav>
-            <div class="tab-content" id="nav-tabContent">
+            <div class="tab-content" id="screenshot-tabs-content">
                 <div class="tab-pane fade show active" id="android_screenshots">
                     {{#each page-contents.android-screnshots.sections}}
                         <div class="row">


### PR DESCRIPTION
### Problem 
In the current version of the app (87571d529b21e7d578901abd143de2d1874f13e3) there is an error on the console:

![image](https://user-images.githubusercontent.com/600565/127908209-08ffdff5-8e48-4005-8c4b-e90a7cdb28e7.png)

This error is caused by the `checkHashAndChangeTab` function that expects the screenshot tabs to be present.

This results in a lower lighthouse score:

![image](https://user-images.githubusercontent.com/600565/127908352-0f464aea-dae1-4a5f-910b-0a352513723f.png)

### Solution

Check if the screenshot tabs exist on the page before executing the `checkHashAndChangeTab` function.