### PR TITLE
Correct link to de blog archiv in link checker

### DIFF
--- a/cypress/integration/check_links.js
+++ b/cypress/integration/check_links.js
@@ -13,7 +13,7 @@ context("Check for broken links", () => {
                   '/en/analysis/',
                   '/de/blog/',
                   '/en/blog/',
-                  '/de/blog/archive/',
+                  '/de/blog/archiv/',
                   '/en/blog/archive/',
                   '/de/screenshots/',
                   '/en/screenshots/',


### PR DESCRIPTION
This PR corrects an error in the cypress script https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/check_links.js, introduced by PR https://github.com/corona-warn-app/cwa-website/pull/1794, where in 

https://github.com/corona-warn-app/cwa-website/blob/a56849a712d91d3eed500b62c480614d0f57d6ec/cypress/integration/check_links.js#L16

the directory  `/de/blog/archive/` is listed for link checking.

There is however no https://www.coronawarn.app/en/blog/archive/ so it returns a 404 and fails this test.

The correct German-language directory is https://www.coronawarn.app/en/blog/archiv (without an "e" at the end).

The cypress script is corrected to `/de/blog/archiv/` so that it is able to check an existing directory.

(Note this is the only directory where the German-language directory has a different name to the English-language one.)

## Steps to verify

`npm run test:open`
select `check_links.js` in the Cypress console when it starts