### PR TITLE
Bump app versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -354,10 +354,10 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.7.1'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.7.2'))
+    .pipe(replace('[ios.current-app-version]', '2.8'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.7.1'))
+    .pipe(replace('[android.current-app-version]', '2.8'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
This PR bumps the app versions in the gulpfile.

There are no GitHub releases for version 2.8 yet.