### PR TITLE
Add eu_dcc_export + vac_cert_booster

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -386,8 +386,8 @@
                         "anchor": "vac_cert_booster_cwa",
                         "active": true,
                         "textblock": [
-                            "In one of the upcoming releases, the Corona-Warn-App will allow importing certificates documenting a booster vaccination.",
-                            "Users will receive a notification to consider a booster vaccination if necessary. The notification is based on national rules that have been implemented in collaboration and alignment with the Robert Koch Institute (RKI). These rules are continuously reviewed and adapted according to developments and new findings.",
+                            "Since version 2.9, the Corona-Warn-App will allow importing certificates documenting a booster vaccination.",
+                            "In a future release, users will receive a notification to consider a booster vaccination if necessary. The notification is based on national rules that have been implemented in collaboration and alignment with the Robert Koch Institute (RKI). These rules are continuously reviewed and adapted according to developments and new findings.",
                             "Please note: The booster vaccination certificate is only valid if you can also prove the required basic immunization by the corresponding last certificate of the vaccination series. Please do not delete the other vaccination certificates from the CWA! Since no uniform EU-standards have yet been defined on this topic, you should also carry the basic immunization certificates with you, especially when traveling abroad, whether in the CWA, as a PDF, or as a paper printout. We therefore recommend keeping all vaccination certificates in the app, even if they are no longer up to date.",
                             "<a href='#vac_cert_booster' target='_self' rel='noopener noreferrer'>To the index of the booster vaccination</a>"
                         ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -193,6 +193,26 @@
                             "<ul><li>A vaccination certificate issued in Germany is usually valid for one year from the date of issue</li><li>A recovery certificate on the other hand may not be valid for longer than 180 days from the date of the last positive PCR test, as defined by the EU.</li></ul>",
                             "If your certificate is technically still valid, it appears it was issued by an unauthorized body or incorrectly. In this case, we ask you to contact the <a href='#international_phone_numbers' target='_blank' rel='noopener noreferrer'>technical hotline</a> and tell us when and by which body this certificate was issued. Then please have a new certificate with a valid signature issued by an authorized body."
                         ]
+                    },
+                    {
+                        "title": "How do I create a printout of my EU Digital COVID Certificate?",
+                        "anchor": "eu_dcc_export",
+                        "active": true,
+                        "textblock": [
+                            "<b>Purpose</b>",
+                            "As of version 2.10 of the Corona-Warn-App, you can export scanned Digital COVID Certificates of the EU into PDF documents. This function is primarily used to create backup copies of the certificates for your personal purposes",
+                            "Of course, the original EU templates are used for the layout of the certificates.",
+                            "<b>Safety information</b>",
+                            "Exporting and saving the certificates is voluntary. The creation of the PDF file takes place exclusively locally on your smartphone. Only you have access to this document.",
+                            "However, please note that the generated document contains sensitive personal information. Therefore, please handle the PDF file with care. Show the document only to people you trust and who are authorized to review it.",
+                            "We strongly advise against sharing the PDF document via potentially insecure channels (e.g. by email or via other apps).",
+                            "<b>Limitation</b>",
+                            "With the new function, only PDF documents of certificates that were also issued in Germany can be generated. Otherwise, a detailed message appears: 'Display print version not possible - The print version of the certificate cannot be displayed because the certificate was not issued in Germany.'",
+                            "<b>Application</b>",
+                            "After successfully exporting the certificate to the PDF document, you can decide whether you want to save it on your smartphone, import it to other apps or print it. To do this, please use the standard functions of the operating system.",
+                            "<b>Step-by-step instructions:</b>",
+                            "To create a printout of your EU COVID Digital Certificate, please follow these steps: <ul><li>Click on the 'Certificates' tab in the Corona-Warn-App</li><li>Select a person, by clicking on a corresponding certificate in the certificate overview</li><li>Scroll down and select a certificate of this person</li><li>In this detail view, click on the three-dot menu in the upper right corner (Android) or on 'More' at the bottom (iOS)</li><li>Click on 'Display print version'</li><li>Click on the icon for 'Print' or for 'Share' in the upper right corner</li><li>In the following view, you can print the created PDF document using the standard functions of the operating system, import it into other apps or even share it</li></ul>"
+                        ]
                     }
                 ]
             },
