### PR TITLE
Fix/8884 invalid certificates Android 2.8

### DIFF
--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -184,8 +184,8 @@
                 "anchor": "android_invalid_certificate",
                 "images": [
                     { "filename": "/assets/screenshots/2-8/en/ios/iPhone 11 Pro-screenshot_recovery_certificate_overview_part1", "alt": "Invalid certificate image 1 of 3" },
-                    { "filename": "/assets/screenshots/2-8/en/ios/iPhone 11 Pro-screenshot_recovery_certificate_valid_details_part1", "alt": "Invalid certificate image 2 of 3" },
-                    { "filename": "/assets/screenshots/2-8/en/ios/iPhone 11 Pro-screenshot_recovery_certificate_valid_details_part2", "alt": "Invalid certificate image 3 of 3" }
+                    { "filename": "/assets/screenshots/2-8/en/ios/iPhone 11 Pro-screenshot_recovery_certificate_expired_details_part1", "alt": "Invalid certificate image 2 of 3" },
+                    { "filename": "/assets/screenshots/2-8/en/ios/iPhone 11 Pro-screenshot_recovery_certificate_expired_details_part2", "alt": "Invalid certificate image 3 of 3" }
                 ]
             }
         ]

--- a/src/data/screenshots_de.json
+++ b/src/data/screenshots_de.json
@@ -184,8 +184,8 @@
                 "anchor": "android_invalid_certificate",
                 "images": [
                     { "filename": "/assets/screenshots/2-8/de/ios/iPhone 11 Pro-screenshot_recovery_certificate_overview_part1", "alt": "Ungültige Zertifikate Bild 1 von 3" },
-                    { "filename": "/assets/screenshots/2-8/de/ios/iPhone 11 Pro-screenshot_recovery_certificate_valid_details_part1", "alt": "Ungültige Zertifikate Bild 2 von 3" },
-                    { "filename": "/assets/screenshots/2-8/de/ios/iPhone 11 Pro-screenshot_recovery_certificate_valid_details_part2", "alt": "Ungültige Zertifikate Bild 3 von 3" }
+                    { "filename": "/assets/screenshots/2-8/de/ios/iPhone 11 Pro-screenshot_recovery_certificate_expired_details_part1", "alt": "Ungültige Zertifikate Bild 2 von 3" },
+                    { "filename": "/assets/screenshots/2-8/de/ios/iPhone 11 Pro-screenshot_recovery_certificate_expired_details_part2", "alt": "Ungültige Zertifikate Bild 3 von 3" }
                 ]
             }
         ]


### PR DESCRIPTION
This PR addresses issue https://github.com/corona-warn-app/cwa-website/issues/1710 for 

- https://www.coronawarn.app/en/screenshots/#android_invalid_certificate
- https://www.coronawarn.app/de/screenshots/#android_invalid_certificate

The links in the above sections are changed to use screenshots of invalid certificates from iOS for Android (since are no equivalent Android screenshots available).

Previously 2 of the 3 screenshots in the Android sections were incorrectly valid where they were supposed to demonstrate what an invalid screenshot looked like.

Now section 
https://www.coronawarn.app/en/screenshots/#android_invalid_certificate
is identical to
https://www.coronawarn.app/en/screenshots/#ios_invalid_certificate
and
https://www.coronawarn.app/de/screenshots/#android_invalid_certificate
is identical to
https://www.coronawarn.app/de/screenshots/#ios_invalid_certificate