### PR TITLE
Bump current Android app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -424,7 +424,7 @@ function replaceVersionNumbers() {
     .pipe(replace('[ios.current-app-version]', '2.11.1'))
     .pipe(replace('[android.latest-os-version]', '11'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.11.1'))
+    .pipe(replace('[android.current-app-version]', '2.11.2'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
This PR bumps the current Android app version from 2.11.1 to 2.11.2.

---

GitHub release: https://github.com/corona-warn-app/cwa-app-android/releases/tag/v2.11.2