@@ -213,7 +233,8 @@
                         "anchor": "test_cert_why",
                         "active": true,
                         "textblock": [
-                            "Starting with version 2.4 of the Corona-Warn-App (CWA), you can request a digital test certificate via the app. The new feature allows you to prove your negative test result through an official, digital COVID test certificate in the form of a QR code in the CWA. Within the countries of the European Union, it can serve as officially valid proof of a negative test result, which you can use, for example, for travel or in other legally prescribed cases, such as a visit to a restaurant. You can then show the QR code in the CWA."
+                            "Starting with version 2.4 of the Corona-Warn-App (CWA), you can request a digital test certificate via the app. The new feature allows you to prove your negative test result through an official, digital COVID test certificate in the form of a QR code in the CWA. Within the countries of the European Union, it can serve as officially valid proof of a negative test result, which you can use, for example, for travel or in other legally prescribed cases, such as a visit to a restaurant. You can then show the QR code in the CWA.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>To the index of the test certificate</a>"
                         ]
                     },
                     {
@@ -221,7 +242,8 @@
                         "anchor": "test_cert_get",
                         "active": true,
                         "textblock": [
-                            "You can request the certificate by registering a test in the Corona-Warn-App (CWA): To do this, tap on 'Manage Your Tests' on the Start Screen of your CWA (or on 'Register Test' for app versions until 2.5) and then on 'Scan QR Code'. After scanning the QR code for test registration, the window for the COVID test certificate automatically opens. There you can tap 'Request Test Certificate' or decline it if you do not want to receive one."
+                            "You can request the certificate by registering a test in the Corona-Warn-App (CWA): To do this, tap on 'Manage Your Tests' on the Start Screen of your CWA (or on 'Register Test' for app versions until 2.5) and then on 'Scan QR Code'. After scanning the QR code for test registration, the window for the COVID test certificate automatically opens. There you can tap 'Request Test Certificate' or decline it if you do not want to receive one.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>To the index of the test certificate</a>"
                         ]
                     },
                     {
@@ -231,7 +253,8 @@
                         "textblock": [
                             "You can request a certificate for both PCR and rapid tests, which are then issued in the event of a negative test.",
                             "<b>Rapid tests</b><br>In the case of rapid tests, it may be that the respective test site does not support the digital certificate. In this case, after scanning the QR code, you will not be redirected to apply for the certificate. You will then receive the information that a test certificate cannot be requested because the test site does not support the issuance of test certificates.",
-                            "<b>PCR tests</b><br>When requesting a test certificate for a PCR test, you must provide your date of birth. It is important that the date of birth corresponds to the one that was also indicated for the sample of the PCR test. If the dates of birth do not match, for example due to a typo, you will not receive the test result or the certificate via the app. You cannot change the date of birth that you enter in the app afterwards. Before you request the test certificate after entering the date, you should therefore briefly check whether the date is correct."
+                            "<b>PCR tests</b><br>When requesting a test certificate for a PCR test, you must provide your date of birth. It is important that the date of birth corresponds to the one that was also indicated for the sample of the PCR test. If the dates of birth do not match, for example due to a typo, you will not receive the test result or the certificate via the app. You cannot change the date of birth that you enter in the app afterwards. Before you request the test certificate after entering the date, you should therefore briefly check whether the date is correct.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>To the index of the test certificate</a>"
                         ]
                     },
                     {
@@ -239,7 +262,8 @@
                         "anchor": "test_cert_when_and_where",
                         "active": true,
                         "textblock": [
-                            "Shortly after the test result is available in the app, you will also receive your test certificate in the app - provided that you have requested it beforehand, and the respective rapid test site supports the creation of a certificate. You can then view it via the 'Certificates' tab. If you tap on the COVID test certificate, you will be shown the QR code that can be scanned for verification, and more information, such as type of test, date and time of execution and test result."
+                            "Shortly after the test result is available in the app, you will also receive your test certificate in the app - provided that you have requested it beforehand, and the respective rapid test site supports the creation of a certificate. You can then view it via the 'Certificates' tab. If you tap on the COVID test certificate, you will be shown the QR code that can be scanned for verification, and more information, such as type of test, date and time of execution and test result.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>To the index of the test certificate</a>"
                         ]
                     },
                     {
@@ -247,7 +271,8 @@
                         "anchor": "test_cert_validity",
                         "active": true,
                         "textblock": [
-                            "How long the certificate is valid depends on the regulations of the respective federal state or municipality."
+                            "How long the certificate is valid depends on the regulations of the respective federal state or municipality.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>To the index of the test certificate</a>"
                         ]
                     },
                     {
@@ -256,7 +281,8 @@
                         "active": true,
                         "textblock": [
                             "To create the test certificate, the data is encrypted end-to-end and transmitted from the laboratory or the rapid test site to the Corona-Warn-App. For this purpose, the encrypted data is transmitted to the Robert Koch Institute (RKI) in order to digitally sign it and thus confirm the validity of the certificate. The data cannot be decrypted by the RKI and will be deleted after delivery of the certificate.",
-                            "Test certificates are stored in the app for an unlimited period of time. You can delete certificates manually by going to the 'Certificates' tab, selecting the respective test certificate and then selecting 'Remove test certificate'."
+                            "Test certificates are stored in the app for an unlimited period of time. You can delete certificates manually by going to the 'Certificates' tab, selecting the respective test certificate and then selecting 'Remove test certificate'.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>To the index of the test certificate</a>"
                         ]
                     }
                 ]
@@ -272,6 +298,16 @@
                         "textblock": [
                             "<ul>",
                             "<li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>Can I save a vaccination certificate on multiple smartphones, e.g., on my private and business phone?</a></li><li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>How can I transfer vaccination certificates when changing device?</a></li><li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>What do I do if I lose my phone?</a></li><li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>Will vaccination certificates be included in my backup?</a></li><li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>Can I manage certificates in the Corona-Warn-App and the CovPass-App at the same time, or do I have to choose one of the two apps?</a></li>",
+                            "</ul>"
+                        ]
+                    },
+                    {
+                        "title": "Questions and answers about the booster vaccination",
+                        "anchor": "eu_dcc_booster",
+                        "active": true,
+                        "textblock": [
+                            "<ul>",
+                            "<li><a href='#vac_cert_booster_info' target='_self' rel='noopener noreferrer'>How do I become aware of booster vaccinations in the context of Corona?</a></li><li><a href='#vac_cert_booster_cwa' target='_self' rel='noopener noreferrer'>How do I manage booster vaccination certificates in my CWA?</a></li>",
                             "</ul>"
                         ]
                     },
