### PR TITLE
FAQ: Move google_security_vulnerability to Resolved

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -81,15 +81,6 @@
                 "id": "news",
                 "accordion": [
                     {
-                        "title": "Information about the security vulnerability already fixed by Google in the Exposure Notification Framework",
-                        "anchor": "google_security_vulnerability",
-                        "active": true,
-                        "textblock": [
-                            "On April 27, 2021, reports appeared that a vulnerability in the Exposure Notification Framework (ENF) in the Android operating system was announced. This vulnerability allowed pre-installed apps on Android smartphones to access system log files, thus reading ENF data that is also provided by the Corona-Warn-App (CWA). Google has provided a fix for Android, and says that it has now been rolled out up to 98%. All Android versions that use the Google Play Services below version 21.15 are affected.",
-                            "All risks associated with using the CWA are described in the Privacy Impact Assessment (risk details can be found in <a href='../../assets/documents/cwa-datenschutz-folgenabschaetzung-anlage6.pdf' target='_blank' rel='noopener noreferrer'>Appendix 6, Section 4</a>)."
-                        ]
-                    },
-                    {
                         "title": "Data donation and event-based scientific survey",
                         "anchor": "data_donation_and_EDUS",
                         "active": true,
@@ -1733,6 +1724,15 @@
                 "title": "Resolved",
                 "id": "resolved",
                 "accordion": [
+                    {
+                      "title": "[Google/Android]: Fixed security vulnerability in the Exposure Notification Framework",
+                      "anchor": "google_security_vulnerability",
+                      "active": true,
+                      "textblock": [
+                          "On April 27, 2021, reports appeared that a vulnerability in the Exposure Notification Framework (ENF) in the Android operating system was announced. This vulnerability allowed pre-installed apps on Android smartphones to access system log files, thus reading ENF data that is also provided by the Corona-Warn-App (CWA). All Android versions that used the Google Play services below version 21.15 were affected. Google rolled out a fix in April 2021.",
+                          "All risks associated with using the CWA are described in the Privacy Impact Assessment (risk details can be found in <a href='../../assets/documents/cwa-datenschutz-folgenabschaetzung-anlage6.pdf' target='_blank' rel='noopener noreferrer'>Appendix 6, Section 4</a>)."
+                      ]
+                    },
                     {
                         "title": "Can I enter a test result from a Corona rapid test (Schnelltest)?",
                         "anchor": "rapid_test",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -81,15 +81,6 @@
                 "id": "news",
                 "accordion": [
                     {
-                        "title": "Information zur bereits von Google geschlossenen Sicherheitlücke im Exposure Notification Framework",
-                        "anchor": "google_security_vulnerability",
-                        "active": true,
-                        "textblock": [
-                            "Am 27. April 2021 erschienen Berichte, in denen über eine Sicherheitslücke des Exposure Notification Framework (ENF) im Android-Betriebssystem berichtet wurde. Diese Sicherheitslücke ermöglichte vorinstallierten Apps auf Android-Smartphones, auf Systemlogdateien zuzugreifen, somit Daten des ENF zu lesen, die eben auch von der Corona-Warn-App zur Verfügung gestellt werden. Google hat für Android einen Fix bereitgestellt, der laut Google mittlerweile bis zu 98% ausgerollt sein soll. Betroffen sind alle Android-Versionen, die die Google Play Services unterhalb der Version 21.15 nutzen.",
-                            "Alle Risiken zur Nutzung der CWA sind in der Datenschutzfolgeabschätzung  beschrieben (Risikodetails befinden sich in <a href='../../assets/documents/cwa-datenschutz-folgenabschaetzung-anlage6.pdf' target='_blank' rel='noopener noreferrer'>Anlage 6 Abschnitt 4</a>)."
-                        ]
-                    },
-                    {
                         "title": "Datenspende und ereignisbasierte wissenschaftliche Befragung",
                         "anchor": "data_donation_and_EDUS",
                         "active": true,
@@ -1742,6 +1733,15 @@
                 "id": "resolved",
                 "title": "Geklärt",
                 "accordion": [
+                    {
+                      "title": "[Google/Android]: Geschlossenen Sicherheitlücke im Exposure Notification Framework",
+                      "anchor": "google_security_vulnerability",
+                      "active": true,
+                      "textblock": [
+                          "Am 27. April 2021 erschienen Berichte, in denen über eine Sicherheitslücke des Exposure Notification Framework (ENF) im Android-Betriebssystem berichtet wurde. Diese Sicherheitslücke ermöglichte vorinstallierten Apps auf Android-Smartphones, auf Systemlogdateien zuzugreifen, somit Daten des ENF zu lesen, die eben auch von der Corona-Warn-App zur Verfügung gestellt werden. Betroffen waren alle Android-Versionen, die die Google Play-Dienste unterhalb der Version 21.15 nutzten. Google hat bereits in April 2021 einen Fix ausgerollt.",
+                          "Alle Risiken zur Nutzung der CWA sind in der Datenschutzfolgeabschätzung  beschrieben (Risikodetails befinden sich in <a href='../../assets/documents/cwa-datenschutz-folgenabschaetzung-anlage6.pdf' target='_blank' rel='noopener noreferrer'>Anlage 6 Abschnitt 4</a>)."
+                      ]
+                    },
                     {
                         "title": "Kann ich das Ergebnis eines Corona-Schnelltests eingeben?",
                         "anchor": "rapid_test",


### PR DESCRIPTION
This PR resolves https://github.com/corona-warn-app/cwa-website/issues/1597 "Outdated news article for Google ENS security vulnerability".

- The articles are moved from "News" to "Resolved"
- The titles are updated to use the [Google/Android] prefix
- Since the event is now more than 3 months old, the past tense is used
- The information about 98% rollout (which will no longer be correct) has been replaced with a statement that a fix has been rolled out

Users can determine that their current version of the Google Play services / Google Play-Dienst app is higher or equal to version 21.15 via Android > Settings > Apps. This is not stated in the FAQ, since it is a standard Android function and any smartphone which is connected to Internet will automatically update to the latest Google Play version (which is currently 21.26).

---
EN
- https://www.coronawarn.app/en/faq/#google_security_vulnerability "Information about the security vulnerability already fixed by Google in the Exposure Notification Framework" is moved from https://www.coronawarn.app/en/faq/#news to https://www.coronawarn.app/en/faq/#resolved

- The title and text are updated as follows:

![ENF sec EN](https://user-images.githubusercontent.com/66998419/128872799-4c3aae49-a685-4b6e-ac01-fc570ac3c14b.jpg)

---
DE
- https://www.coronawarn.app/de/faq/#google_security_vulnerability "Information zur bereits von Google geschlossenen Sicherheitlücke im Exposure Notification Framework" is moved from https://www.coronawarn.app/de/faq/#news to https://www.coronawarn.app/de/faq/#resolved

- The title and text are updated as follows:

![ENF sec DE](https://user-images.githubusercontent.com/66998419/128872870-696a4378-f718-49e1-93b2-61969cc6a4e4.jpg)
