### PR TITLE
Update inboxes of graphs on analysis page

### DIFF
--- a/src/data/analyse_de.json
+++ b/src/data/analyse_de.json
@@ -70,7 +70,7 @@
             "title": "Downloads",
             "export": "https://obs.eu-de.otc.t-systems.com/obs-public-dashboard/csv/cwa_downloads_data.zip",
             "info": {
-                "content": "<strong>Täglich</strong><p>Tagesgenaue Anzahl der Corona-Warn-App-Downloads aus Google Play (Google) und dem App Store (Apple) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der Corona-Warn-App-Downloads aus Google Play (Google) und dem App Store (Apple) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der Corona-Warn-App-Downloads aus Google Play (Google) und dem App Store (Apple) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der Corona-Warn-App-Downloads aus Google Play (Google) und dem App Store (Apple) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores seit Veröffentlichung der Corona-Warn-App.</p><br><strong>Weitere Informationen</strong><p>In die Erhebung der Downloadzahlen gehen nur die in der Corona-Warn-App-Downloads aus den offiziellen App-Stores von Google und Apple ein.</p><p>Aus diesen Zahlen können keine Rückschlüsse bezüglich der aktiven Nutzerbasis gezogen werden. </p>"
+                "content": "<strong>Downloads</strong><p>Anzahl der Corona-Warn-App-Downloads aus dem Google-Play-Store (Android) und Apple-App-Store (iOS) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores (Gesamt).</p><strong>Zeitintervalle</strong><p>Täglich: Tagesgenaue Anzahl<br />Wöchentlich: Wöchentliche Anzahl nach Kalenderwoche (KW)<br />7-Tage-Mittelwert: Tagesgenauer Mittelwert der letzten sieben Tage<br />Kumuliert: Tagesgenaue kumulative Summe seit Beginn der Messung</p><strong>Datenquellen</strong><p>Apple-App-Store<br />Google-Play-Store</p><strong>Weitere Informationen</strong><p>In die Erhebung der Downloadzahlen gehen nur die in der Corona-Warn-App-Downloads aus den offiziellen App-Stores von Google und Apple ein.</p><p>Aus diesen Zahlen können keine Rückschlüsse bezüglich der aktiven Nutzerbasis gezogen werden.</p>"
             },
             "totalKey": ["app_downloads_cumulated"]
         },
