### PR TITLE
Add note reg. free of charge PCR test to the FAQ entry `rat_red_card_which_test`

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -557,7 +557,8 @@
                         "anchor": "rat_red_card_which_test",
                         "active": true,
                         "textblock": [
-                            "If the Corona-Warn-App shows you an encounter with increased risk (red tile), you should take a PCR test and quarantine yourself."
+                            "If the Corona-Warn-App shows you an encounter with increased risk (red tile), you should take a PCR test and quarantine yourself.",
+                            "An encounter with increased risk in the Corona-Warn-App allows you to take a free PCR test."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -557,7 +557,8 @@
                         "anchor": "rat_red_card_which_test",
                         "active": true,
                         "textblock": [
-                            "Wenn die Corona-Warn-App Ihnen eine Begegnung mit erhöhtem Risiko (rote Kachel) anzeigt, sollten Sie einen PCR-Test machen und sich in Quarantäne begeben."
+                            "Wenn die Corona-Warn-App Ihnen eine Begegnung mit erhöhtem Risiko (rote Kachel) anzeigt, sollten Sie einen PCR-Test machen und sich in Quarantäne begeben.",
+                            "Eine Begegnung mit erhöhtem Risiko in der Corona-Warn-App ermöglicht Ihnen einen kostenlosen PCR-Test."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR adds a note about the free of charge PCR test, which is possible if CWA shows an encounter with increased risk, to the FAQ entry `rat_red_card_which_test`.

| German | English |
|---|---|
| <img width="1039" alt="Preview DE" src="https://user-images.githubusercontent.com/67682506/134801504-864529bf-5bbd-46ad-923c-ea4d3315eb55.png"> | <img width="1039" alt="Preview EN" src="https://user-images.githubusercontent.com/67682506/134801506-cd60c684-b2ce-49c5-919a-46f9b2cf79fc.png"> |