### PR TITLE
Update "Where can I get tested" link (Addresses #1611)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -68,9 +68,9 @@
                             "Meanwhile, more than 100 rapid test partners are connected to the CWA infrastructure and can provide their test results to the app.",
                             "A local search that shows the compatible partners with nearby testing sites in your area can be found here: <a href='https://map.schnelltestportal.de' target='_blank' rel='noopener noreferrer'>map.schnelltestportal.de</a>",
                             "The list of test sites contains only those entries that have been reported by the partners concerned.",
-                            "<a href='https://map.schnelltestportal.de' target='_blank' rel='noopener'><img src='../../assets/img/faq/schnelltestportal_1.jpeg' alt='image' width='300'></a>",
+                            "<a href='https://map.schnelltestportal.de' target='_blank' rel='noopener'><div class='left-float'><img src='../../assets/img/faq/schnelltestportal_1.jpeg' alt='image' width='300'></a>",
                             "<hr>An overview of the <b>PCR and rapid antigen test sites</b> can be found on this <a href='https://www.zusammengegencorona.de/testen/?articlefilter=alleartikel' target='_blank' rel='noopener noreferrer'>BMG webpage</a> (not clear whether the test site is connected to the CWA or not).",
-                            "<a href='https://www.zusammengegencorona.de/testen/?articlefilter=alleartikel' target='_blank' rel='noopener'><img src='../../assets/img/faq/BMG_testzentren.png' alt='image' width='300'></a>",
+                            "<a href='https://www.zusammengegencorona.de/testen/?articlefilter=alleartikel' target='_blank' rel='noopener'><div class='left-float'><img src='../../assets/img/faq/BMG_testzentren.png' alt='image' width='300'></a>",
                             "Another list of test sites from the GitHub community: <a href='https://github.com/corona-warn-app/cwa-documentation/issues/569' target='_blank' rel='noopener noreferrer'>Where to get tested?</a>"
                         ]
                     }

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -68,9 +68,9 @@
                             "Mittlerweile wurden mehr als 100 Schnelltest-Partner an die CWA-Infrastruktur angeschlossen und können die Ergebnisse in die App übermitteln.",
                             "Eine lokale Suche, die Ihnen in der Umgebung die kompatiblen Partner mit den Teststellen anzeigt, finden Sie hier: <a href='https://map.schnelltestportal.de' target='_blank' rel='noopener noreferrer'>map.schnelltestportal.de</a>",
                             "Die Liste der aufgeführten Teststellen enthält nur die Einträge, die von den betreffenden Partnern gemeldet wurden.",
-                            "<a href='https://map.schnelltestportal.de' target='_blank' rel='noopener'><img src='../../assets/img/faq/schnelltestportal_1.jpeg' alt='image' width='300'></a>",
+                            "<a href='https://map.schnelltestportal.de' target='_blank' rel='noopener'><div class='left-float'><img src='../../assets/img/faq/schnelltestportal_1.jpeg' alt='image' width='300'></a>",
                             "<hr>Eine Übersicht der <b>PCR- und Schnell-Teststellen</b> finden Sie auf dieser <a href='https://www.zusammengegencorona.de/testen/?articlefilter=alleartikel' target='_blank' rel='noopener noreferrer'>BMG Seite</a> (nicht ersichtlich, ob die Teststelle an die CWA angebunden ist oder nicht).",
-                            "<a href='https://www.zusammengegencorona.de/testen/?articlefilter=alleartikel' target='_blank' rel='noopener'><img src='../../assets/img/faq/BMG_testzentren.png' alt='image' width='300'></a>",
+                            "<a href='https://www.zusammengegencorona.de/testen/?articlefilter=alleartikel' target='_blank' rel='noopener'><div class='left-float'><img src='../../assets/img/faq/BMG_testzentren.png' alt='image' width='300'></a>",
                             "Weitere Liste mit Teststellen aus der GitHub-Community : <a href='https://github.com/corona-warn-app/cwa-documentation/issues/569' target='_blank' rel='noopener noreferrer'>Wo kann man sich testen lassen?</a>"
                         ]
                     }

--- a/src/data/global.json
+++ b/src/data/global.json
@@ -17,11 +17,11 @@
     "wherecanigettested": {
         "en": {
             "text": "Where can I get tested?",
-            "link": "https://map.schnelltestportal.de"
+            "link": "/en/faq/#where_can_i_get_tested"
         },
         "de": {
             "text": "Wo kann ich mich testen lassen?",
-            "link": "https://map.schnelltestportal.de"
+            "link": "/de/faq/#where_can_i_get_tested"
         }
     },
     "screenshots": {


### PR DESCRIPTION
This PR updates the "Where can I get tested" links which are on the top of every page. The images in the FAQ entry "where_can_i_get_tested" are updated too. There are no big visible differences, so no screenshots this time (;

--- 

**Closes #1611**

---

Internal Tracking ID: [EXPOSUREAPP-8937](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8937)