@@ -78,7 +78,7 @@
             "title": "Registrierte Tests",
             "export": "https://obs.eu-de.otc.t-systems.com/obs-public-dashboard/csv/test_results_data.zip",
             "info": {
-                "content": "<strong>Täglich</strong><p>Tagesgenaue Anzahl der registrierten PCR-Tests und registrierten Antigen-Schnelltests sowie die Summe beider registrierten Testarten in der Corona-Warn-App.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der registrierten PCR-Tests und registrierten Antigen-Schnelltests sowie die Summe beider registrierten Testarten in der Corona-Warn-App (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der registrierten PCR-Tests und registrierten Antigen-Schnelltests sowie die Summe beider registrierten Testarten in der Corona-Warn-App.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der registrierten PCR-Tests und registrierten Antigen-Schnelltests sowie die Summe beider registrierten Testarten in der Corona-Warn-App seit Beginn der Pandemie.</p><br><strong>Reiter: PCR-Tests </strong><strong>Täglich</strong><p>Tagesgenaue Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse seit Beginn der Messung.</p><br><strong>Reiter: Antigen-Schnelltest</strong><strong>Täglich</strong><p>Tagesgenaue Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse seit Beginn der Messung.</p>"
+                "content": "<strong>Registrierte Tests</strong><p>Anzahl der registrierten PCR-Tests und Antigen-Schnelltests sowie die Summe beider registrierter Testarten in der Corona-Warn-App.</p><strong>Testergebnisse PCR-Tests</strong><p>Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse.</p><strong>Testergebnisse Antigen-Schnelltests</strong><p>Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse.</p><strong>Zeitintervalle</strong><p>Täglich: Tagesgenaue Anzahl<br />Wöchentlich: Wöchentliche Anzahl nach Kalenderwoche (KW)<br />7-Tage-Mittelwert: Tagesgenauer Mittelwert der letzten sieben Tage<br />Kumuliert: Tagesgenaue kumulative Summe seit Beginn der Messung</p><strong> Datenquellen </strong><p>Corona-Warn-App-Backend</p>"
             },
             "totalKey": [
                 "tests_total_cumulated",
@@ -95,13 +95,13 @@
                 {
                     "label": "Antigen-Schnelltests"
                 }
-            ] 
+            ]
         },
         {
             "title": "Teilungsverhalten",
             "export": "https://obs.eu-de.otc.t-systems.com/obs-public-dashboard/csv/cwa_sharing_data.zip",
             "info": {
-                "content": "<strong>Täglich</strong><p>Tagesgenaue Anzahl der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten seit Beginn der Messung.</p><br><strong>Weitere Informationen</strong><p>Für das Beenden der Infektionsketten sind nur die positiven Testergebnisse relevant. Um Missbrauch zu verhindern, müssen positive Testergebnisse verifiziert werden. Dafür gibt es zwei Möglichkeiten: einen QR-Code oder eine teleTAN, die in der Corona-Warn-App eingegeben werden müssen. Den QR-Code erhält die/der Nutzende bei der Probenentnahme für den Test. Mit Hilfe des QR-Codes kann der Test in der Corona-Warn-App registriert werden. Sobald das Ergebnis vorliegt, wird es automatisch abgerufen und auf dem Smartphone angezeigt. Die/der Nutzende kann dann entscheiden, die eigenen Zufallscodes der letzten 14 Tage freizugeben und mögliche Risikokontakte zu warnen. Steht kein QR-Code zur Verfügung oder geht dieser verloren, kann die/der Nutzende die Verifizierungshotline anrufen. Dort wird eine teleTAN zur Verifizierung des positiven Testergebnisses erzeugt. Diese muss durch die/den Nutzenden in die App eingegeben werden.</p><br><strong>Reiter: QR-Codes</strong><strong>Täglich</strong><p>Tagesgenaue Anzahl der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes seit Beginn der Messung.</p><br><strong>Reiter: teleTANs</strong><strong>Täglich</strong><p>Tagesgenaue Anzahl der in der Corona-Warn-App geteilten und nicht geteilten teleTANs.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der in der Corona-Warn-App geteilten und nicht geteilten teleTANs (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der in der Corona-Warn-App geteilten und nicht geteilten teleTANs.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der in der Corona-Warn-App geteilten und nicht geteilten teleTANs seit Beginn der Messung.</p>"
+                "content": "<strong>Teilungsverhalten</strong><p>Anzahl der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten.</p><strong>Teilungsverhalten: QR-Codes</strong><p>Anzahl der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes.</p><strong>Teilungsverhalten: teleTANs</strong><p>Anzahl der in der Corona-Warn-App geteilten und nicht geteilten teleTANs.</p><strong>Zeitintervalle</strong><p>Täglich: Tagesgenaue Anzahl<br />Wöchentlich: Wöchentliche Anzahl nach Kalenderwoche (KW)<br />7-Tage-Mittelwert: Tagesgenauer Mittelwert der letzten sieben Tage<br />Kumuliert: Tagesgenaue kumulative Summe seit Beginn der Messung</p><strong>Datenquellen</strong><p>Corona-Warn-App-Backend</p><strong>Weitere Informationen</strong><p>Für das Beenden der Infektionsketten sind nur die positiven Testergebnisse relevant. Um Missbrauch zu verhindern, müssen positive Testergebnisse verifiziert werden. Dafür gibt es zwei Möglichkeiten: einen QR-Code oder eine teleTAN, die in der Corona-Warn-App eingegeben werden müssen. Den QR-Code erhält die/der Nutzende bei der Probenentnahme für den Test. Mit Hilfe des QR-Codes kann der Test in der Corona-Warn-App registriert werden. Sobald das Ergebnis vorliegt, wird es automatisch abgerufen und auf dem Smartphone angezeigt. Die/der Nutzende kann dann entscheiden, die eigenen Zufallscodes der letzten 14 Tage freizugeben und mögliche Risikokontakte zu warnen. Steht kein QR-Code zur Verfügung oder geht dieser verloren, kann die/der Nutzende die Verifizierungshotline anrufen. Dort wird eine teleTAN zur Verifizierung des positiven Testergebnisses erzeugt. Diese muss durch die/den Nutzenden in die App eingegeben werden.</p>"
             },
             "totalKey": [
                 "qr_teletan_redeemable_cumulated",
@@ -118,13 +118,13 @@
                 {
                     "label": "TeleTAN"
                 }
-            ] 
+            ]
         },
         {
             "title": "Warnungen",
             "export": "https://obs.eu-de.otc.t-systems.com/obs-public-dashboard/csv/cwa_ppa_warnings_data.zip",
             "info": {
-                "content": "<strong>Täglich</strong><p>Tagesgenaue Anzahl roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App seit Beginn der Messung.</p><br><strong>Weitere Informationen</strong><p>Eine grüne Risikowarnung erhalten Nutzende, die in den letzten 14 Tagen eine kurze und/oder räumlich entfernte Begegnung mit einer Corona-positiv getesteten Person hatten. Die Begegnung lag somit nicht über dem definierten Schwellenwert. Für die betroffenen Nutzenden besteht kein aktiver Handlungsbedarf.</p><p>Eine rote Risikowarnung erhalten Nutzende, die in den letzten 14 Tagen eine lang andauernde und/oder räumlich nahe Begegnungen mit mindestens einer Corona-positiv getesteten Person hatten. Die Begegnung lag über dem definierten Schwellenwert. Betroffene Nutzende werden aufgefordert, persönliche Kontakte zu reduzieren. Bei Symptomen soll die Hausarztpraxis, der kassenärztliche Bereitschaftsdienst oder das Gesundheitsamt kontaktiert werden. Die Hausarztpraxis oder das Gesundheitsamt entscheiden über ein Testangebot.</p>"
+                "content": "<strong>Warnungen</strong><p>Anzahl roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App.</p><strong>Zeitintervalle</strong><p>Täglich: Tagesgenaue Anzahl<br />Wöchentlich: Wöchentliche Anzahl nach Kalenderwoche (KW)<br />7-Tage-Mittelwert: Tagesgenauer Mittelwert der letzten sieben Tage<br />Kumuliert: Tagesgenaue kumulative Summe seit Beginn der Messung</p><strong>Datenquellen</strong><p>Privacy-Preserving-Analytics (PPA)</p><strong>Weitere Informationen</strong><p>Eine grüne Risikowarnung erhalten Nutzende, die in den letzten 14 Tagen eine kurze und/oder räumlich entfernte Begegnung mit einer Corona-positiv getesteten Person hatten. Die Begegnung lag somit nicht über dem definierten Schwellenwert. Für die betroffenen Nutzenden besteht kein aktiver Handlungsbedarf.</p><p>Eine rote Risikowarnung erhalten Nutzende, die in den letzten 14 Tagen eine lang andauernde und/oder räumlich nahe Begegnungen mit mindestens einer Corona-positiv getesteten Person hatten. Die Begegnung lag über dem definierten Schwellenwert. Betroffene Nutzende werden aufgefordert, persönliche Kontakte zu reduzieren. Bei Symptomen soll die Hausarztpraxis, der kassenärztliche Bereitschaftsdienst oder das Gesundheitsamt kontaktiert werden. Die Hausarztpraxis oder das Gesundheitsamt entscheiden über ein Testangebot.</p>"
             },
             "totalKey": ["ppa_total_warnings_cumulated"]
         }
