### PR TITLE
Added blog and science entries to Cypress test

### DIFF
--- a/cypress/integration/check_links.js
+++ b/cypress/integration/check_links.js
@@ -31,7 +31,7 @@ context("Check for broken links", () => {
 
   const subpages = ['/de/blog/', '/en/blog/','/de/science/', '/en/science/']
   pages.forEach(page => {
-    it(`"${page}" - Check for broken links`, () => {
+    it(`"${subpages.includes(page) ? page+" and entries": page}" - Check for broken links`, () => {
       cy.visit({log: false, url: page} )
       cy.get("a:not([href*='mailto:'],[href*='tel:'])").not('.email').each(url => {
         if (url.prop('href') ) { 

--- a/cypress/integration/check_links.js
+++ b/cypress/integration/check_links.js
@@ -13,7 +13,7 @@ context("Check for broken links", () => {
                   '/en/analysis/',
                   '/de/blog/',
                   '/en/blog/',
-                  '/de/blog/archive/',
+                  '/de/blog/archiv/',
                   '/en/blog/archive/',
                   '/de/screenshots/',
                   '/en/screenshots/',
@@ -29,11 +29,27 @@ context("Check for broken links", () => {
                   '/en/event-qr-code-guide/'
                 ]
 
+  const subpages = ['/de/blog/', '/en/blog/','/de/science/', '/en/science/']
   pages.forEach(page => {
     it(`"${page}" - Check for broken links`, () => {
       cy.visit({log: false, url: page} )
       cy.get("a:not([href*='mailto:'],[href*='tel:'])").not('.email').each(url => {
         if (url.prop('href') ) { 
+          subpages.forEach(sub => {
+            if(url.prop('href').includes(sub) && url.prop('href') !== sub) {
+              cy.get("a:not([href*='mailto:'],[href*='tel:'])").not('.email').each(entry => {
+                if (entry.prop('href') ) {
+                  cy.request({
+                    failOnStatusCode: false, 
+                    log: false,
+                    url: entry.prop('href')
+                  }).then((response) => {
+                    softExpect(response.status, "Link: " + entry.prop('href')).to.eq(200)
+                  })
+                }
+              })
+            }
+          })
           cy.request({
             failOnStatusCode: false, 
             log: false,


### PR DESCRIPTION
In this branch I added blogs and science entries on broken list Cypress test dynamically.

![dd9165a81c0b90112ed4761a5f6a0c35](https://user-images.githubusercontent.com/44208107/135865899-34b16ce7-8e81-4081-b96b-178cd31e13e7.png)

First test item appears failed because I force stop.