### PR TITLE
Bump current iOS version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -419,7 +419,7 @@ function createFaqRedirects() {
 function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html"])
-    .pipe(replace('[ios.latest-os-version]', '15.0'))
+    .pipe(replace('[ios.latest-os-version]', '15.0.1'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.10.2'))
     .pipe(replace('[android.latest-os-version]', '11'))


### PR DESCRIPTION
This PR bumps the current iOS version from 15.0 to 15.0.1.

---

Apple release: https://developer.apple.com/news/releases/?id=10012021b