### PR TITLE
Remove link to missing test station status graphic in 2.4 blog announcement (resolves #1803)

### DIFF
--- a/blog/2021-06-24 CWA 2.4 Testzertifikat/index.md
+++ b/blog/2021-06-24 CWA 2.4 Testzertifikat/index.md
@@ -37,10 +37,6 @@ Users can then view the certificate via the "Certificates" tab in their tab bar.
 
 Not every rapid test center supports the digital certificate. In this case, users won’t be redirected to request the certificate after scanning the QR code. They will then be informed that a test certificate cannot be requested because the testing center does not support test certificates. 
 
-<br></br>
-<center> <img src="./.png" title="Teststelle unterstützt Testzertifikate nicht" style="align: center"></center>
-<br></br>
-
 Users requesting a test certificate for a PCR test must provide their date of birth when making the request. It is important that the date of birth is the same as the date of birth used for the PCR swab test. If the dates don’t match, for example due to a typing error, the user will neither receive the test result nor the certificate via the app. Also, users cannot change the date of birth that they enter in the app later. Therefore, they should check whether the date is correct before completing the request for a certificate.
 
 <br></br>


### PR DESCRIPTION
This PR resolves an issue https://github.com/corona-warn-app/cwa-website/issues/1803 in the English-language blog article https://www.coronawarn.app/en/blog/2021-06-24-cwa-version-2-4/ announcing the release of version 2.4 where there is a missing graphic.

The German-language blog article https://www.coronawarn.app/de/blog/2021-06-24-cwa-version-2-4/ includes the screenshot https://www.coronawarn.app/assets/img/blog/2021-06-24%20CWA%202.4%20Testzertifikat/teststelle-nicht-unterstützt.png which is not available as a screenshot from an English device.

The 2.4 English article is understandable even without presenting such a screenshot. The PR removes the unsightly failed link from the source. This also remediates the issue that the bad link is reported in web link checkers.

![image](https://user-images.githubusercontent.com/66998419/136212057-c73c577a-3c66-4c09-ae10-b733f142bef2.png)

The text now appears as:

![image](https://user-images.githubusercontent.com/66998419/136212368-0a2309a3-1edb-4954-804a-0d941b06ef49.png)

