### PR TITLE
Make the text "CSV Datei laden" more clear

### DIFF
--- a/src/data/eventregistration_de.json
+++ b/src/data/eventregistration_de.json
@@ -22,7 +22,7 @@
                 "show": "Erstellen",
                 "download": "Herunterladen",
                 "print": "Drucken",
-                "csvFile": "CSV Datei laden",
+                "csvFile": "Ihre CSV Datei hochladen",
                 "pageTemplate": "Vorlage auswählen"
             },
             "placeholders": {


### PR DESCRIPTION
This commit makes the button text "csvFile" more clear.

Currently the text says "CSV Datei laden", the user could think that the button downloads the file ("laden") instead of giving the user the chance to upload a file.

<details>
<summary>Preview of the change (DE only)</summary>

<img width="1438" alt="Bildschirmfoto 2021-09-05 um 15 50 52" src="https://user-images.githubusercontent.com/67682506/132129417-8949ad2f-7a6b-480c-98b3-8479695cfb02.png">


</details>