### PR TITLE
Fix index_de.md for statisticstiles (closes #1581)

### DIFF
--- a/blog/2021-08-05-explain-statistics-tiles/index_de.md
+++ b/blog/2021-08-05-explain-statistics-tiles/index_de.md
@@ -1,7 +1,7 @@
 ---
 page-title: "Erläuterung der Statistikkacheln in der Corona-Warn-App"
 page-description: "Erläuterung der Statistikkacheln in der Corona-Warn-App"
-page-name: statistikkacheln
+page-name: statistictiles
 page-name_de: statistikkacheln
 author: Open Source Team
 layout: blog


### PR DESCRIPTION
This PR corrects the issue reported in https://github.com/corona-warn-app/cwa-website/issues/1581 "Language switch for Blog - Statistic tiles - fails".

In https://github.com/corona-warn-app/cwa-website/blob/master/blog/2021-08-05-explain-statistics-tiles/index_de.md

`page-name: statistikkacheln`
is changed to
`page-name: statistictiles`
to be identical to the value of
`page-name:`
in https://github.com/corona-warn-app/cwa-website/blob/master/blog/2021-08-05-explain-statistics-tiles/index.md

## Steps to verify
1. Open https://www.coronawarn.app/en/blog/2021-08-05-statistictiles/
2. Click on "DE" in header
3. Check that page https://www.coronawarn.app/de/blog/2021-08-05-statistictiles/ is displayed without error 404
4. Click on "EN" in header
5. Check that page https://www.coronawarn.app/en/blog/2021-08-05-statistictiles/ is displayed without error 404


