### PR TITLE
FAQ: red_card_how_to_test made explicit for PCR test

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -766,10 +766,10 @@
                         "anchor": "red_card_how_to_test",
                         "active": true,
                         "textblock": [
-                            "If the Corona-Warn-App indicates a high infection risk with the red card, please isolate yourself quickly and consult a doctor to get screened if necessary.",
+                            "If the Corona-Warn-App indicates a high infection risk with the red card, please isolate yourself quickly and consult a doctor to get a PCR test if necessary.",
                             "For a smooth testing process, to receive the test result and to warn others in case of a positive result, please follow the steps in <a href='../../assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ02_x3b-EN.pdf' target='_blank' rel='noopener'>this overview from the Robert Koch Institute</a>.",
                             "<a href='../../assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ02_x3b-EN.pdf' target='_blank' rel='noopener'><img src='../../assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ02_x3b-EN.jpg' alt='PDF'></a>",
-                            "See also: <a href='#where_can_i_get_tested' target='_blank' rel='noopener noreferrer'>Where to get tested?</a>"
+                            "See also: <ul><li><a href='#rat_red_card_which_test' target='_blank' rel='noopener'>If I see a high-risk encounter in the App, i.e. a red card, should I do a rapid antigen test or PCR-Test?</a></li><li><a href='#vac_cert_red_warning' target='_blank' rel='noopener'>How to behave if I am partially or completely vaccinated, but receive a red warning in the Corona-Warn-App?</a></li><li><a href='#where_can_i_get_tested' target='_blank' rel='noopener noreferrer'>Where to get tested?</a></li></ul>"
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -767,10 +767,10 @@
                         "anchor": "red_card_how_to_test",
                         "active": true,
                         "textblock": [
-                            "Wenn die Corona-Warn-App Ihnen mit der roten Karte ein hohes Infektionsrisiko anzeigt, isolieren Sie sich bitte zügig und konsultieren Sie einen Arzt, um sich ggf. testen zu lassen.",
+                            "Wenn die Corona-Warn-App Ihnen mit der roten Karte ein hohes Infektionsrisiko anzeigt, isolieren Sie sich bitte zügig und konsultieren Sie einen Arzt, um ggf. einen PCR-Test durchführen zu lassen.",
                             "Für einen reibungslosen Ablauf beim Testen, zum Empfang des Testbefundes und zu Warnung Anderer bei einem positiven Ergebnis folgen Sie bitte den Schritten in <a href='../../assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ04_x3b.pdf' target='_blank' rel='noopener'>dieser Übersicht vom Robert Koch-Institut</a>.",
                             "<a href='../../assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ04_x3b.pdf' target='_blank' rel='noopener'><img src='../../assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ04_x3b.jpg' alt='PDF'></a>",
-                            "Siehe auch: <a href='#where_can_i_get_tested' target='_blank' rel='noopener noreferrer'>Wo kann man sich testen lassen?</a>"
+                            "Siehe auch: <ul><li><a href='#rat_red_card_which_test' target='_blank' rel='noopener'>Wenn ich eine hohe Risikobegegnung in der App angezeigt bekomme, d.&nbsp;h. eine rote Karte/Kachel, sollte ich dann einen Schnelltest oder PCR-Test machen?</a></li><li><a href='#vac_cert_red_warning' target='_blank' rel='noopener'>Wie sollte man sich verhalten, wenn man teil- oder vollständig geimpft ist, aber eine rote Warnung in der Corona-Warn-App erhält?</a></li><li><a href='#where_can_i_get_tested' target='_blank' rel='noopener noreferrer'>Wo kann man sich testen lassen?</a></li></ul>"
                         ]
                     },
                     {


### PR DESCRIPTION
This PR supports the resolution of https://github.com/corona-warn-app/cwa-website/issues/1238 "FAQ: Differentiate between PCR Test and Rapid Antigen Test".

It modifies the FAQ articles:
- https://www.coronawarn.app/en/faq/#red_card_how_to_test "Red Card? How to go through Corona testing" and
- https://www.coronawarn.app/de/faq/#red_card_how_to_test "Rote Karte? So geht es zum Corona Test"

The type of test is explicitly named as PCR test.

---
In the "See also" section of the FAQ articles links are added to:

EN
[If I see a high-risk encounter in the App, i.e. a red card, should I do a rapid antigen test or PCR-Test?](http://localhost:8000/en/faq/#rat_red_card_which_test) and
[How to behave if I am partially or completely vaccinated, but receive a red warning in the Corona-Warn-App?](http://localhost:8000/en/faq/#vac_cert_red_warning)

DE
[Wenn ich eine hohe Risikobegegnung in der App angezeigt bekomme, d. h. eine rote Karte/Kachel, sollte ich dann einen Schnelltest oder PCR-Test machen?](http://localhost:8000/de/faq/#rat_red_card_which_test)
[Wie sollte man sich verhalten, wenn man teil- oder vollständig geimpft ist, aber eine rote Warnung in der Corona-Warn-App erhält?](http://localhost:8000/de/faq/#vac_cert_red_warning)

---
EN
https://www.coronawarn.app/en/faq/#red_card_how_to_test "Red Card? How to go through Corona testing"

![image](https://user-images.githubusercontent.com/66998419/128743273-303afb4c-773b-46c9-8afd-36cbbadae696.png)

---
DE
https://www.coronawarn.app/de/faq/#red_card_how_to_test "Rote Karte? So geht es zum Corona Test"

![image](https://user-images.githubusercontent.com/66998419/128743527-e7033532-8f5f-4ff7-be39-c1f990277186.png)