@@ -341,7 +377,8 @@
                         "textblock": [
                             "The Conference of Health Ministers has now passed a regulation on COVID 19 booster vaccinations. An additional booster vaccination is designed to help raise neutralizing antibody titers again, which may decline over time after basic immunization. This becomes particularly important if a weak/muted vaccine response is assumed or recognized after basic immunization in certain groups of vulnerable people.",
                             "The Corona-Warn-App (CWA) will notify the user to consider a booster vaccination if certain conditions are met. These conditions are based on the recommendations of the Paul Ehrlich Institute and the Permanent Vaccination Commission (STIKO) of the Robert Koch Institute (RKI).",
-                            "How long someone is effectively protected by a COVID 19 vaccination (basic immunization) depends on several factors and can therefore not be answered in general terms according to current knowledge. For this reason, the corresponding CWA rules for vaccination schedules and booster vaccinations are continuously reviewed and adapted in coordination with the RKI according to developments and new findings."
+                            "How long someone is effectively protected by a COVID 19 vaccination (basic immunization) depends on several factors and can therefore not be answered in general terms according to current knowledge. For this reason, the corresponding CWA rules for vaccination schedules and booster vaccinations are continuously reviewed and adapted in coordination with the RKI according to developments and new findings.",
+                            "<a href='#eu_dcc_booster' target='_self' rel='noopener noreferrer'>To the index of the booster vaccination</a>"
                         ]
                     },
                     {
@@ -351,7 +388,8 @@
                         "textblock": [
                             "In one of the upcoming releases, the Corona-Warn-App will allow importing certificates documenting a booster vaccination.",
                             "Users will receive a notification to consider a booster vaccination if necessary. The notification is based on national rules that have been implemented in collaboration and alignment with the Robert Koch Institute (RKI). These rules are continuously reviewed and adapted according to developments and new findings.",
-                            "Please note: The booster vaccination certificate is only valid if you can also prove the required basic immunization by the corresponding last certificate of the vaccination series. Please do not delete the other vaccination certificates from the CWA! Since no uniform EU-standards have yet been defined on this topic, you should also carry the basic immunization certificates with you, especially when traveling abroad, whether in the CWA, as a PDF, or as a paper printout. We therefore recommend keeping all vaccination certificates in the app, even if they are no longer up to date."
+                            "Please note: The booster vaccination certificate is only valid if you can also prove the required basic immunization by the corresponding last certificate of the vaccination series. Please do not delete the other vaccination certificates from the CWA! Since no uniform EU-standards have yet been defined on this topic, you should also carry the basic immunization certificates with you, especially when traveling abroad, whether in the CWA, as a PDF, or as a paper printout. We therefore recommend keeping all vaccination certificates in the app, even if they are no longer up to date.",
+                            "<a href='#eu_dcc_booster' target='_self' rel='noopener noreferrer'>To the index of the booster vaccination</a>"
                         ]
                     },
                     {
@@ -407,7 +445,8 @@
                         "anchor": "vac_cert_multiple_scan_possible",
                         "active": true,
                         "textblock": [
-                            "There is no limit to how often you can scan the QR code of vaccination certificates. By scanning the QR code of a certificate you can add and manage the vaccination certificates: <ul><li>on multiple devices, e.g. on your private and business phone </li><li>on a new device, when changing device</li><li> in several apps, e.g. the Corona-Warn-App and the CovPass-App</li><li> on a device you have reset. Certificates are not included in the backup. </li></ul>"
+                            "There is no limit to how often you can scan the QR code of vaccination certificates. By scanning the QR code of a certificate you can add and manage the vaccination certificates: <ul><li>on multiple devices, e.g. on your private and business phone </li><li>on a new device, when changing device</li><li> in several apps, e.g. the Corona-Warn-App and the CovPass-App</li><li> on a device you have reset. Certificates are not included in the backup. </li></ul>",
+                            "<a href='#vac_cert_index' target='_self' rel='noopener noreferrer'>To the index of the vaccination certificate</a>"
                         ]
                     },
                     {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -303,7 +303,7 @@
                     },
                     {
                         "title": "Questions and answers about the booster vaccination",
-                        "anchor": "eu_dcc_booster",
+                        "anchor": "vac_cert_booster",
                         "active": true,
                         "textblock": [
                             "<ul>",
@@ -378,7 +378,7 @@
                             "The Conference of Health Ministers has now passed a regulation on COVID 19 booster vaccinations. An additional booster vaccination is designed to help raise neutralizing antibody titers again, which may decline over time after basic immunization. This becomes particularly important if a weak/muted vaccine response is assumed or recognized after basic immunization in certain groups of vulnerable people.",
                             "The Corona-Warn-App (CWA) will notify the user to consider a booster vaccination if certain conditions are met. These conditions are based on the recommendations of the Paul Ehrlich Institute and the Permanent Vaccination Commission (STIKO) of the Robert Koch Institute (RKI).",
                             "How long someone is effectively protected by a COVID 19 vaccination (basic immunization) depends on several factors and can therefore not be answered in general terms according to current knowledge. For this reason, the corresponding CWA rules for vaccination schedules and booster vaccinations are continuously reviewed and adapted in coordination with the RKI according to developments and new findings.",
-                            "<a href='#eu_dcc_booster' target='_self' rel='noopener noreferrer'>To the index of the booster vaccination</a>"
+                            "<a href='#vac_cert_booster' target='_self' rel='noopener noreferrer'>To the index of the booster vaccination</a>"
                         ]
                     },
                     {
@@ -389,7 +389,7 @@
                             "In one of the upcoming releases, the Corona-Warn-App will allow importing certificates documenting a booster vaccination.",
                             "Users will receive a notification to consider a booster vaccination if necessary. The notification is based on national rules that have been implemented in collaboration and alignment with the Robert Koch Institute (RKI). These rules are continuously reviewed and adapted according to developments and new findings.",
                             "Please note: The booster vaccination certificate is only valid if you can also prove the required basic immunization by the corresponding last certificate of the vaccination series. Please do not delete the other vaccination certificates from the CWA! Since no uniform EU-standards have yet been defined on this topic, you should also carry the basic immunization certificates with you, especially when traveling abroad, whether in the CWA, as a PDF, or as a paper printout. We therefore recommend keeping all vaccination certificates in the app, even if they are no longer up to date.",
-                            "<a href='#eu_dcc_booster' target='_self' rel='noopener noreferrer'>To the index of the booster vaccination</a>"
+                            "<a href='#vac_cert_booster' target='_self' rel='noopener noreferrer'>To the index of the booster vaccination</a>"
                         ]
                     },
                     {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -200,9 +200,9 @@
                         "active": true,
                         "textblock": [
                             "<b>Purpose</b>",
-                            "As of version 2.10 of the Corona-Warn-App, you can export scanned Digital COVID Certificates of the EU into PDF documents. This function is primarily used to create backup copies of the certificates for your personal purposes",
+                            "As of version 2.10 of the Corona-Warn-App, you can export scanned EU Digital COVID Certificates into PDF documents. This function is primarily used to create backup copies of the certificates for your personal purposes",
                             "Of course, the original EU templates are used for the layout of the certificates.",
-                            "<b>Safety information</b>",
+                            "<b>Confidentiality</b>",
                             "Exporting and saving the certificates is voluntary. The creation of the PDF file takes place exclusively locally on your smartphone. Only you have access to this document.",
                             "However, please note that the generated document contains sensitive personal information. Therefore, please handle the PDF file with care. Show the document only to people you trust and who are authorized to review it.",
                             "We strongly advise against sharing the PDF document via potentially insecure channels (e.g. by email or via other apps).",
@@ -377,7 +377,7 @@
                         "textblock": [
                             "The Conference of Health Ministers has now passed a regulation on COVID 19 booster vaccinations. An additional booster vaccination is designed to help raise neutralizing antibody titers again, which may decline over time after basic immunization. This becomes particularly important if a weak/muted vaccine response is assumed or recognized after basic immunization in certain groups of vulnerable people.",
                             "The Corona-Warn-App (CWA) will notify the user to consider a booster vaccination if certain conditions are met. These conditions are based on the recommendations of the Paul Ehrlich Institute and the Permanent Vaccination Commission (STIKO) of the Robert Koch Institute (RKI).",
-                            "How long someone is effectively protected by a COVID 19 vaccination (basic immunization) depends on several factors and can therefore not be answered in general terms according to current knowledge. For this reason, the corresponding CWA rules for vaccination schedules and booster vaccinations are continuously reviewed and adapted in coordination with the RKI according to developments and new findings.",
+                            "How long someone is effectively protected by a COVID 19 vaccination (basic immunization) depends on several factors and can therefore not be answered in general terms according to current knowledge. For this reason, the corresponding CWA rules for vaccination schedules and booster vaccinations are continually reviewed and adapted in coordination with the RKI according to developments and new findings.",
                             "<a href='#vac_cert_booster' target='_self' rel='noopener noreferrer'>To the index of the booster vaccination</a>"
                         ]
                     },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -303,7 +303,7 @@
                     },
                     {
                         "title": "Fragen und Antworten zur Auffrischungsimpfung",
-                        "anchor": "eu_dcc_booster",
+                        "anchor": "vac_cert_booster",
                         "active": "true",
                         "textblock": [
                             "<ul>",
@@ -378,7 +378,7 @@
                             "Durch die Gesundheitsminister-Konferenz wurde inzwischen die Regelung zu COVID-19-Auffrischimpfungen beschlossen. Eine zusätzliche Auffrischimpfung soll helfen, die neutralisierenden Antikörpertiter wieder zu erhöhen, die nach der Grundimmunisierung mit der Zeit absinken können. Das gilt insbesondere bei den Personengruppen, bei denen nach einer Grundimmunisierung eine gedämpfte Impfantwort vermutet oder erkannt wird.",
                             "Die Corona-Warn-App wird darauf hinweisen, eine Auffrischimpfung in Betracht zu ziehen, falls bestimmte Bedingungen erfüllt sind. Diese Bedingungen basieren auf den Empfehlungen der Paul-Ehrlich-Instituts sowie der Ständigen Impfkommission (STIKO) des Robert Koch-Instituts (RKI).",
                             "Wie lange jemand durch eine COVID-19-Impfung (Grundimmunisierung) tatsächlich geschützt ist, hängt von verschiedenen Faktoren ab und lässt sich daher nach heutigem Kenntnisstand nicht pauschal beantworten. Deswegen werden die entsprechenden Regeln für Impfschemata und Auffrischimpfungen in der Corona-Warn-App in Abstimmung mit dem RKI entsprechend den Entwicklungen und neuen Erkenntnissen fortlaufend überprüft und angepasst.",
-                            "<a href='#eu_dcc_booster' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis der Auffrischungsimpfung</a>"
+                            "<a href='#vac_cert_booster' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis der Auffrischungsimpfung</a>"
                         ]
                     },
                     {
@@ -389,7 +389,7 @@
                             "In einem der kommenden Releases unterstützt die Corona-Warn-App auch den Import von Zertifikaten, die eine Auffrischimpfung dokumentieren.",
                             "Die Anwender erhalten dazu einen Hinweis, ggf. eine Auffrischimpfung in Betracht zu ziehen. Der Hinweis basiert auf nationalen Regeln, die in Absprache mit dem Robert Koch-Institut (RKI) implementiert wurden. Diese Regeln werden fortlaufend geprüft und entsprechend den Entwicklungen und neuen Erkenntnissen angepasst.",
                             "Bitte beachten Sie: Das Zertifikat zur Auffrischungsimpfung ist nur gültig, wenn Sie auch die nötige Grundimmunisierung durch das entsprechende letzte Zertifikat der Impfreihe nachweisen können. Löschen Sie bitte die anderen Impfzertifikate nicht aus der CWA! Da bisher noch keine einheitlichen EU-Standards zu diesem Thema festgelegt wurden, sollte man insbesondere bei Reisen ins Ausland auch die Zertifikate der Grundimmunisierung mit sich führen, sei es in der CWA, als PDF, oder als Papierausdruck. Wir empfehlen daher alle Impfzertifikate in der App zu behalten, auch wenn diese nicht mehr aktuell sind.",
-                            "<a href='#eu_dcc_booster' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis der Auffrischungsimpfung</a>"
+                            "<a href='#vac_cert_booster' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis der Auffrischungsimpfung</a>"
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -386,8 +386,8 @@
                         "anchor": "vac_cert_booster_cwa",
                         "active": true,
                         "textblock": [
-                            "In einem der kommenden Releases unterstützt die Corona-Warn-App auch den Import von Zertifikaten, die eine Auffrischimpfung dokumentieren.",
-                            "Die Anwender erhalten dazu einen Hinweis, ggf. eine Auffrischimpfung in Betracht zu ziehen. Der Hinweis basiert auf nationalen Regeln, die in Absprache mit dem Robert Koch-Institut (RKI) implementiert wurden. Diese Regeln werden fortlaufend geprüft und entsprechend den Entwicklungen und neuen Erkenntnissen angepasst.",
+                            "Seit Version 2.9 unterstützt die Corona-Warn-App auch den Import von Zertifikaten, die eine Auffrischimpfung dokumentieren.",
+                            "In einer zukünftigen Version werden Anwender dazu einen Hinweis erhalten, ggf. eine Auffrischimpfung in Betracht zu ziehen. Der Hinweis basiert auf nationalen Regeln, die in Absprache mit dem Robert Koch-Institut (RKI) implementiert wurden. Diese Regeln werden fortlaufend geprüft und entsprechend den Entwicklungen und neuen Erkenntnissen angepasst.",
                             "Bitte beachten Sie: Das Zertifikat zur Auffrischungsimpfung ist nur gültig, wenn Sie auch die nötige Grundimmunisierung durch das entsprechende letzte Zertifikat der Impfreihe nachweisen können. Löschen Sie bitte die anderen Impfzertifikate nicht aus der CWA! Da bisher noch keine einheitlichen EU-Standards zu diesem Thema festgelegt wurden, sollte man insbesondere bei Reisen ins Ausland auch die Zertifikate der Grundimmunisierung mit sich führen, sei es in der CWA, als PDF, oder als Papierausdruck. Wir empfehlen daher alle Impfzertifikate in der App zu behalten, auch wenn diese nicht mehr aktuell sind.",
                             "<a href='#vac_cert_booster' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis der Auffrischungsimpfung</a>"
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -193,6 +193,26 @@
                             "<ul><li>In der Regel ist ein in Deutschland ausgestelltes Impfzertifikat ein Jahr ab Ausstellungdatum gültig.</li><li>Ein Genesenenzertifikat darf laut Festlegung der EU dagegen nicht länger als 180 Tage ab dem Datum des letzten positiven PCR-Tests gültig sein.</li></ul>",
                             "Ist Ihr Zertifikat technisch noch gültig, wurde es offenbar von einer nicht autorisierten Stelle oder fehlerhaft ausgestellt. In diesem Fall bitten wir Sie, sich an die <a href='#international_phone_numbers' target='_blank' rel='noopener noreferrer'>technische Hotline</a> zu wenden und uns mitzuteilen, wann und von welcher Stelle dieses Zertifikat ausgestellt wurde. Dann lassen Sie sich bitte ein neues Zertifikat mit gültiger Signatur von einer autorisierten Stelle ausstellen."
                         ]
+                    },
+                    {
+                        "title": "Wie erstelle ich einen Ausdruck meines Digitalen COVID Zertifikates der EU?",
+                        "anchor": "eu_dcc_export",
+                        "active": true,
+                        "textblock": [
+                            "<b>Zweck</b>",
+                            "Ab der Version 2.10 der Corona-Warn-App können Sie eingescannte Digitale COVID Zertifikate der EU in PDF-Dokumente exportieren. Diese Funktion dient vorrangig der Erstellung von Sicherheitskopien der Zertifikate für Ihre persönlichen Zwecke",
+                            "Selbstverständlich werden für das Layout der Zertifikate die Original-EU-Vorlagen benutzt.",
+                            "<b>Sicherheitshinweise</b>",
+                            "Der Export und die Speicherung der Zertifikate sind freiwillig. Das Erstellen der PDF-Datei findet ausschließlich lokal auf Ihrem Smartphone statt. Nur Sie selbst haben Zugriff auf dieses Dokument.",
+                            "Beachten Sie aber, dass das erzeugte Dokument sensible persönliche Informationen enthält. Gehen Sie daher bitte sorgsam mit der PDF-Datei um. Zeigen Sie das Dokument nur solchen Personen vor, denen Sie vertrauen und die zur Prüfung auch berechtigt sind.",
+                            "Wir raten dringend davon ab, das PDF-Dokument zu veröffentlichen über potentiell unsichere Kanäle (z.B. per E-Mail oder über andere Apps) zu teilen.",
+                            "<b>Limitierung</b>",
+                            "Mit der neuen Funktion können nur PDF-Dokumente von Zertifikaten erzeugt werden, die auch in Deutschland ausgestellt wurden. Ansonsten erscheint eine ausführliche Meldung: 'Druckversion anzeigen nicht möglich - Die Druckversion des Zertifikats kann nicht angezeigt werden, da das Zertifikat nicht in Deutschland ausgestellt wurde.'",
+                            "<b>Anwendung</b>",
+                            "Nach dem erfolgreichen Export des Zertifikates in das PDF-Dokument können Sie entscheiden, ob Sie es auf Ihrem Smartphone speichern, in andere Apps importieren oder drucken möchten. Dazu nutzen Sie bitte die Standard-Funktionen des Betriebssystems.",
+                            "<b>Schritt-für-Schritt-Anleitung:</b>",
+                            "Um einen Ausdruck Ihres Digitalen COVID Zertifikates der EU zu erstellen, gehen Sie bitte folgendermaßen vor: <ul><li>Klicken Sie auf den „Zertifikate“-Reiter in der Corona-Warn-App</li><li>Wählen Sie eine Person aus, indem Sie in der Zertifikate-Übersicht auf ein entsprechendes Zertifikat klicken</li><Scrollen Sie nach unten und wählen Sie ein Zertifikat dieser Person aus</li><li>In dieser Detailansicht klicken Sie oben rechts auf das Drei-Punkte-Menü (Android) beziehungsweise unten auf „Mehr“ (iOS)</li><li>Klicken Sie auf „Druckversion anzeigen“</li><Klicken Sie auf „Druckversion anzeigen“</li><li>Klicken Sie oben rechts auf das Symbol für “Drucken” oder für “Teilen”</li><li>In der folgenden Ansicht können Sie das erstellte PDF-Dokument mit den Standardfunktionen des Betriebssystems drucken, in andere Apps importieren oder auch teilen</li>"
+                        ]
                     }
                 ]
             },
