### PR TITLE
Add method to find out glossary entry link

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2082,6 +2082,7 @@
     "glossary": {
         "glossaryHeadline": "Glossary",
         "optionalText": "",
+        "permalink": "Link to this entry",
         "linkToGlossary": "Link to the Glossary",
         "glossaryWords": {
             "B": [

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2092,6 +2092,7 @@
     "glossary": {
         "glossaryHeadline": "Glossar",
         "optionalText": "",
+        "permalink": "Link zu diesem Eintrag",
         "linkToGlossary": "Link zum Glossar",
         "glossaryWords": {
             "B": [

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -80,11 +80,13 @@
                   <div>
                     <h5 class="mt-4 px-3" id="glossary_{{content.anchor}}"><b>{{content.term}}</b></h5>
                     <div class="px-3">{{{content.description}}}</div>
+                    <p class="px-3">{{#if anchor}}<a href="#{{anchor}}" class="faq-anchor">{{../../page-contents.glossary.permalink}}</a>{{/if}}</p>
                   </div>
                 {{else}}
                   <div class="nav-tabs pb-3">
                     <h5 class="mt-4 px-3" id="glossary_{{content.anchor}}"><b>{{content.term}}</b></h5>
                     <div class="px-3">{{{content.description}}}</div>
+                    <p class="px-3">{{#if anchor}}<a href="#{{anchor}}" class="faq-anchor">{{../../page-contents.glossary.permalink}}</a>{{/if}}</p>
                   </div>
                 {{/if}}
                 {{else}}
@@ -101,11 +103,13 @@
                   <div>
                     <h5 class="mt-4 px-3" id="glossary_{{content.anchor}}"><b>{{content.term}}</b></h5>
                     <div class="px-3">{{{content.description}}}</div>
+                    <p class="px-3">{{#if anchor}}<a href="#{{anchor}}" class="faq-anchor">{{../../page-contents.glossary.permalink}}</a>{{/if}}</p>
                   </div>
                   {{else}}
                   <div class="nav-tabs pb-3">
                     <h5 class="mt-4 px-3" id="glossary_{{content.anchor}}"><b>{{content.term}}</b></h5>
                     <div class="px-3">{{{content.description}}}</div>
+                    <p class="px-3">{{#if anchor}}<a href="#{{anchor}}" class="faq-anchor">{{../../page-contents.glossary.permalink}}</a>{{/if}}</p>
                   </div>
                 {{/if}}
                 {{else}}


### PR DESCRIPTION
As a response to [this issue](https://github.com/corona-warn-app/cwa-website/issues/1673), I've created the possibility to easily get the link to a glossary entry (similar to the FAQ links)