### PR TITLE
Capitalize English screenshot headings (closes #1740)

### DIFF
--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -89,7 +89,7 @@
                 ]
             },
             {
-                "title": "Test registration & Key sharing",
+                "title": "Test Registration & Key Sharing",
                 "anchor": "android_registertest",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/android/SubmissionDispatcherFragment", "alt": "Test registration & Key sharing image 1 of 10" },
@@ -105,7 +105,7 @@
                 ]
             },
             {
-                "title": "Warn for others",
+                "title": "Warn for Others",
                 "anchor": "android_warn_for_others",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/android/TestCertificateDetailsFragment", "alt": "Warn for others image 1 of 6" },
@@ -128,7 +128,7 @@
                 ]
             },
             {
-                "title": "Rapid antigen test",
+                "title": "Rapid Antigen Test",
                 "anchor": "android_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
@@ -184,7 +184,7 @@
                         ]
               },
               {
-                  "title": "Check certificates for validity before a trip",
+                  "title": "Check Certificates for Validity Before a Trip",
                   "anchor": "android_check_validity_certificate",
                   "images": [
                       { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-screenshot_first_vaccination_certificate_details_part1", "alt": "Certificate check image 1 of 4" },
@@ -194,7 +194,7 @@
                   ]
               },
               {
-                  "title": "Invalid certificates",
+                  "title": "Invalid Certificates",
                   "anchor": "android_invalid_certificate",
                   "images": [
                       { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-screenshot_recovery_certificate_overview_part1", "alt": "Invalid certificate image 1 of 3" },
@@ -244,7 +244,7 @@
                 ]
             },
             {
-                "title": "Check In - Scan QR code",
+                "title": "Check In - Scan QR Code",
                 "anchor": "ios_check_in",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-event_checkin_004_mycheckins_emptyList", "alt": "Check In image 1 of 6" },
@@ -256,7 +256,7 @@
                 ]
             },
             {
-                "title": "Check In - Create QR code",
+                "title": "Check In - Create QR Code",
                 "anchor": "ios_check_in_create_event",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-traceLocation_004_emptyList", "alt": "Check In image 1 of 8" },
@@ -287,7 +287,7 @@
                 ]
             },
             {
-                "title": "Test registration & Key sharing",
+                "title": "Test Registration & Key Sharing",
                 "anchor": "ios_registertest",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-tan_submissionflow_qr_0002", "alt": "Test registration & Key sharing image 1 of 9" },
@@ -302,7 +302,7 @@
                 ]
             },
             {
-                "title": "Warn for others",
+                "title": "Warn for Others",
                 "anchor": "ios_warn_for_others",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-onbehalfwarning_info", "alt": "Warn for others image 1 of 6" },
@@ -314,7 +314,7 @@
                 ]
             },
             {
-                "title": "Test result home",
+                "title": "Test Result Home",
                 "anchor": "ios_results",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-homescreenrisk_show_pending_test_result_0001", "alt": "Test result home image 1 of 4" },
@@ -324,7 +324,7 @@
                 ]
             },
             {
-                "title": "Rapid antigen test",
+                "title": "Rapid Antigen Test",
                 "anchor": "ios_rat",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/ios/rat_1", "alt": "Rapid antigen test image 1 of 10" },
@@ -379,7 +379,7 @@
                 ]
             },
             {
-                "title": "Check certificates for validity before a trip",
+                "title": "Check Certificates for Validity Before a Trip",
                 "anchor": "ios_check_validity_certificate",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-screenshot_first_vaccination_certificate_details_part1", "alt": "Certificate check image 1 of 4" },
@@ -389,7 +389,7 @@
                 ]
             },
             {
-                "title": "Invalid certificates",
+                "title": "Invalid Certificates",
                 "anchor": "ios_invalid_certificate",
                 "images": [
                     { "filename": "/assets/screenshots/2-9/en/ios/iPhone 11 Pro-screenshot_recovery_certificate_overview_part1", "alt": "Invalid certificate image 1 of 3" },


### PR DESCRIPTION
This PR sets the screenshot headings for the current CWA version 2.9 in English and for iOS and Android consistently to title case. It resolves issue #1740.

It does **not** change any archived screenshot versions.