### PR TITLE
Add a reference to the science blog (Closes #1605)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -94,6 +94,7 @@
                         "anchor": "data_donation_and_EDUS",
                         "active": true,
                         "textblock": [
+                            "<b>UPDATE</b><br/>In our <a href=../science/ target='_blank' rel='noopener noreferrer'>Science Blog</a> we publish the results from the research undertaken by the Robert Koch Institute. This research is based on the data from the data donation and the event-based scientific survey.<hr/>",
                             "More information on the topics of data donation by the user and event-based scientific survey can be found in this blog entry:",
                             " <a href='../blog/2021-03-04-corona-warn-app-version-1-13/' target='_blank' rel='noopener noreferrer'> Users can provide data voluntarily to help improve the Corona-Warn-App further </a>.",
                             "Further details regarding data protection can be found on this poster:",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -94,6 +94,7 @@
                         "anchor": "data_donation_and_EDUS",
                         "active": true,
                         "textblock": [
+                            "<b>AKTUELL</b><br/>In unserem <a href=../science/ target='_blank' rel='noopener noreferrer'>Science-Blog</a> veröffentlichen wir die Ergebnisse der wissenschaftlichen Evaluation durch das Robert Koch-Institut. Diese Evaluation findet auf Grundlage der Daten der Datenspende und der ereignisbasierten wissenschaftlichen Befragung statt.<hr/>",
                             "Mehr Informationen zu den Themen Datenspende durch den Nutzer und ereignisbasierte wissenschaftliche Befragung finden Sie in diesem Blog-Eintrag:",
                             "<a href='../blog/2021-03-04-corona-warn-app-version-1-13/' target='_blank' rel='noopener noreferrer'>Corona-Warn-App nun mit Datenspende und Link zu wissenschaftlicher Befragung</a>.",
                             "Weitere Details bezüglich des Datenschutzes finden Sie auf diesem Poster:",


### PR DESCRIPTION
This PR adds a reference to the science blog to the FAQ entry "data_donation_and_EDUS".

<details>
<summary>Preview of the changes</summary>

| English | German |
|---|---|
|<img width="1030" alt="EN" src="https://user-images.githubusercontent.com/67682506/129010901-83b3a98e-b305-436f-95b3-64157b6b485d.png">| <img width="1030" alt="DE" src="https://user-images.githubusercontent.com/67682506/129010887-6c1736f0-3dc2-4aba-83de-07a312c0ed6f.png">|

</details>

---

**Closes #1605**