### PR TITLE
Screenshots page update and remove space on FAQ's left menu

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -352,7 +352,7 @@ function createFaqRedirects() {
 function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html"])
-    .pipe(replace('[ios.latest-os-version]', '14.8'))
+    .pipe(replace('[ios.latest-os-version]', '15.0'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.9.1'))
     .pipe(replace('[android.latest-os-version]', '11'))

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -238,6 +238,10 @@ $(document).ready(function(){
 
         //Toggle target tab
         $($(this).attr('href')).addClass('show active').siblings().removeClass('show active');
+
+        //Keep selected on refresh
+        if(window.location.href.includes("#")) window.location.href = window.location.href.split("#")[0]+=$(this).attr('href');           
+        else window.location.href += $(this).attr('href');
       });
 
       // glossary links onclick handler

--- a/src/assets/js/screenshots.js
+++ b/src/assets/js/screenshots.js
@@ -2,6 +2,17 @@ import $ from 'jquery';
 
 window.jQuery = $;
 
+//Sets the option selected according to the version of the application being consulted
+$(document).ready(function() {
+    const version = window.location.pathname.split(".")[0].split("/")[3].replace("-", ".");
+    if(version == '') $('select[name="archived-screenshots"]').children().last().attr('selected','selected');
+    else {
+        $('select[name="archived-screenshots"]').children().each(function( index ) {
+            if(version == $(this).text()) $(this).attr('selected','selected');
+        });
+    }
+});
+
 // Screenshots screen: redirect to selected option's value after changing version in dropdown
 $('select[name="archived-screenshots"]').on("change", function(e) {
     window.location.href = e.target.value;

--- a/src/assets/js/screenshots.js
+++ b/src/assets/js/screenshots.js
@@ -18,6 +18,23 @@ $('select[name="archived-screenshots"]').on("change", function(e) {
     window.location.href = e.target.value + window.location.hash;
 });
 
+// Show/hide menu after changing OS tabs
+$('a.nav-link').on("click", function(e) {
+    const { hash } = window.location;
+    const hashDevice = hash.replace("#", "").split("_")[0]
+    const androidMenu = document.querySelector('#android_menu')
+    const iosMenu = document.querySelector('#ios_menu')
+    if (hashDevice === "android") {
+        // Show/hide menu
+        androidMenu.remove("d-none")
+        iosMenu.add("d-none")
+    } else {
+        // Show/hide menu
+        androidMenu.add("d-none")
+        iosMenu.remove("d-none")
+    }
+});
+
 //   Add feature for tag auto-navigation with hash in the URL
 const scrollTo = (hash) => {
     location.hash = hash;
@@ -27,6 +44,8 @@ const scrollTo = (hash) => {
 const checkHashAndChangeTab = () => {
     const { hash } = window.location;
     const hashDevice = hash.replace("#", "").split("_")[0]
+    const androidMenu = document.querySelector('ul #android')
+    const iosMenu = document.querySelector('ul #ios')
     const androidTab = document.querySelector('[href="#android_screenshots"]')
     const iosTab = document.querySelector('[href="#ios_screenshots"]')
     const androidContent = document.querySelector("#android_screenshots")
@@ -39,6 +58,9 @@ const checkHashAndChangeTab = () => {
         // Show/hide content
         iosContent.classList.remove(...contentClasses)
         androidContent.classList.add(...contentClasses)
+        // Show/hide menu
+        androidMenu.remove("d-none")
+        iosMenu.add("d-none")
         scrollTo(hash)
     } else {
         // Put tabs correctly
@@ -47,6 +69,9 @@ const checkHashAndChangeTab = () => {
         // Show/hide content
         androidContent.classList.remove(...contentClasses)
         iosContent.classList.add(...contentClasses)
+        // Show/hide menu
+        androidMenu.add("d-none")
+        iosMenu.remove("d-none")
         scrollTo(hash)
     }
 }

--- a/src/assets/js/screenshots.js
+++ b/src/assets/js/screenshots.js
@@ -15,7 +15,7 @@ $(document).ready(function() {
 
 // Screenshots screen: redirect to selected option's value after changing version in dropdown
 $('select[name="archived-screenshots"]').on("change", function(e) {
-    window.location.href = e.target.value;
+    window.location.href = e.target.value + window.location.hash;
 });
 
 //   Add feature for tag auto-navigation with hash in the URL

--- a/src/assets/js/screenshots.js
+++ b/src/assets/js/screenshots.js
@@ -8,7 +8,7 @@ $(document).ready(function() {
     if(version == '') $('select[name="archived-screenshots"]').children().last().attr('selected','selected');
     else {
         $('select[name="archived-screenshots"]').children().each(function( index ) {
-            if(version == $(this).text()) $(this).attr('selected','selected');
+            if(version == $(this).text().split(" ")[1]) $(this).attr('selected','selected');
         });
     }
 });
@@ -19,19 +19,21 @@ $('select[name="archived-screenshots"]').on("change", function(e) {
 });
 
 // Show/hide menu after changing OS tabs
-$('a.nav-link').on("click", function(e) {
+$('.nav-tabs a').on("click", function(e) {
+    if(window.location.href.includes("#")) window.location.href = window.location.href.split("#")[0]+=$(this).attr('href');           
+    else window.location.href += $(this).attr('href');
     const { hash } = window.location;
-    const hashDevice = hash.replace("#", "").split("_")[0]
+    const hashDevice = hash != "" ? hash.replace("#", "").split("_")[0] : "ios";
     const androidMenu = document.querySelector('#android_menu')
     const iosMenu = document.querySelector('#ios_menu')
     if (hashDevice === "android") {
         // Show/hide menu
-        androidMenu.remove("d-none")
-        iosMenu.add("d-none")
+        androidMenu.classList.remove("d-none")
+        iosMenu.classList.add("d-none")
     } else {
         // Show/hide menu
-        androidMenu.add("d-none")
-        iosMenu.remove("d-none")
+        androidMenu.classList.add("d-none")
+        iosMenu.classList.remove("d-none")
     }
 });
 
@@ -44,8 +46,8 @@ const scrollTo = (hash) => {
 const checkHashAndChangeTab = () => {
     const { hash } = window.location;
     const hashDevice = hash.replace("#", "").split("_")[0]
-    const androidMenu = document.querySelector('ul #android')
-    const iosMenu = document.querySelector('ul #ios')
+    const androidMenu = document.querySelector('#android_menu')
+    const iosMenu = document.querySelector('#ios_menu')
     const androidTab = document.querySelector('[href="#android_screenshots"]')
     const iosTab = document.querySelector('[href="#ios_screenshots"]')
     const androidContent = document.querySelector("#android_screenshots")
@@ -59,8 +61,8 @@ const checkHashAndChangeTab = () => {
         iosContent.classList.remove(...contentClasses)
         androidContent.classList.add(...contentClasses)
         // Show/hide menu
-        androidMenu.remove("d-none")
-        iosMenu.add("d-none")
+        androidMenu.classList.remove("d-none")
+        iosMenu.classList.add("d-none")
         scrollTo(hash)
     } else {
         // Put tabs correctly
@@ -70,8 +72,8 @@ const checkHashAndChangeTab = () => {
         androidContent.classList.remove(...contentClasses)
         iosContent.classList.add(...contentClasses)
         // Show/hide menu
-        androidMenu.add("d-none")
-        iosMenu.remove("d-none")
+        androidMenu.classList.add("d-none")
+        iosMenu.classList.remove("d-none")
         scrollTo(hash)
     }
 }

--- a/src/assets/scss/_box.scss
+++ b/src/assets/scss/_box.scss
@@ -335,6 +335,9 @@ p:not([class]) + .btn {
             }
         }
         
+        .nav-link-left-menu {
+            padding: .1rem 1rem;
+        }
     }
 
     .main {

--- a/src/data/global.json
+++ b/src/data/global.json
@@ -25,10 +25,6 @@
         }
     },
     "screenshots": {
-        "archive-placeholder": {
-            "de": "Versionen",
-            "en": "Versions"
-        },
         "anchorText": {
             "de": "Link zu dieser Sektion",
             "en": "Link to this section"
@@ -39,35 +35,35 @@
         },
         "archive-dropdown": [
             {
-                "version": "2.2",
+                "version": "Version 2.2",
                 "link": "/screenshots-archive/2-2.html"
             },
             {
-                "version": "2.3",
+                "version": "Version 2.3",
                 "link": "/screenshots-archive/2-3.html"
             },
             {
-                "version": "2.4",
+                "version": "Version 2.4",
                 "link": "/screenshots-archive/2-4.html"
             },
             {
-                "version": "2.5",
+                "version": "Version 2.5",
                 "link": "/screenshots-archive/2-5.html"
             },
             {
-                "version": "2.6",
+                "version": "Version 2.6",
                 "link": "/screenshots-archive/2-6.html"
             },
             {
-                "version": "2.7",
+                "version": "Version 2.7",
                 "link": "/screenshots-archive/2-7.html"
             },
             {
-                "version": "2.8",
+                "version": "Version 2.8",
                 "link": "/screenshots-archive/2-8.html"
             },
             {
-                "version": "2.9",
+                "version": "Version 2.9",
                 "link": "/screenshots"
             }
         ]

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -5,7 +5,7 @@
     <ul class="nav flex-column js-scroll-navigate" data-target="main">
       {{#each page-contents.section-main.sections}}
       <li class="nav-item">
-        <a class="nav-link{{#if active}} active{{/if}}"{{#if id}} href="#{{id}}"{{/if}}>{{{title}}}</a>
+        <a class="nav-link nav-link-left-menu{{#if active}} active{{/if}}"{{#if id}} href="#{{id}}"{{/if}}>{{{title}}}</a>
       </li>
       {{/each}}
     </ul>

--- a/src/partials/page-screenshots.html
+++ b/src/partials/page-screenshots.html
@@ -1,24 +1,36 @@
 {{#if page-contents}}
 <script src="/assets/js/lazyload.js"></script>
 <section class="section">
-    <div class="container">
-        <div class="container-inner container-inner_lg">
-            <div class="row">
-                <div class="col ">
-                {{> headline-component page-contents.section-main.headline}}
-                {{> text-component page-contents.section-main.content}}
-                </div>
-            </div>
+    <div class="container container_flex">
+        <aside class="side-menu js-menu" id="side-menu">
+            <div class="menu-close"><button class="btn btn-close js-toggle" data-target="#side-menu"></button></div>
+            <ul id="ios_menu" class="nav flex-column js-scroll-navigate" data-target="main">
+              {{#each page-contents.ios-screenshots.sections}}
+              <li class="nav-item">
+                <a class="nav-link nav-link-left-menu{{#if active}} active{{/if}}"{{#if anchor}} href="#{{anchor}}"{{/if}}>{{{title}}}</a>
+              </li>
+              {{/each}}
+            </ul>
+
+            <ul id="android_menu" class="nav flex-column js-scroll-navigate" data-target="main">
+                {{#each page-contents.android-screenshots.sections}}
+                <li class="nav-item">
+                  <a class="nav-link nav-link-left-menu{{#if active}} active{{/if}}"{{#if anchor}} href="#{{anchor}}"{{/if}}>{{{title}}}</a>
+                </li>
+                {{/each}}
+              </ul>
+        </aside>
+        <main class="main">
+            {{> headline-component page-contents.section-main.headline}}
+            {{> text-component page-contents.section-main.content}}
 
             <div class="d-flex justify-content-sm-end position-relative mb-3 mb-sm-0">
                 <select name="archived-screenshots" class="form-select form-select-sm w-auto position-sm-absolute">
                     {{#if lang_de}}
-                        <option value="">{{global.screenshots.archive-placeholder.de}}</option>
                         {{#each global.screenshots.archive-dropdown}}
                             <option value="/de{{link}}" >{{version}}</option>
                         {{/each}}
                     {{else}}
-                        <option value="">{{global.screenshots.archive-placeholder.en}}</option>
                         {{#each global.screenshots.archive-dropdown}}
                             <option value="/en{{link}}">{{version}}</option>
                         {{/each}}
@@ -100,7 +112,7 @@
                 {{/each}}
                 </div>
             </div>
-        </div>
+        </main>
     </div>
 </section>
 {{/if}}


### PR DESCRIPTION
In this update I had work on the next features:

**app.js**

- On jQuery tabs function, add anchor link to keep it on refresh

**screenshots.js**

- On option input now appears the version that the user is consulting
- Keep tab selected on refresh or change version clicking of version option
- Left menu switchable on change OS tab

**_box.scss**

- Created new class 'nav-link-left-menu' to remove space between options on left side menu in Screenshots and FAQ pages

**global.json**

- Remove option 'Version' for DE and EN, now it is not necessary
- Added tag 'Version' to every version

**page-faq.html**

- Added class 'nav-link-left-menu' to remove space between left side options menu

**page-screenshots.html**

- Added left side menu