### PR TITLE
Repositioning of the glossary

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2094,6 +2094,7 @@
     "glossary": {
         "glossaryHeadline": "Glossar",
         "optionalText": "",
+        "linkToGlossary": "Link zum Glossar",
         "glossaryWords": {
             "B": [
                 {

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -1,8 +1,63 @@
 {{#if page-contents}}
+<div class="container container_flex">
+  <aside class="side-menu js-menu" id="side-menu">
+    <div class="menu-close"><button class="btn btn-close js-toggle" data-target="#side-menu"></button></div>
+    <ul class="nav flex-column js-scroll-navigate" data-target="main">
+      {{#each page-contents.section-main.sections}}
+      <li class="nav-item">
+        <a class="nav-link{{#if active}} active{{/if}}"{{#if id}} href="#{{id}}"{{/if}}>{{{title}}}</a>
+      </li>
+      {{/each}}
+    </ul>
+  </aside>
+  <main class="main">
+    <h1 class="headline headline-heavy" id="top">{{page-contents.section-main.headline.title}}</h1>
 
-  {{#if page-contents.glossary.glossaryWords}}
+    <form method="get" id="faq-search-form">
+      <!-- Actual search box -->
+      <div class="input-group input-group-sm">
+        <div class="input-group-text">
+          <span class="input-group-addon">
+            <span id="match-count">X / X</span>&nbsp;{{page-contents.section-main.texts.questions}}
+          </span>
+        </div>
+        <input type="text" class="form-control" placeholder="{{page-contents.section-main.texts.search}}" id="faq-search" name="search">
+      </div>
+    </form>
+    <p><a href="#glossary">{{page-contents.glossary.linkToGlossary}}</a></p>
+    <hr />
+
+    {{#each page-contents.section-main.sections}}
+
+      {{> text-component this=. large-title=true}}
+      <dl class="accordion js-accordion" data-toggle="accordion-header">
+      {{#each accordion}}
+        <div id="{{anchor}}-div">
+          <dt class="accordion-header{{#if active}} active{{/if}}">
+            <h3 class="accordion-item-title"{{#if anchor}} id="{{anchor}}"{{/if}}>{{title}}</h3>
+            <span class="accordion-item-icon"></span>
+          </dt>
+          <dd class="accordion-body">
+            <div class="accordion-item-content">
+              {{#if textblock}}
+              {{#each textblock}}
+              <p>{{{.}}}</p>
+              {{/each}}
+              {{/if}}
+              <p>{{#if anchor}}<a href="#{{anchor}}" class="faq-anchor">{{../../page-contents.section-main.texts.permalink}}</a>{{/if}}</p>
+              <p><a href="#top">{{../../page-contents.section-main.texts.to_top}}</a></p>
+            </div>
+          </dd>
+        </div>
+      {{/each}}
+      </dl>
+    {{/each}}
+  </main>
+</div>
+{{#if page-contents.glossary.glossaryWords}}
     <div class="container container_flex  my-5">
       <div class="d-flex flex-column w-100">
+        <p id="glossary"></p>
         <h2 class="headline mb-0">{{page-contents.glossary.glossaryHeadline}}</h2>
         {{#if page-contents.glossary.optionalText}}
           <p class="mb-3">{{page-contents.glossary.optionalText}}</p>
@@ -69,60 +124,4 @@
       </div>
     </div>
   {{/if}}
-
-
-<div class="container container_flex">
-  <aside class="side-menu js-menu" id="side-menu">
-    <div class="menu-close"><button class="btn btn-close js-toggle" data-target="#side-menu"></button></div>
-    <ul class="nav flex-column js-scroll-navigate" data-target="main">
-      {{#each page-contents.section-main.sections}}
-      <li class="nav-item">
-        <a class="nav-link{{#if active}} active{{/if}}"{{#if id}} href="#{{id}}"{{/if}}>{{{title}}}</a>
-      </li>
-      {{/each}}
-    </ul>
-  </aside>
-  <main class="main">
-    <h1 class="headline headline-heavy" id="top">{{page-contents.section-main.headline.title}}</h1>
-
-    <form method="get" id="faq-search-form">
-      <!-- Actual search box -->
-      <div class="input-group input-group-sm">
-        <div class="input-group-text">
-          <span class="input-group-addon">
-            <span id="match-count">X / X</span>&nbsp;{{page-contents.section-main.texts.questions}}
-          </span>
-        </div>
-        <input type="text" class="form-control" placeholder="{{page-contents.section-main.texts.search}}" id="faq-search" name="search">
-      </div>
-    </form>
-    <hr />
-
-    {{#each page-contents.section-main.sections}}
-
-      {{> text-component this=. large-title=true}}
-      <dl class="accordion js-accordion" data-toggle="accordion-header">
-      {{#each accordion}}
-        <div id="{{anchor}}-div">
-          <dt class="accordion-header{{#if active}} active{{/if}}">
-            <h3 class="accordion-item-title"{{#if anchor}} id="{{anchor}}"{{/if}}>{{title}}</h3>
-            <span class="accordion-item-icon"></span>
-          </dt>
-          <dd class="accordion-body">
-            <div class="accordion-item-content">
-              {{#if textblock}}
-              {{#each textblock}}
-              <p>{{{.}}}</p>
-              {{/each}}
-              {{/if}}
-              <p>{{#if anchor}}<a href="#{{anchor}}" class="faq-anchor">{{../../page-contents.section-main.texts.permalink}}</a>{{/if}}</p>
-              <p><a href="#top">{{../../page-contents.section-main.texts.to_top}}</a></p>
-            </div>
-          </dd>
-        </div>
-      {{/each}}
-      </dl>
-    {{/each}}
-  </main>
-</div>
 {{/if}}


### PR DESCRIPTION
As a response to [this issue](https://github.com/corona-warn-app/cwa-website/issues/1540), here's the pull request to reposition the glossary. The glossary will be displayed at the bottom of the page instead of on top, but there's still a hyperlink below the search bar that will lead to the glossary, so you don't have to scroll all the way down. 

Comparison of the top of the new FAQ page and the old FAQ page:
<img width="375" alt="vergleich" src="https://user-images.githubusercontent.com/88365935/129329418-ff27eed7-ba10-49ce-a749-5e9ee88f5884.png">
