### PR TITLE
`2021-08-05-statistictiles` blog: Remove line break too much (DE)

### DIFF
--- a/blog/2021-08-05-explain-statistics-tiles/index_de.md
+++ b/blog/2021-08-05-explain-statistics-tiles/index_de.md
@@ -88,9 +88,7 @@ Hier stellt die App das gleitende arithmetische Mittel (Durchschnitt) der Werte 
 
 Um tägliche leichte Schwankungen auszugleichen, zeigt der <i>**Trendindikator**</i> mit einem Pfeil, ob sich der 7-Tage-Mittelwert gegenüber dem <u>vor einer Woche</u> angezeigten Wert um 5% oder mehr verändert hat - jeweils nach oben oder nach unten, bei einer Veränderung kleiner als 5% waagerecht.
 
-Da allein aus der Veränderung der Anzahl der Warnungen nicht eindeutig eine positive oder negative
-
-Bewertung abgeleitet werden kann, wird der Pfeil immer grau gefärbt und zeigt nur die Richtung der Änderung an.
+Da allein aus der Veränderung der Anzahl der Warnungen nicht eindeutig eine positive oder negative Bewertung abgeleitet werden kann, wird der Pfeil immer grau gefärbt und zeigt nur die Richtung der Änderung an.
 
 **3. Gesamt**
 


### PR DESCRIPTION
This PR removes a line break from the blog post https://www.coronawarn.app/de/blog/2021-08-05-statistictiles/.