### PR TITLE
Restore js usability on german screenshots page

### DIFF
--- a/src/pages/de/screenshots/index.html
+++ b/src/pages/de/screenshots/index.html
@@ -4,5 +4,6 @@ page-title: Open-Source-Projekt Corona-Warn-App – Screenshots
 page-description: Screenshots der Corona-Warn-App.
 page-name: screenshots
 lightbox: true
+is_screenshots: true
 ---
 {{> page-screenshots page-contents=screenshots_de}}


### PR DESCRIPTION
[This merge](https://github.com/corona-warn-app/cwa-website/pull/1672) caused html files to require "is_screenshots: true" in both files in order to properly work, but it was only added to the english page. With this pull request, it's added to the german page too