@@ -259,24 +259,24 @@
 
 
         "ppa_total_warnings_cumulated": "Gesamt",
-        "ppa_risk_red_cumulated": "Rotes Risiko", 
+        "ppa_risk_red_cumulated": "Rotes Risiko",
         "ppa_risk_green_cumulated": "Grünes Risiko",
 
         "ppa_total_warnings_daily": "Gesamt",
-        "ppa_risk_red_daily": "Rotes Risiko", 
+        "ppa_risk_red_daily": "Rotes Risiko",
         "ppa_risk_green_daily": "Grünes Risiko",
 
         "ppa_total_warnings_7days_sum": "Gesamt",
-        "ppa_risk_red_7days_sum": "Rotes Risiko", 
+        "ppa_risk_red_7days_sum": "Rotes Risiko",
         "ppa_risk_green_7days_sum": "Grünes Risiko",
 
         "ppa_total_warnings_7days_avg": "Gesamt X̅",
-        "ppa_risk_red_7days_avg": "Rotes Risiko X̅", 
+        "ppa_risk_red_7days_avg": "Rotes Risiko X̅",
         "ppa_risk_green_7days_avg": "Grünes Risiko X̅"
 
 
-        
-        
+
+
     },
     "moreHeadline": "Weitere Dashboards",
     "moreLinks": [


### PR DESCRIPTION
Registrierte Tests
---
  - OLD
<strong>Täglich</strong><p>Tagesgenaue Anzahl der registrierten PCR-Tests und registrierten Antigen-Schnelltests sowie die Summe beider registrierten Testarten in der Corona-Warn-App.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der registrierten PCR-Tests und registrierten Antigen-Schnelltests sowie die Summe beider registrierten Testarten in der Corona-Warn-App (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der registrierten PCR-Tests und registrierten Antigen-Schnelltests sowie die Summe beider registrierten Testarten in der Corona-Warn-App.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der registrierten PCR-Tests und registrierten Antigen-Schnelltests sowie die Summe beider registrierten Testarten in der Corona-Warn-App seit Beginn der Pandemie.</p><br><strong>Reiter: PCR-Tests </strong><strong>Täglich</strong><p>Tagesgenaue Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse seit Beginn der Messung.</p><br><strong>Reiter: Antigen-Schnelltest</strong><strong>Täglich</strong><p>Tagesgenaue Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse seit Beginn der Messung.</p>
  - NEW
<strong>Registrierte Tests</strong><p>Anzahl der registrierten PCR-Tests und Antigen-Schnelltests sowie die Summe beider registrierter Testarten in der Corona-Warn-App.</p><strong>Testergebnisse PCR-Tests</strong><p>Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten PCR-Testergebnisse.</p><strong>Testergebnisse Antigen-Schnelltests</strong><p>Anzahl der positiven, negativen und ungültigen sowie die Summe aller in der Corona-Warn-App registrierten Antigen-Schnelltestergebnisse.</p><strong>Zeitintervalle</strong><p>Täglich: Tagesgenaue Anzahl<br />Wöchentlich: Wöchentliche Anzahl nach Kalenderwoche (KW)<br />7-Tage-Mittelwert: Tagesgenauer Mittelwert der letzten sieben Tage<br />Kumuliert: Tagesgenaue kumulative Summe seit Beginn der Messung</p><strong> Datenquellen </strong><p>Corona-Warn-App-Backend</p>

Downloads
---

  - OLD
<strong>Täglich</strong><p>Tagesgenaue Anzahl der Corona-Warn-App-Downloads aus Google Play (Google) und dem App Store (Apple) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der Corona-Warn-App-Downloads aus Google Play (Google) und dem App Store (Apple) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der Corona-Warn-App-Downloads aus Google Play (Google) und dem App Store (Apple) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der Corona-Warn-App-Downloads aus Google Play (Google) und dem App Store (Apple) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores seit Veröffentlichung der Corona-Warn-App.</p><br><strong>Weitere Informationen</strong><p>In die Erhebung der Downloadzahlen gehen nur die in der Corona-Warn-App-Downloads aus den offiziellen App-Stores von Google und Apple ein.</p><p>Aus diesen Zahlen können keine Rückschlüsse bezüglich der aktiven Nutzerbasis gezogen werden. </p>
  - NEW 
<strong>Downloads</strong><p>Anzahl der Corona-Warn-App-Downloads aus dem Google-Play-Store (Android) und Apple-App-Store (iOS) sowie die Summe der Corona-Warn-App-Downloads aus beiden App-Stores (Gesamt).</p><strong>Zeitintervalle</strong><p>Täglich: Tagesgenaue Anzahl<br />Wöchentlich: Wöchentliche Anzahl nach Kalenderwoche (KW)<br />7-Tage-Mittelwert: Tagesgenauer Mittelwert der letzten sieben Tage<br />Kumuliert: Tagesgenaue kumulative Summe seit Beginn der Messung</p><strong>Datenquellen</strong><p>Apple-App-Store<br />Google-Play-Store</p><strong>Weitere Informationen</strong><p>In die Erhebung der Downloadzahlen gehen nur die in der Corona-Warn-App-Downloads aus den offiziellen App-Stores von Google und Apple ein.</p><p>Aus diesen Zahlen können keine Rückschlüsse bezüglich der aktiven Nutzerbasis gezogen werden.</p>

Teilungsverhalten
---
  - OLD
<strong>Täglich</strong><p>Tagesgenaue Anzahl der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten seit Beginn der Messung.</p><br><strong>Weitere Informationen</strong><p>Für das Beenden der Infektionsketten sind nur die positiven Testergebnisse relevant. Um Missbrauch zu verhindern, müssen positive Testergebnisse verifiziert werden. Dafür gibt es zwei Möglichkeiten: einen QR-Code oder eine teleTAN, die in der Corona-Warn-App eingegeben werden müssen. Den QR-Code erhält die/der Nutzende bei der Probenentnahme für den Test. Mit Hilfe des QR-Codes kann der Test in der Corona-Warn-App registriert werden. Sobald das Ergebnis vorliegt, wird es automatisch abgerufen und auf dem Smartphone angezeigt. Die/der Nutzende kann dann entscheiden, die eigenen Zufallscodes der letzten 14 Tage freizugeben und mögliche Risikokontakte zu warnen. Steht kein QR-Code zur Verfügung oder geht dieser verloren, kann die/der Nutzende die Verifizierungshotline anrufen. Dort wird eine teleTAN zur Verifizierung des positiven Testergebnisses erzeugt. Diese muss durch die/den Nutzenden in die App eingegeben werden.</p><br><strong>Reiter: QR-Codes</strong><strong>Täglich</strong><p>Tagesgenaue Anzahl der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes seit Beginn der Messung.</p><br><strong>Reiter: teleTANs</strong><strong>Täglich</strong><p>Tagesgenaue Anzahl der in der Corona-Warn-App geteilten und nicht geteilten teleTANs.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl der in der Corona-Warn-App geteilten und nicht geteilten teleTANs (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl der in der Corona-Warn-App geteilten und nicht geteilten teleTANs.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe der in der Corona-Warn-App geteilten und nicht geteilten teleTANs seit Beginn der Messung.</p>
  - NEW
<strong>Teilungsverhalten</strong><p>Anzahl der in der Corona-Warn-App geteilten QR-Codes und teleTANs sowie die Summe beider Teilungsmöglichkeiten.</p><strong>Teilungsverhalten: QR-Codes</strong><p>Anzahl der in der Corona-Warn-App geteilten und nicht geteilten QR-Codes.</p><strong>Teilungsverhalten: teleTANs</strong><p>Anzahl der in der Corona-Warn-App geteilten und nicht geteilten teleTANs.</p><strong>Zeitintervalle</strong><p>Täglich: Tagesgenaue Anzahl<br />Wöchentlich: Wöchentliche Anzahl nach Kalenderwoche (KW)<br />7-Tage-Mittelwert: Tagesgenauer Mittelwert der letzten sieben Tage<br />Kumuliert: Tagesgenaue kumulative Summe seit Beginn der Messung</p><strong>Datenquellen</strong><p>Corona-Warn-App-Backend</p><strong>Weitere Informationen</strong><p>Für das Beenden der Infektionsketten sind nur die positiven Testergebnisse relevant. Um Missbrauch zu verhindern, müssen positive Testergebnisse verifiziert werden. Dafür gibt es zwei Möglichkeiten: einen QR-Code oder eine teleTAN, die in der Corona-Warn-App eingegeben werden müssen. Den QR-Code erhält die/der Nutzende bei der Probenentnahme für den Test. Mit Hilfe des QR-Codes kann der Test in der Corona-Warn-App registriert werden. Sobald das Ergebnis vorliegt, wird es automatisch abgerufen und auf dem Smartphone angezeigt. Die/der Nutzende kann dann entscheiden, die eigenen Zufallscodes der letzten 14 Tage freizugeben und mögliche Risikokontakte zu warnen. Steht kein QR-Code zur Verfügung oder geht dieser verloren, kann die/der Nutzende die Verifizierungshotline anrufen. Dort wird eine teleTAN zur Verifizierung des positiven Testergebnisses erzeugt. Diese muss durch die/den Nutzenden in die App eingegeben werden.</p>

Warnungen
---
  - OLD
<strong>Täglich</strong><p>Tagesgenaue Anzahl roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App.</p><strong>Wöchentlich</strong><p>Wöchentliche Anzahl roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App (nach Kalenderwoche (KW)).</p><strong>7-Tage-Mittelwert</strong><p>Tagesgenauer Mittelwert der letzten sieben Tage und tagesgenaue Anzahl roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App.</p><strong>Kumuliert</strong><p>Tagesgenaue kumulative Summe roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App seit Beginn der Messung.</p><br><strong>Weitere Informationen</strong><p>Eine grüne Risikowarnung erhalten Nutzende, die in den letzten 14 Tagen eine kurze und/oder räumlich entfernte Begegnung mit einer Corona-positiv getesteten Person hatten. Die Begegnung lag somit nicht über dem definierten Schwellenwert. Für die betroffenen Nutzenden besteht kein aktiver Handlungsbedarf.</p><p>Eine rote Risikowarnung erhalten Nutzende, die in den letzten 14 Tagen eine lang andauernde und/oder räumlich nahe Begegnungen mit mindestens einer Corona-positiv getesteten Person hatten. Die Begegnung lag über dem definierten Schwellenwert. Betroffene Nutzende werden aufgefordert, persönliche Kontakte zu reduzieren. Bei Symptomen soll die Hausarztpraxis, der kassenärztliche Bereitschaftsdienst oder das Gesundheitsamt kontaktiert werden. Die Hausarztpraxis oder das Gesundheitsamt entscheiden über ein Testangebot.</p>
  - NEW
<strong>Warnungen</strong><p>Anzahl roter und grüner Risikowarnungen sowie deren Summe in der Corona-Warn-App.</p><strong>Zeitintervalle</strong><p>Täglich: Tagesgenaue Anzahl<br />Wöchentlich: Wöchentliche Anzahl nach Kalenderwoche (KW)<br />7-Tage-Mittelwert: Tagesgenauer Mittelwert der letzten sieben Tage<br />Kumuliert: Tagesgenaue kumulative Summe seit Beginn der Messung</p><strong>Datenquellen</strong><p>Privacy-Preserving-Analytics (PPA)</p><strong>Weitere Informationen</strong><p>Eine grüne Risikowarnung erhalten Nutzende, die in den letzten 14 Tagen eine kurze und/oder räumlich entfernte Begegnung mit einer Corona-positiv getesteten Person hatten. Die Begegnung lag somit nicht über dem definierten Schwellenwert. Für die betroffenen Nutzenden besteht kein aktiver Handlungsbedarf.</p><p>Eine rote Risikowarnung erhalten Nutzende, die in den letzten 14 Tagen eine lang andauernde und/oder räumlich nahe Begegnungen mit mindestens einer Corona-positiv getesteten Person hatten. Die Begegnung lag über dem definierten Schwellenwert. Betroffene Nutzende werden aufgefordert, persönliche Kontakte zu reduzieren. Bei Symptomen soll die Hausarztpraxis, der kassenärztliche Bereitschaftsdienst oder das Gesundheitsamt kontaktiert werden. Die Hausarztpraxis oder das Gesundheitsamt entscheiden über ein Testangebot.</p>