@@ -213,7 +233,8 @@
                         "anchor": "test_cert_why",
                         "active": true,
                         "textblock": [
-                            "Ab der Version 2.4 der Corona-Warn-App (CWA) können Sie ein digitales Testzertifikat über die App anfordern. Durch die neue Funktion haben Sie die Möglichkeit, Ihr negatives Testergebnis durch ein offizielles, digitales COVID-Testzertifikat in Form eines QR-Codes in der CWA nachzuweisen. Innerhalb der Länder der Europäischen Union kann es als offiziell gültiger Nachweis eines negativen Testergebnisses dienen, den Sie beispielsweise für Reisen nutzen können oder in anderen gesetzlich vorgeschriebenen Fällen, wie z.&nbsp;B. einem Restaurantbesuch. Sie können dann den QR-Code in der CWA vorzeigen."
+                            "Ab der Version 2.4 der Corona-Warn-App (CWA) können Sie ein digitales Testzertifikat über die App anfordern. Durch die neue Funktion haben Sie die Möglichkeit, Ihr negatives Testergebnis durch ein offizielles, digitales COVID-Testzertifikat in Form eines QR-Codes in der CWA nachzuweisen. Innerhalb der Länder der Europäischen Union kann es als offiziell gültiger Nachweis eines negativen Testergebnisses dienen, den Sie beispielsweise für Reisen nutzen können oder in anderen gesetzlich vorgeschriebenen Fällen, wie z.&nbsp;B. einem Restaurantbesuch. Sie können dann den QR-Code in der CWA vorzeigen.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis des Testzertifikats</a>"
                         ]
                     },
                     {
@@ -221,7 +242,8 @@
                         "anchor": "test_cert_get",
                         "active": true,
                         "textblock": [
-                            "Das Zertifikat können Sie anfordern, indem Sie einen Test in der Corona-Warn-App (CWA) registrieren: Dazu können Sie auf der Startseite Ihrer CWA auf 'Sie lassen sich testen?' tippen (bzw. auf 'Test registrieren' in App-Versionen bis 2.5 tippen) und dann auf 'QR-Code scannen'. Nachdem Sie den QR-Code zur Test-Registrierung gescannt haben, öffnet sich automatisch das Fenster zum COVID-Testzertifikat. Dort können Sie das 'Testzertifikat anfordern' oder ablehnen, falls Sie keins erhalten möchten."
+                            "Das Zertifikat können Sie anfordern, indem Sie einen Test in der Corona-Warn-App (CWA) registrieren: Dazu können Sie auf der Startseite Ihrer CWA auf 'Sie lassen sich testen?' tippen (bzw. auf 'Test registrieren' in App-Versionen bis 2.5 tippen) und dann auf 'QR-Code scannen'. Nachdem Sie den QR-Code zur Test-Registrierung gescannt haben, öffnet sich automatisch das Fenster zum COVID-Testzertifikat. Dort können Sie das 'Testzertifikat anfordern' oder ablehnen, falls Sie keins erhalten möchten.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis des Testzertifikats</a>"
                         ]
                     },
                     {
@@ -231,7 +253,8 @@
                         "textblock": [
                             "Sie können sowohl für PCR- als auch für Schnelltests ein Zertifikat anfordern, das dann bei einem negativen Test ausgestellt wird.",
                             "<b>Schnelltests</b><br>Bei Schnelltests kann es sein, dass die jeweilige Teststelle das digitale Zertifikat nicht unterstützt. In diesem Fall werden Sie nach dem Scannen des QR-Codes nicht zum Beantragen des Zertifikats weitergeleitet. Sie erhalten im Anschluss die Information, dass ein Testzertifikat nicht angefordert werden kann, da die Teststelle die Ausstellung von Testzertifikaten nicht unterstützt.",
-                            "<b>PCR-Tests</b><br>Bei der Anforderung eines Testzertifikats für einen PCR-Test müssen Sie Ihr Geburtsdatum angeben. Dabei ist wichtig, dass das Geburtsdatum mit dem übereinstimmt, das auch beim Abstrich für den PCR-Test angegeben wurde. Sollten die Geburtsdaten nicht übereinstimmen, beispielsweise aufgrund eines Tippfehlers, bekommen Sie weder das Testergebnis noch das Zertifikat über die App. Sie können das Geburtsdatum, das Sie in der App eintragen, nachträglich nicht mehr ändern. Bevor Sie das Testzertifikat nach der Eingabe des Datums anfordern, sollten Sie deshalb kurz überprüfen, ob das Datum auch wirklich korrekt ist."
+                            "<b>PCR-Tests</b><br>Bei der Anforderung eines Testzertifikats für einen PCR-Test müssen Sie Ihr Geburtsdatum angeben. Dabei ist wichtig, dass das Geburtsdatum mit dem übereinstimmt, das auch beim Abstrich für den PCR-Test angegeben wurde. Sollten die Geburtsdaten nicht übereinstimmen, beispielsweise aufgrund eines Tippfehlers, bekommen Sie weder das Testergebnis noch das Zertifikat über die App. Sie können das Geburtsdatum, das Sie in der App eintragen, nachträglich nicht mehr ändern. Bevor Sie das Testzertifikat nach der Eingabe des Datums anfordern, sollten Sie deshalb kurz überprüfen, ob das Datum auch wirklich korrekt ist.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis des Testzertifikats</a>"
                         ]
                     },
                     {
@@ -239,7 +262,8 @@
                         "anchor": "test_cert_when_and_where",
                         "active": true,
                         "textblock": [
-                            "Kurz nachdem das Testergebnis in der App vorliegt, erhalten Sie auch Ihr Testzertifikat in der App - vorausgesetzt, Sie haben es vorher angefordert und die jeweilige Schnellteststelle unterstützt die Erstellung eines Zertifikats. Sie können es dann über den Reiter 'Zertifikate' in Ihrer Registerkarte einsehen. Tippen Sie auf das COVID-Testzertifikat, wird Ihnen der QR-Code angezeigt, der zur Überprüfung gescannt werden kann, und weitere Informationen, wie Art des Tests, Datum und Uhrzeit der Durchführung und Testergebnis."
+                            "Kurz nachdem das Testergebnis in der App vorliegt, erhalten Sie auch Ihr Testzertifikat in der App - vorausgesetzt, Sie haben es vorher angefordert und die jeweilige Schnellteststelle unterstützt die Erstellung eines Zertifikats. Sie können es dann über den Reiter 'Zertifikate' in Ihrer Registerkarte einsehen. Tippen Sie auf das COVID-Testzertifikat, wird Ihnen der QR-Code angezeigt, der zur Überprüfung gescannt werden kann, und weitere Informationen, wie Art des Tests, Datum und Uhrzeit der Durchführung und Testergebnis.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis des Testzertifikats</a>"
                         ]
                     },
                     {
@@ -247,7 +271,8 @@
                         "anchor": "test_cert_validity",
                         "active": true,
                         "textblock": [
-                            "Wie lange das Zertifikat gültig ist, hängt von den Bestimmungen des jeweiligen Bundeslandes oder der Kommune ab."
+                            "Wie lange das Zertifikat gültig ist, hängt von den Bestimmungen des jeweiligen Bundeslandes oder der Kommune ab.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis des Testzertifikats</a>"
                         ]
                     },
                     {
@@ -256,7 +281,8 @@
                         "active": true,
                         "textblock": [
                             "Zur Erstellung des Testzertifikats werden die Daten Ende-zu-Ende verschlüsselt und vom Labor, beziehungsweise der Schnellteststelle an die Corona-Warn-App übermittelt. Dafür werden die verschlüsselten Daten an das Robert Koch-Institut (RKI) übermittelt, um sie digital zu signieren und so die Gültigkeit des Zertifikats zu bestätigen. Die Daten können vom RKI nicht entschlüsselt werden und werden nach Zustellung des Zertifikats gelöscht.",
-                            "Testzertifikate werden unbefristet in der App gespeichert. Sie können Zertifikate manuell löschen, indem Sie auf den Reiter 'Zertifikate' gehen, das jeweilige Testzertifikat auswählen und dann 'Testzertifikat entfernen' auswählen."
+                            "Testzertifikate werden unbefristet in der App gespeichert. Sie können Zertifikate manuell löschen, indem Sie auf den Reiter 'Zertifikate' gehen, das jeweilige Testzertifikat auswählen und dann 'Testzertifikat entfernen' auswählen.",
+                            "<a href='#test_cert_index' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis des Testzertifikats</a>"
                         ]
                     }
                 ]
