### PR TITLE
Bump current iOS app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -354,7 +354,7 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '14.8'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.9.0'))
+    .pipe(replace('[ios.current-app-version]', '2.9.1'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '2.9.0'))


### PR DESCRIPTION
This PR bumps the current iOS app version from 2.9.0 to 2.9.1.

---

GitHub Release: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v2.9.1