### PR TITLE
Fix Android test certificate screenshots using wrong anchor name

### DIFF
--- a/src/data/screenshots-archive-2-4_de.json
+++ b/src/data/screenshots-archive-2-4_de.json
@@ -137,7 +137,7 @@
              },
              {
                  "title": "Testzertifikat",
-                 "anchor": "android_vaccination_certificate",
+                 "anchor": "android_test_certificate",
                  "images": [
                     { "filename": "/assets/screenshots/2-4/de/android/CertificatesFragment_immune", "alt": "Image/Bild" },
                     { "filename": "/assets/screenshots/2-4/de/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Image/Bild" },

--- a/src/data/screenshots-archive-2-5_de.json
+++ b/src/data/screenshots-archive-2-5_de.json
@@ -139,7 +139,7 @@
             },
             {
                 "title": "Testzertifikat",
-                "anchor": "android_vaccination_certificate",
+                "anchor": "android_test_certificate",
                 "images": [
                    { "filename": "/assets/screenshots/2-5/de/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Image/Bild" },
                    { "filename": "/assets/screenshots/2-5/de/android/RequestCovidCertificateFragment_pcr", "alt": "Image/Bild" },

--- a/src/data/screenshots-archive-2-6_de.json
+++ b/src/data/screenshots-archive-2-6_de.json
@@ -141,7 +141,7 @@
             },
             {
                 "title": "Testzertifikat",
-                "anchor": "android_vaccination_certificate",
+                "anchor": "android_test_certificate",
                 "images": [
                    { "filename": "/assets/screenshots/2-6/de/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Testzertifikat Bild 1 von 6" },
                    { "filename": "/assets/screenshots/2-6/de/android/RequestCovidCertificateFragment_pcr", "alt": "Testzertifikat Bild 2 von 6" },

--- a/src/data/screenshots_de.json
+++ b/src/data/screenshots_de.json
@@ -143,7 +143,7 @@
             },
             {
                 "title": "Testzertifikat",
-                "anchor": "android_vaccination_certificate",
+                "anchor": "android_test_certificate",
                 "images": [
                    { "filename": "/assets/screenshots/2-7/de/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Testzertifikat Bild 1 von 6" },
                    { "filename": "/assets/screenshots/2-7/de/android/RequestCovidCertificateFragment_pcr", "alt": "Testzertifikat Bild 2 von 6" },


### PR DESCRIPTION
Resolves partially #1654

Ideally as mentioned in #1654 the GitHub workflow would be adjusted to detect such incorrect anchors.