@@ -272,6 +298,16 @@
                         "textblock": [
                             "<ul>",
                             "<li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>Kann ich Impfzertifikate auf mehreren Smartphones speichern, z.&nbsp;B. auf meinem Privat- und dem Geschäftshandy?</a></li><li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>Wie kann ich Impfbescheinigungen beim Gerätewechsel übertragen?</a></li><li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>Was mache ich, wenn ich mein Smartphone verloren habe?</a></li><li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>Sind Impfzertifikate in meinem Backup enthalten?</a></li><li><a href='#vac_cert_multiple_scan_possible' target='_self' rel='noopener noreferrer'>Kann ich Zertifikate in der Corona-Warn-App und der CovPass-App gleichzeitig verwalten, oder muss ich mich für eine der beiden Apps entscheiden?</a></li>",
+                            "</ul>"
+                        ]
+                    },
+                    {
+                        "title": "Fragen und Antworten zur Auffrischungsimpfung",
+                        "anchor": "eu_dcc_booster",
+                        "active": "true",
+                        "textblock": [
+                            "<ul>",
+                            "<li><a href='#vac_cert_booster_info' target='_self' rel='noopener noreferrer'>Wie erfahre ich von Auffrischungsimpfungen im Kontext von Corona?</a></li><li><a href='#vac_cert_booster_cwa' target='_self' rel='noopener noreferrer'>Wie verwalte ich Auffrischungsimpfungen in der CWA?</a></li>",
                             "</ul>"
                         ]
                     },
