### PR TITLE
Use spelling "traveling" in FAQs (fixes #1861)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -154,12 +154,12 @@
                         ]
                     },
                     {
-                        "title": "Is my certificate valid in the country I am travelling to?",
+                        "title": "Is my certificate valid in the country I am traveling to?",
                         "anchor": "cert_eu_travel",
                         "active": true,
                         "textblock": [
                             "<b>Update</b><br/>Please note that the behavior of the certificate validity check has changed with version 2.8. For more information on this change, please see the FAQ entry: <a href='#dcc_no_rules' target='_blank' rel='noopener noreferrer'>Why does the Corona-Warn-App with version 2.8 or newer show that my certificate couldn't be validated although versions 2.6 & 2.7 showed my certificate as valid?</a><hr>",
-                            "Starting with version 2.6, you can check before travelling whether your certificates (test, recovery and/or vaccination certificate) are valid in a selected country at the time of your trip. The Corona-Warn-App takes into account the applicable entry rules of the selected travel country and compares them with various parameters of the certificate, such as the date and type of test, test center or date of vaccination.",
+                            "Starting with version 2.6, you can check before traveling whether your certificates (test, recovery and/or vaccination certificate) are valid in a selected country at the time of your trip. The Corona-Warn-App takes into account the applicable entry rules of the selected travel country and compares them with various parameters of the certificate, such as the date and type of test, test center or date of vaccination.",
                             "Every European country that supports EU digital COVID certificates has the ability to upload rules that the Corona-Warn-App can match for verification. At the start of this new feature, Ireland, Lithuania, Luxembourg, the Netherlands, Slovenia and Spain, together with Germany, have uploaded rules, with more countries to follow in the coming weeks.",
                             "If the app shows after checking that there are no entry rules available, you can find out about the rules at <a href='https://reopen.europa.eu/en' target='_blank' rel='noopener noreferrer'>https://reopen.europa.eu/en</a>."
                         ]
@@ -222,7 +222,7 @@
                         "textblock": [
                             "In Germany, third parties can only reliably check whether it is a valid vaccination certificate, recovery certificate, or test certificate using the CovPassCheck app. Additionally, an identity check with photo ID should take place. Please note that other countries may use different apps for certificate verification.",
                             "A pure visual check of the certificates is not sufficient, as manipulated screenshots, apps or system settings (e.g. changed date) could be used, for example. The CovPassCheck-App is a secure solution for e.g. traders and public authorities to reliably check EU digital COVID certificates. More information and download links to the CovPassCheck app can be found here: <a href='https://www.digitaler-impfnachweis-app.de/en/covpasscheck-app/' target='_blank' rel='noopener noreferrer'>Check EU COVID certificates directly via app</a>. Please note that third parties in other countries may use other apps to verify certificates.",
-                            "You can check certificates for validity on your own directly in the Corona-Warn-App without the need of using the CovPassCheck-App. For more information, see the blog <a href='../blog/2021-07-28-cwa-version-2-6/' target='_blank' rel='noopener noreferrer'>Users can add local 7-day incidences and check certificates for validity before traveling</a> and the FAQ article <a href='#cert_eu_travel' target='_blank' rel='noopener noreferrer'>Is my certificate valid in the country I am travelling to?</a>"
+                            "You can check certificates for validity on your own directly in the Corona-Warn-App without the need of using the CovPassCheck-App. For more information, see the blog <a href='../blog/2021-07-28-cwa-version-2-6/' target='_blank' rel='noopener noreferrer'>Users can add local 7-day incidences and check certificates for validity before traveling</a> and the FAQ article <a href='#cert_eu_travel' target='_blank' rel='noopener noreferrer'>Is my certificate valid in the country I am traveling to?</a>"
                         ]
                     }
                 ]
@@ -503,7 +503,7 @@
                             "The app only reads the data contained in the QR code of the vaccination certificate and displays it readable in the app. If, for example, typing errors or different spellings were used in the two vaccination certificates, the app does not recognize them as belonging together. Typical examples are: additional spaces, typing errors in the name or in the specification of a title.",
                             "If the second vaccination certificate was issued correctly, it is usually sufficient to remove the first vaccination certificate in the Corona-Warn-App and then re-scan the second vaccination certificate. The app recognizes that this also achieves full vaccination protection (after 14 days).",
                             "However, if the data in the second vaccination certificate is incorrect, only the issuer of the certificate can correct it.",
-                            "<b>Important notice:</b> Since in some countries proof of vaccination is still required for both the first and second vaccination, it is advisable to carry all vaccination certificates with you, especially when travelling abroad, be it in the Corona-Warn-App, as a PDF, or as a paper printout."
+                            "<b>Important notice:</b> Since in some countries proof of vaccination is still required for both the first and second vaccination, it is advisable to carry all vaccination certificates with you, especially when traveling abroad, be it in the Corona-Warn-App, as a PDF, or as a paper printout."
                         ]
                     }
                 ]
@@ -2205,7 +2205,7 @@
                     "term": "Business Rules",
                     "anchor": "business_rules",
 
-                    "description": "For the introduction of <a href='#glossary_digital_certificate'>Digital COVID Certificates</a>, the eHealth network of the European Commission and the EU member states agreed that every country compiles the individual rules which have to be checked for transnational travelling. These \"Business Rules\" have two categories:<ul><li>Invalidation Rules of the Country of Administration, which decide under which circumstances a <a href='#glossary_digital_certificate'>certificate</a> is rejected</li><li>Acceptance Rules of the Country of Arrival, which must be fulfilled to enter the country</li></ul>"
+                    "description": "For the introduction of <a href='#glossary_digital_certificate'>Digital COVID Certificates</a>, the eHealth network of the European Commission and the EU member states agreed that every country compiles the individual rules which have to be checked for transnational traveling. These \"Business Rules\" have two categories:<ul><li>Invalidation Rules of the Country of Administration, which decide under which circumstances a <a href='#glossary_digital_certificate'>certificate</a> is rejected</li><li>Acceptance Rules of the Country of Arrival, which must be fulfilled to enter the country</li></ul>"
                 }
             ],
             "C": [


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/1861 "Inconsistent spelling "traveling" / "travelling" in FAQs" by changing occurrences of "travelling" in https://www.coronawarn.app/en/faq/ to be spelled as "traveling".

It makes the FAQ consistent within itself, also concerning the related word "traveler". It aligns the FAQ with text messages from the (Android) app which also use the spelling "traveling".