### PR TITLE
Fix link to tcn-coalition (resolves #1847)

### DIFF
--- a/src/data/index.json
+++ b/src/data/index.json
@@ -203,7 +203,7 @@
                 "list": [
                     {
                         "title": "Decentralized approach",
-                        "text": "The architecture follows a decentralized approach – based on the <a href='https://github.com/DP-3T/documents' target='_blank' rel='noopener noreferrer' title=''>DP-3T</a> and <a href='https://tcn-coalition.org/' target='_blank' rel='noopener noreferrer' title=''>TCN</a> protocols, as well as the Privacy-Preserving Contact Tracing specifications by Apple and Google."
+                        "text": "The architecture follows a decentralized approach – based on the <a href='https://github.com/DP-3T/documents' target='_blank' rel='noopener noreferrer' title=''>DP-3T</a> and <a href='https://www.lfph.io/tcn-coalition/' target='_blank' rel='noopener noreferrer' title=''>TCN</a> protocols, as well as the Privacy-Preserving Contact Tracing specifications by Apple and Google."
                     },
                     {
                         "title": "Two objectives",

--- a/src/data/index_de.json
+++ b/src/data/index_de.json
@@ -203,7 +203,7 @@
                 "list": [
                     {
                         "title": "Dezentraler Ansatz",
-                        "text": "Die Architektur beruht wie die Protokolle <a href='https://github.com/DP-3T/documents' target='_blank' rel='noopener noreferrer' title=''>DP-3T</a> und <a href='https://tcn-coalition.org/' target='_blank' rel='noopener noreferrer' title=''>TCN</a> auf einem dezentralen Ansatz und baut auf den Exposure-Notification-API-Spezifikationen von Apple und Google auf."
+                        "text": "Die Architektur beruht wie die Protokolle <a href='https://github.com/DP-3T/documents' target='_blank' rel='noopener noreferrer' title=''>DP-3T</a> und <a href='https://www.lfph.io/tcn-coalition/' target='_blank' rel='noopener noreferrer' title=''>TCN</a> auf einem dezentralen Ansatz und baut auf den Exposure-Notification-API-Spezifikationen von Apple und Google auf."
                     },
                     {
                         "title": "Zwei Zwecke",


### PR DESCRIPTION
This PR resolves the issue https://github.com/corona-warn-app/cwa-website/issues/1847 "TCN Coalition website moved" by changing TCN links from 

`https://tcn-coalition.org/`

to

`https://www.lfph.io/tcn-coalition/`.

## Steps to verify

### Local verification

1. Open http://localhost:8000/en/ and click on link to TCN
2. Open http://localhost:8000/de/ and click on link to TCN
3. `npm run test` with no error
