### PR TITLE
Fix `ios_rat` anchors being used for Android screenshots

### DIFF
--- a/src/data/screenshots-archive-2-2.json
+++ b/src/data/screenshots-archive-2-2.json
@@ -110,7 +110,7 @@
             },
             {
                 "title": "Rapid antigen test",
-                "anchor": "ios_rat",
+                "anchor": "android_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-2/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
                     { "filename": "/assets/screenshots/2-2/en/android/rat_2", "alt": "Rapid antigen test image 2 of 10" },

--- a/src/data/screenshots-archive-2-3.json
+++ b/src/data/screenshots-archive-2-3.json
@@ -109,7 +109,7 @@
             },
             {
                 "title": "Rapid antigen test",
-                "anchor": "ios_rat",
+                "anchor": "android_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-3/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
                     { "filename": "/assets/screenshots/2-3/en/android/rat_2", "alt": "Rapid antigen test image 2 of 10" },

--- a/src/data/screenshots-archive-2-4.json
+++ b/src/data/screenshots-archive-2-4.json
@@ -109,7 +109,7 @@
             },
             {
                 "title": "Rapid antigen test",
-                "anchor": "ios_rat",
+                "anchor": "android_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-4/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
                     { "filename": "/assets/screenshots/2-4/en/android/rat_2", "alt": "Rapid antigen test image 2 of 10" },

--- a/src/data/screenshots-archive-2-5.json
+++ b/src/data/screenshots-archive-2-5.json
@@ -111,7 +111,7 @@
             },
             {
                 "title": "Rapid antigen test",
-                "anchor": "ios_rat",
+                "anchor": "android_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-5/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
                     { "filename": "/assets/screenshots/2-5/en/android/rat_2", "alt": "Rapid antigen test image 2 of 10" },

--- a/src/data/screenshots-archive-2-6.json
+++ b/src/data/screenshots-archive-2-6.json
@@ -113,7 +113,7 @@
             },
             {
                 "title": "Rapid antigen test",
-                "anchor": "ios_rat",
+                "anchor": "android_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-6/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
                     { "filename": "/assets/screenshots/2-6/en/android/rat_2", "alt": "Rapid antigen test image 2 of 10" },

--- a/src/data/screenshots-archive.json
+++ b/src/data/screenshots-archive.json
@@ -107,7 +107,7 @@
             },
             {
                 "title": "Rapid antigen test",
-                "anchor": "ios_rat",
+                "anchor": "android_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-3/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
                     { "filename": "/assets/screenshots/2-3/en/android/rat_2", "alt": "Rapid antigen test image 2 of 10" },

--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -115,7 +115,7 @@
             },
             {
                 "title": "Rapid antigen test",
-                "anchor": "ios_rat",
+                "anchor": "android_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-7/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
                     { "filename": "/assets/screenshots/2-7/en/android/rat_2", "alt": "Rapid antigen test image 2 of 10" },


### PR DESCRIPTION
Resolves partially #1653

Ideally as mentioned in #1653 the GitHub workflow would be adjusted to detect such incorrect anchors.