### PR TITLE
Add favicon filename to redirect layout (resolves #1833)

### DIFF
--- a/src/layouts/redirect.html
+++ b/src/layouts/redirect.html
@@ -11,7 +11,7 @@
       rel="icon"
       type="image/{{#if global.favicon.type}}{{global.favicon.type}}{{/if}}{{#unless global.favicon.type}}png{{/unless}}"
       sizes="32x32"
-      href="{{root}}{{global.favicon.url}}"
+      href="{{root}}{{global.favicon.url}}{{global.favicon.name}}-32x32.png"
     />
     {{/if}}
     <meta property="og:title" content="{{page-title}}" />


### PR DESCRIPTION
This PR effectively adds the filename `favicon-32x32.png` to the `public/index.html` which will then be published to https://www.coronawarn.app/index.html and it resolves the issue described in "Missing link to icon file for web top level" #1833.

Without a real file specified in public/index.html the [deadlinkchecker](https://www.deadlinkchecker.com) fails when attempting to check the URL `https://www.coronawarn.app`.

## Steps to verify

1. run `npm start`
2. Examine local file public/index.html
3. Note the section
```
    <link
      rel="icon"
      type="image/png"
      sizes="32x32"
      href="/assets/img/icons/favicon-32x32.png"
    />
```
4. Confirm that the image public/assets/img/icons/favicon-32x32.png exists within the local clone of `cwa-website`
5. Open the file and confirm that it contains a Corona-Warn-App logo