### PR TITLE
Bump iOS app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -354,7 +354,7 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.7.1'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.7.1'))
+    .pipe(replace('[ios.current-app-version]', '2.7.2'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '2.7.1'))


### PR DESCRIPTION
This PR bumps the current iOS app version from 2.7.1 to 2.7.2.

There is no GitHub release for this version yet, but it is already in the [App Store](https://apps.apple.com/de/app/corona-warn-app/id1512595757). 