@@ -341,7 +377,8 @@
                         "textblock": [
                             "Durch die Gesundheitsminister-Konferenz wurde inzwischen die Regelung zu COVID-19-Auffrischimpfungen beschlossen. Eine zusätzliche Auffrischimpfung soll helfen, die neutralisierenden Antikörpertiter wieder zu erhöhen, die nach der Grundimmunisierung mit der Zeit absinken können. Das gilt insbesondere bei den Personengruppen, bei denen nach einer Grundimmunisierung eine gedämpfte Impfantwort vermutet oder erkannt wird.",
                             "Die Corona-Warn-App wird darauf hinweisen, eine Auffrischimpfung in Betracht zu ziehen, falls bestimmte Bedingungen erfüllt sind. Diese Bedingungen basieren auf den Empfehlungen der Paul-Ehrlich-Instituts sowie der Ständigen Impfkommission (STIKO) des Robert Koch-Instituts (RKI).",
-                            "Wie lange jemand durch eine COVID-19-Impfung (Grundimmunisierung) tatsächlich geschützt ist, hängt von verschiedenen Faktoren ab und lässt sich daher nach heutigem Kenntnisstand nicht pauschal beantworten. Deswegen werden die entsprechenden Regeln für Impfschemata und Auffrischimpfungen in der Corona-Warn-App in Abstimmung mit dem RKI entsprechend den Entwicklungen und neuen Erkenntnissen fortlaufend überprüft und angepasst."
+                            "Wie lange jemand durch eine COVID-19-Impfung (Grundimmunisierung) tatsächlich geschützt ist, hängt von verschiedenen Faktoren ab und lässt sich daher nach heutigem Kenntnisstand nicht pauschal beantworten. Deswegen werden die entsprechenden Regeln für Impfschemata und Auffrischimpfungen in der Corona-Warn-App in Abstimmung mit dem RKI entsprechend den Entwicklungen und neuen Erkenntnissen fortlaufend überprüft und angepasst.",
+                            "<a href='#eu_dcc_booster' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis der Auffrischungsimpfung</a>"
                         ]
                     },
                     {
@@ -351,7 +388,8 @@
                         "textblock": [
                             "In einem der kommenden Releases unterstützt die Corona-Warn-App auch den Import von Zertifikaten, die eine Auffrischimpfung dokumentieren.",
                             "Die Anwender erhalten dazu einen Hinweis, ggf. eine Auffrischimpfung in Betracht zu ziehen. Der Hinweis basiert auf nationalen Regeln, die in Absprache mit dem Robert Koch-Institut (RKI) implementiert wurden. Diese Regeln werden fortlaufend geprüft und entsprechend den Entwicklungen und neuen Erkenntnissen angepasst.",
-                            "Bitte beachten Sie: Das Zertifikat zur Auffrischungsimpfung ist nur gültig, wenn Sie auch die nötige Grundimmunisierung durch das entsprechende letzte Zertifikat der Impfreihe nachweisen können. Löschen Sie bitte die anderen Impfzertifikate nicht aus der CWA! Da bisher noch keine einheitlichen EU-Standards zu diesem Thema festgelegt wurden, sollte man insbesondere bei Reisen ins Ausland auch die Zertifikate der Grundimmunisierung mit sich führen, sei es in der CWA, als PDF, oder als Papierausdruck. Wir empfehlen daher alle Impfzertifikate in der App zu behalten, auch wenn diese nicht mehr aktuell sind."
+                            "Bitte beachten Sie: Das Zertifikat zur Auffrischungsimpfung ist nur gültig, wenn Sie auch die nötige Grundimmunisierung durch das entsprechende letzte Zertifikat der Impfreihe nachweisen können. Löschen Sie bitte die anderen Impfzertifikate nicht aus der CWA! Da bisher noch keine einheitlichen EU-Standards zu diesem Thema festgelegt wurden, sollte man insbesondere bei Reisen ins Ausland auch die Zertifikate der Grundimmunisierung mit sich führen, sei es in der CWA, als PDF, oder als Papierausdruck. Wir empfehlen daher alle Impfzertifikate in der App zu behalten, auch wenn diese nicht mehr aktuell sind.",
+                            "<a href='#eu_dcc_booster' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis der Auffrischungsimpfung</a>"
                         ]
                     },
                     {
@@ -407,7 +445,8 @@
                         "anchor": "vac_cert_multiple_scan_possible",
                         "active": true,
                         "textblock": [
-                            "Es gibt keine Begrenzung, wie oft Sie den QR-Code eines Impfzertifikats scannen können. Indem Sie den QR-Code scannen, können Sie Impfzertifikate hinzufügen und verwalten: <ul><li>auf mehreren Geräten, </li><li>auf einem neuen Gerät, wenn Sie das Gerät wechseln</li><li>in mehreren Apps, z.&nbsp;B. in der Corona-Warn-App und der CovPass-App</li><li>auf einem zurückgesetzten Gerät. Zertifikate sind nicht in der Sicherung (Backup) enthalten.</li></ul>"
+                            "Es gibt keine Begrenzung, wie oft Sie den QR-Code eines Impfzertifikats scannen können. Indem Sie den QR-Code scannen, können Sie Impfzertifikate hinzufügen und verwalten: <ul><li>auf mehreren Geräten, </li><li>auf einem neuen Gerät, wenn Sie das Gerät wechseln</li><li>in mehreren Apps, z.&nbsp;B. in der Corona-Warn-App und der CovPass-App</li><li>auf einem zurückgesetzten Gerät. Zertifikate sind nicht in der Sicherung (Backup) enthalten.</li></ul>",
+                            "<a href='#vac_cert_index' target='_self' rel='noopener noreferrer'>Zum Inhaltsverzeichnis des Impfzertifikats</a>"
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -205,7 +205,7 @@
                             "<b>Sicherheitshinweise</b>",
                             "Der Export und die Speicherung der Zertifikate sind freiwillig. Das Erstellen der PDF-Datei findet ausschließlich lokal auf Ihrem Smartphone statt. Nur Sie selbst haben Zugriff auf dieses Dokument.",
                             "Beachten Sie aber, dass das erzeugte Dokument sensible persönliche Informationen enthält. Gehen Sie daher bitte sorgsam mit der PDF-Datei um. Zeigen Sie das Dokument nur solchen Personen vor, denen Sie vertrauen und die zur Prüfung auch berechtigt sind.",
-                            "Wir raten dringend davon ab, das PDF-Dokument zu veröffentlichen über potentiell unsichere Kanäle (z.B. per E-Mail oder über andere Apps) zu teilen.",
+                            "Wir raten dringend davon ab, das PDF-Dokument zu veröffentlichen über potentiell unsichere Kanäle (z.&nbsp;B. per E-Mail oder über andere Apps) zu teilen.",
                             "<b>Limitierung</b>",
                             "Mit der neuen Funktion können nur PDF-Dokumente von Zertifikaten erzeugt werden, die auch in Deutschland ausgestellt wurden. Ansonsten erscheint eine ausführliche Meldung: 'Druckversion anzeigen nicht möglich - Die Druckversion des Zertifikats kann nicht angezeigt werden, da das Zertifikat nicht in Deutschland ausgestellt wurde.'",
                             "<b>Anwendung</b>",


### PR DESCRIPTION
As a response to these issues ([Create FAQ eu_dcc_booster #1735](https://github.com/corona-warn-app/cwa-website/issues/1735), [Create FAQ eu_dcc_export #1645](https://github.com/corona-warn-app/cwa-website/issues/1645)), here's the pull request to add both faq entries for the upcoming release 2.10. While creating the index for eu_dcc_booster, I've stumbled upon missing index links in test certificate faq entries, and have added them in this commit too. Times mentioned in vac_cert_booster_cwa have also been adjusted.

eu_dcc_export: 
DE:
![image](https://user-images.githubusercontent.com/88365935/133441340-d0833bb8-35ae-4430-b11c-c3f0a118ff73.png)
EN:
![image](https://user-images.githubusercontent.com/88365935/133441290-94b770ae-3aaa-4c02-8a0e-affb21c0dc65.png)

vac_cert_booster (used to be named eu_dcc_booster):
DE:
![image](https://user-images.githubusercontent.com/88365935/133441392-beac2cc0-9444-4d92-92a5-46dc0d9b3b78.png)
EN:
![image](https://user-images.githubusercontent.com/88365935/133441226-62e55c2b-9d41-4147-bf92-1e13cc7888f5.png)

vac_cert_booster_cwa:
DE:
![image](https://user-images.githubusercontent.com/88365935/133441100-23f6673e-1c3b-408b-8c98-32adadd0ebd2.png)
EN:
![image](https://user-images.githubusercontent.com/88365935/133441164-48a5faae-bac5-499c-ae63-60dcd46ba83c.png)

---
Internal Tracking ID: [EXPOSUREAPP-](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-)
Internal Tracking ID: [EXPOSUREAPP-](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-)
