### PR TITLE
Document 4 character soft-tab indentation convention for JSON files

### DIFF
--- a/docs/CHANGE_WEBSITE_CONTENT.md
+++ b/docs/CHANGE_WEBSITE_CONTENT.md
@@ -34,4 +34,5 @@ This is a rather random list of things to keep in mind when altering content:
 * Partials are language independent, data is not
 * For every change, you probably have to change two data files (one for each language)
 * English is the "main" language, i.e., `{stuff}.json` should contain the English text, `{stuff}_de.json` the German text
-* Use a proper JSON formatter after making your changes (e.g. the format document option of VSCode) from time to time
+* JSON files use 4 space-character soft-tab indentation
+* Use a proper JSON formatter after making your changes (e.g. the format document option of VSCode) from time to time    


### PR DESCRIPTION
This PR documents the convention in [docs/CHANGE_WEBSITE_CONTENT.md](https://github.com/corona-warn-app/cwa-website/blob/master/docs/CHANGE_WEBSITE_CONTENT.md) that JSON files in this repository should be formatted using soft tabs of 4 space characters.

It follows on from a discussion in https://github.com/corona-warn-app/cwa-website/pull/1658.