### PR TITLE
Replacement of cross-references with links to the respective entry

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2127,14 +2127,14 @@
                 {
                 "term": "Proof of vaccination",
                 "anchor": "vaccination_proof",
-                "description": "The proof of vaccination documents a vaccination procedure with a vaccine recommended by the Paul Ehrlich Institute. A vaccination proof must contain at least the following attributes: <ul><li>the personal data of the vaccinated person (at least surname, first name and date of birth)</li><li>date of vaccination, number of vaccinations,</li><li>designation of the vaccine,</li><li>name of the disease against which the vaccination was carried out, and</li><li>characteristics that indicate the person or institution responsible for carrying out the vaccination or issuing the proof of vaccination, for example, an official symbol or the name of the issuer. </li></ul> <br/><br/> For entry, according to § 2 number 10 Coronavirus-Einreiseverordnung, the vaccination certificate must still meet additional requirements (regarding languages and vaccination schema). <br/><br/> The proof of vaccination can be documented in different ways, one form is the digital => vaccination certificate."
+                "description": "The proof of vaccination documents a vaccination procedure with a vaccine recommended by the Paul Ehrlich Institute. A vaccination proof must contain at least the following attributes: <ul><li>the personal data of the vaccinated person (at least surname, first name and date of birth)</li><li>date of vaccination, number of vaccinations,</li><li>designation of the vaccine,</li><li>name of the disease against which the vaccination was carried out, and</li><li>characteristics that indicate the person or institution responsible for carrying out the vaccination or issuing the proof of vaccination, for example, an official symbol or the name of the issuer. </li></ul> <br/><br/> For entry, according to § 2 number 10 Coronavirus-Einreiseverordnung, the vaccination certificate must still meet additional requirements (regarding languages and vaccination schema). <br/><br/> The proof of vaccination can be documented in different ways, one form is the digital <a href='#glossary_vaccination_certificate'>vaccination certificate</a>."
                 }
             ],
             "R": [
                 {
                     "term": "Recovery Certificate",
                     "anchor": "recovery_certificate",
-                    "description": "The certificate of recovery is a => digital certificate issued for a person who has demonstrably recovered from COVID-19 and proved immunity by a PCR test."
+                    "description": "The certificate of recovery is a <a href='#glossary_digital_certificate'>digital certificate</a> issued for a person who has demonstrably recovered from COVID-19 and proved immunity by a PCR test."
                 }
             ],
             "S": [
@@ -2148,7 +2148,7 @@
                 {
                     "term": "Test Certificate",
                     "anchor": "test_certificate",
-                    "description": "A test certificate is a => digital certificate issued for a person who has completed a COVID-19 test with a negative result."
+                    "description": "A test certificate is a <a href='#glossary_digital_certificate'>digital certificate</a> issued for a person who has completed a COVID-19 test with a negative result."
                 }
             ],
             "V": [
@@ -2160,12 +2160,12 @@
                 {
                     "term": "Vaccination certificate",
                     "anchor": "vaccination_certificate",
-                    "description": "The vaccination certificate is a => digital certificate issued for a person who has received a vaccination with a vaccine approved in the EU. Each vaccination certificate documents exactly one vaccination event (one dose). <br/><br/>The vaccination certificate represents a digital form of a => proof of vaccination."
+                    "description": "The vaccination certificate is a <a href='#glossary_digital_certificate'>digital certificate</a> issued for a person who has received a vaccination with a vaccine approved in the EU. Each vaccination certificate documents exactly one vaccination event (one dose). <br/><br/>The vaccination certificate represents a digital form of a <a href='#glossary_vaccination_proof'>proof of vaccination</a>."
                 },
                 {
                     "term": "Verifier-App / Checking a certificate / Verifying a certificate",
                     "anchor": "verify",
-                    "description": "The mere existence of a (digital) document has no verification/evidence power. Rather, <b>each document/certificate must</b> also be checked for validity and validation. <br/><br/> This check is done by a special app (in Germany the CovPassCheck app), the check app. <br/><br/> Individual countries may have different implementations of the check app. However all check apps use the same - consolidated on a European gateway - keys of the participating countries as well as the stored => Business Rules. Therefore, all check apps will be able to validate all EU certificates in the future, as long as they follow the specification of the European eHealth Network."
+                    "description": "The mere existence of a (digital) document has no verification/evidence power. Rather, <b>each document/certificate must</b> also be checked for validity and validation. <br/><br/> This check is done by a special app (in Germany the CovPassCheck app), the check app. <br/><br/> Individual countries may have different implementations of the check app. However all check apps use the same - consolidated on a European gateway - keys of the participating countries as well as the stored <a href='#glossary_business_rules'>Business Rules</a>. Therefore, all check apps will be able to validate all EU certificates in the future, as long as they follow the specification of the European eHealth Network."
                 }
             ]    
         },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2099,7 +2099,7 @@
                 {
                     "term": "Business rules",
                     "anchor": "business_rules",
-                    "description": "Im Kontext der Einführung digitaler => Impfzertifikate für COVID-19 wurde durch das eHealth Network der Europäischen Kommission und durch die EU-Länder abgestimmt, dass jedes Land die individuellen Regeln zusammenstellt, die im grenzüberschreitenden Reiseverkehr zu prüfen sind. Diese „Business Rules“ bestehen in der Regel aus zwei Kategorien: <ul><li>Ungültigkeitsregeln (invalidation rules) des Herausgeber-Landes (country of administration), die bestimmen, unter welchen Umständen ein Impfzertifikat nicht anerkannt wird</li><li>Akzeptanz-Regeln (acceptance rules) des Ziel-Landes (country of arrival), die erfüllt sein müssen, um in das Land einreisen zu können</li></ul>"
+                    "description": "Im Kontext der Einführung digitaler <a href='#glossary_vaccination_certificate'>Impfzertifikate</a> für COVID-19 wurde durch das eHealth Network der Europäischen Kommission und durch die EU-Länder abgestimmt, dass jedes Land die individuellen Regeln zusammenstellt, die im grenzüberschreitenden Reiseverkehr zu prüfen sind. Diese „Business Rules“ bestehen in der Regel aus zwei Kategorien: <ul><li>Ungültigkeitsregeln (invalidation rules) des Herausgeber-Landes (country of administration), die bestimmen, unter welchen Umständen ein Impfzertifikat nicht anerkannt wird</li><li>Akzeptanz-Regeln (acceptance rules) des Ziel-Landes (country of arrival), die erfüllt sein müssen, um in das Land einreisen zu können</li></ul>"
                 }
             ],
             "D": [
@@ -2111,7 +2111,7 @@
                 {
                     "term": "Digitales Zertifikat",
                     "anchor": "digital_certificate",
-                    "description": "Ein digitales Zertifikat ist ein beglaubigtes digitales Dokument. Es enthält mindestens den Namen des Inhabers, den öffentlichen Schlüssel des Inhabers und die digitale Unterschrift (=> Signatur) der ausstellenden Instanz. <br/><br/> Jedes digitale Zertifikat hat ein Ausstellungsdatum und eine zeitlich begrenzte => Gültigkeit (Ablaufdatum). Nach Ablauf der Gültigkeit muss das Zertifikat erneuert werden. <br/><br/> In der CWA unterscheiden wir zwischen: <br/><ul><li>Impfzertifikat</li><li>Testzertifikat</li><li>Genesenenzertifikat</li></ul>"
+                    "description": "Ein digitales Zertifikat ist ein beglaubigtes digitales Dokument. Es enthält mindestens den Namen des Inhabers, den öffentlichen Schlüssel des Inhabers und die digitale Unterschrift (<a href='#glossary_signature'>Signatur</a>) der ausstellenden Instanz. <br/><br/> Jedes digitale Zertifikat hat ein Ausstellungsdatum und eine zeitlich begrenzte <a href='#glossary_validity'>Gültigkeit</a> (Ablaufdatum). Nach Ablauf der Gültigkeit muss das Zertifikat erneuert werden. <br/><br/> In der CWA unterscheiden wir zwischen: <br/><ul><li>Impfzertifikat</li><li>Testzertifikat</li><li>Genesenenzertifikat</li></ul>"
                 },
                 {
                     "term": "Digitale Signatur",
@@ -2130,7 +2130,7 @@
                 {
                     "term": "Genesenenzertifikat",
                     "anchor": "recovery_certificate",
-                    "description": "Das Genesenenzertifikat ist ein => digitales Zertifikat, das einer Person ausgestellt wird, die nachweislich eine COVID-19-Erkrankung überstanden und die Immunität durch einen PCR-Test nachgewiesen hat."
+                    "description": "Das Genesenenzertifikat ist ein <a href='#glossary_digital_certificate'>digitales Zertifikat</a>, das einer Person ausgestellt wird, die nachweislich eine COVID-19-Erkrankung überstanden und die Immunität durch einen PCR-Test nachgewiesen hat."
                 },
                 {
                     "term": "Gültigkeit eines EU digitalen COVID-Zertifikats",
@@ -2142,19 +2142,19 @@
                 {
                     "term": "Impfnachweis",
                     "anchor": "vaccination_proof",
-                    "description": "Der Impfnachweis dokumentiert einen Impfvorgang mit einem vom Paul-Ehrlich-Institut empfohlenen Impfstoff. Ein Impfnachweis muss mindestens folgende Attribute enthalten: <ul><li>die personenbezogenen Daten des Geimpften (mindestens Name, Vorname und Geburtsdatum)</li><li>Datum der Schutzimpfung, Anzahl der Schutzimpfungen,</li><li>Bezeichnung des Impfstoffes,</li><li>Name der Krankheit, gegen die geimpft wurde sowie</li><li>Merkmale, die auf die für die Durchführung der Schutzimpfung oder die Ausstellung des Zertifikats verantwortliche Person oder Institution schließen lassen, zum Beispiel ein offizielles Symbol oder der Name des Ausstellers.</li></ul> <br/><br/> Für die Einreise muss nach § 2 Nummer 10 Coronavirus-Einreiseverordnung der Impfnachweis noch zusätzliche Anforderungen (bzgl. Sprachen und Impfschema) erfüllen. <br/><br/> Der Impfnachweis kann auf unterschiedliche Weise dokumentiert sein, eine Form ist das digitale => Impfzertifikat."
+                    "description": "Der Impfnachweis dokumentiert einen Impfvorgang mit einem vom Paul-Ehrlich-Institut empfohlenen Impfstoff. Ein Impfnachweis muss mindestens folgende Attribute enthalten: <ul><li>die personenbezogenen Daten des Geimpften (mindestens Name, Vorname und Geburtsdatum)</li><li>Datum der Schutzimpfung, Anzahl der Schutzimpfungen,</li><li>Bezeichnung des Impfstoffes,</li><li>Name der Krankheit, gegen die geimpft wurde sowie</li><li>Merkmale, die auf die für die Durchführung der Schutzimpfung oder die Ausstellung des Zertifikats verantwortliche Person oder Institution schließen lassen, zum Beispiel ein offizielles Symbol oder der Name des Ausstellers.</li></ul> <br/><br/> Für die Einreise muss nach § 2 Nummer 10 Coronavirus-Einreiseverordnung der Impfnachweis noch zusätzliche Anforderungen (bzgl. Sprachen und Impfschema) erfüllen. <br/><br/> Der Impfnachweis kann auf unterschiedliche Weise dokumentiert sein, eine Form ist das digitale <a href='#glossary_vaccination_certificate'>Impfzertifikat</a>."
                 },
                 {
                     "term": "Impfzertifikat",
                     "anchor": "vaccination_certificate",
-                    "description": "Das Impfzertifikat ist ein => digitales Zertifikat, das einer Person ausgestellt wird, die eine Impfung mit einem in der EU zugelassenen Impfstoff wahrgenommen haben. Jedes Impfzertifikat dokumentiert genau einen Impfvorgang (eine Dosis). <br/><br/> Das Impfzertifikat stellt eine digitale Form für einen => Impfnachweis dar."
+                    "description": "Das Impfzertifikat ist ein => <a href='#glossary_digital_certificate'>digitales Zertifikat</a>, das einer Person ausgestellt wird, die eine Impfung mit einem in der EU zugelassenen Impfstoff wahrgenommen haben. Jedes Impfzertifikat dokumentiert genau einen Impfvorgang (eine Dosis). <br/><br/> Das Impfzertifikat stellt eine digitale Form für einen => <a href='#glossary_vaccination_proof'>Impfnachweis</a> dar."
                 }
             ],
             "P": [
                 {
                     "term": "Prüf-App / Prüfen eines Zertifikats / Verifizieren eines Zertifikats",
                     "anchor": "verify",
-                    "description": "Die reine Existenz eines (digitalen) Dokuments hat keine Nachweis-/Beweiskraft. Vielmehr <b>muss</b> jedes Dokument/Zertifikat auch auf die Gültigkeit und Validität überprüft werden. <br/><br/> Diese Prüfung erledigt eine spezielle App (in Deutschland die CovPassCheck-App), die Prüf-App. <br/><br/> Die einzelnen Länder haben möglicherweise unterschiedliche Implementierungen der Prüf-App. Aber alle Prüf-Apps nutzen dieselben – auf einem europäischen Gateway konsolidieren – Schlüssel der teilnehmenden Länder sowie die hinterlegten => Business Rules. Daher können alle Prüf-Apps künftig auch alle EU-Zertifikate validieren, sofern sie der Spezifikation des europäischen eHealth Network folgen."
+                    "description": "Die reine Existenz eines (digitalen) Dokuments hat keine Nachweis-/Beweiskraft. Vielmehr <b>muss</b> jedes Dokument/Zertifikat auch auf die Gültigkeit und Validität überprüft werden. <br/><br/> Diese Prüfung erledigt eine spezielle App (in Deutschland die CovPassCheck-App), die Prüf-App. <br/><br/> Die einzelnen Länder haben möglicherweise unterschiedliche Implementierungen der Prüf-App. Aber alle Prüf-Apps nutzen dieselben – auf einem europäischen Gateway konsolidieren – Schlüssel der teilnehmenden Länder sowie die hinterlegten <a href='#glossary_business_rules'>Business Rules</a>. Daher können alle Prüf-Apps künftig auch alle EU-Zertifikate validieren, sofern sie der Spezifikation des europäischen eHealth Network folgen."
                 }
             ],
             "S": [
@@ -2168,7 +2168,7 @@
                 {
                     "term": "Testzertifikat",
                     "anchor": "test_certificate",
-                    "description": "Das Testzertifikat ist ein => digitales Zertifikat, das einer Person ausgestellt wird, die einen COVID-19-Test mit einem negativen Ergebnis abgeschlossen hat."
+                    "description": "Das Testzertifikat ist ein <a href='#glossary_digital_certificate'>digitales Zertifikat</a>, das einer Person ausgestellt wird, die einen COVID-19-Test mit einem negativen Ergebnis abgeschlossen hat."
                 }
             ],
             "Z": [


### PR DESCRIPTION
As a response to [this issue](https://github.com/corona-warn-app/cwa-website/issues/1678), here's the pull request to replace cross-references with links to their respective entry. See the images below for an example.

Old:
<img width="700" alt="chrome_qdHLNyQw9T" src="https://user-images.githubusercontent.com/88365935/131295973-743d36aa-9b25-4ede-a11c-548c84e2b659.png">


New:
<img width="700" alt="chrome_ByXWtA95Ws" src="https://user-images.githubusercontent.com/88365935/131295964-5f17ad2d-a5dc-4ef2-952c-dfe0cf932c11.png">
