### PR TITLE
Convert blogs 2020-08 to relative paths

### DIFF
--- a/blog/2020-08-12-ios-update-1-2-1/index.md
+++ b/blog/2020-08-12-ios-update-1-2-1/index.md
@@ -7,4 +7,4 @@ author: Hanna Heine
 layout: blog
 ---
 
-Version 1.2.1 of the Corona-Warn-App has been released in the Apple App Store. The update fixes an [error](https://www.coronawarn.app/en/faq/#app_does_not_open) which caused the app to crash or prevented some users from opening the app. Therefore, we recommend all iOS-users to update the app to version 1.2.1.
+Version 1.2.1 of the Corona-Warn-App has been released in the Apple App Store. The update fixes an [error](/en/faq/#app_does_not_open) which caused the app to crash or prevented some users from opening the app. Therefore, we recommend all iOS-users to update the app to version 1.2.1.

--- a/blog/2020-08-12-ios-update-1-2-1/index_de.md
+++ b/blog/2020-08-12-ios-update-1-2-1/index_de.md
@@ -7,4 +7,4 @@ author: Hanna Heine
 layout: blog
 ---
 
-Im Apple App-Store ist die Corona-Warn-App Version 1.2.1 erschienen, die den [Fehler „Die App in der Version 1.2.0 stürzt teilweise direkt beim Start ab.“](https://www.coronawarn.app/de/faq/#app_does_not_open) behebt. Wir empfehlen daher allen iOS-Nutzerinnen und Nutzern, das Update zu installieren.
+Im Apple App-Store ist die Corona-Warn-App Version 1.2.1 erschienen, die den [Fehler „Die App in der Version 1.2.0 stürzt teilweise direkt beim Start ab.“](/de/faq/#app_does_not_open) behebt. Wir empfehlen daher allen iOS-Nutzerinnen und Nutzern, das Update zu installieren.

--- a/blog/2020-08-13-ios-betriebssystem-update/index.md
+++ b/blog/2020-08-13-ios-betriebssystem-update/index.md
@@ -9,4 +9,4 @@ layout: blog
 We recommend iOS users to upgrade the operating system to iOS 13.6.1 as it improves interaction with the Corona-Warn-App.
 <!-- overview -->
 
-The update contains a new function that should ensure that a background app refresh is performed once a day. With the update the Corona-Warn-App also works again on all devices that were stuck with the [error "Exposure logging not available in your region"](https://www.coronawarn.app/en/faq/#iOS_136).
+The update contains a new function that should ensure that a background app refresh is performed once a day. With the update the Corona-Warn-App also works again on all devices that were stuck with the [error "Exposure logging not available in your region"](/en/faq/#iOS_136).

--- a/blog/2020-08-13-ios-betriebssystem-update/index_de.md
+++ b/blog/2020-08-13-ios-betriebssystem-update/index_de.md
@@ -9,4 +9,4 @@ layout: blog
 Allen iOS-Nutzerinnen und Nutzern wird empfohlen, das Upgrade auf iOS 13.6.1 durchzuführen.
 <!-- overview -->
 
-Das Update enthält eine neue Funktionalität, die dafür sorgen soll, dass die Hintergrundaktualisierung der Corona-Warn-App einmal am Tag durchgeführt wird. Es sorgt außerdem dafür, dass die Corona-Warn-App auf allen Geräten, die in dem [Fehler "iOS-Region nicht gefunden"](https://www.coronawarn.app/de/faq/#iOS_136) stecken geblieben sind, wieder funktioniert.
+Das Update enthält eine neue Funktionalität, die dafür sorgen soll, dass die Hintergrundaktualisierung der Corona-Warn-App einmal am Tag durchgeführt wird. Es sorgt außerdem dafür, dass die Corona-Warn-App auf allen Geräten, die in dem [Fehler "iOS-Region nicht gefunden"](/de/faq/#iOS_136) stecken geblieben sind, wieder funktioniert.

--- a/blog/2020-08-14-play-store-version-1-2-1/index.md
+++ b/blog/2020-08-14-play-store-version-1-2-1/index.md
@@ -6,4 +6,4 @@ author: Hanna Heine
 layout: blog
 ---
 
-Version 1.2.1 of the Corona-Warn-App has been released in the Google Play Store. The update corrects the [misleading sentence](https://www.coronawarn.app/en/faq/#low_risk_text) that the probability of infection is ranked as 'increased' even though the risk of infection is, in fact, low. Therefore, we recommend all Android users to install version 1.2.1 of the Corona-Warn-App.
+Version 1.2.1 of the Corona-Warn-App has been released in the Google Play Store. The update corrects the [misleading sentence](/en/faq/#low_risk_text) that the probability of infection is ranked as 'increased' even though the risk of infection is, in fact, low. Therefore, we recommend all Android users to install version 1.2.1 of the Corona-Warn-App.

--- a/blog/2020-08-14-play-store-version-1-2-1/index_de.md
+++ b/blog/2020-08-14-play-store-version-1-2-1/index_de.md
@@ -6,5 +6,5 @@ author: Hanna Heine
 layout: blog
 ---
 
-Im Google Play Store ist die Corona-Warn-App Version 1.2.1 erschienen. Das Update korrigiert den [Satz](https://www.coronawarn.app/de/faq/#low_risk_text), dass trotz eines niedrigen Infektionsrisikos die Infektionswahrscheinlichkeit als erhöht eingestuft werde. Wir empfehlen daher allen Android-Nutzerinnen und Nutzern Version 1.2.1 der Corona-Warn-App zu installieren.
+Im Google Play Store ist die Corona-Warn-App Version 1.2.1 erschienen. Das Update korrigiert den [Satz](/de/faq/#low_risk_text), dass trotz eines niedrigen Infektionsrisikos die Infektionswahrscheinlichkeit als erhöht eingestuft werde. Wir empfehlen daher allen Android-Nutzerinnen und Nutzern Version 1.2.1 der Corona-Warn-App zu installieren.
 <!-- overview -->

--- a/blog/2020-08-25-notes-qr-codes/index.md
+++ b/blog/2020-08-25-notes-qr-codes/index.md
@@ -10,7 +10,7 @@ layout: blog
 The Corona-Warn-App has been active for a few weeks now and has been downloaded over 17.6 million times. An essential part of the app is the QR code procedure, which allows tested users to report test results to the app pseudonymously. 
 <!-- overview -->
 
-If a tested person receives a QR code, they are required to scan it and thus report the results to the app. In some cases, [error messages](https://www.coronawarn.app/en/faq/#qr_scan) appear, in others the [test result cannot be retrieved](https://www.coronawarn.app/en/faq/#qr_test). Why is that and what to do in these cases?
+If a tested person receives a QR code, they are required to scan it and thus report the results to the app. In some cases, [error messages](/en/faq/#qr_scan) appear, in others the [test result cannot be retrieved](/en/faq/#qr_test). Why is that and what to do in these cases?
 
 Possibility 1: During the test, the physician or test personnel did not indicate the necessary consent for data transfer to the Corona-Warn-App. The tick on the [form](https://github.com/corona-warn-app/cwa-documentation/issues/400#issuecomment-669937832) for "Consent of the insured person to transfer the test result for the purposes of the Corona-Warn-App" is missing. Without this consent, the QR Code cannot be further processed in the relevant laboratory and the test result will not be transferred to the Corona-Warn-App.
 
@@ -18,6 +18,6 @@ Possibility 2: The laboratory that evaluates the test result from the physician 
 
 In both cases, please contact your physician or the test center to ask for your test result. If you are informed of a positive test result and would like to use the Corona-Warn-App to warn your risk encounters, call the hotline on [+49 800 7540002](tel:+498007540002) and participate in the TeleTan procedure.
 
-If [several QR codes](https://www.coronawarn.app/en/faq/#QRcodes) are available at the same time, e.g. from several family members, you have to be aware that only one code may be used per smartphone. The remaining test results are reported independently of the Corona-Warn-App. To find out which QR code is the correct one, you should read the leaflet carefully.
+If [several QR codes](/en/faq/#QRcodes) are available at the same time, e.g. from several family members, you have to be aware that only one code may be used per smartphone. The remaining test results are reported independently of the Corona-Warn-App. To find out which QR code is the correct one, you should read the leaflet carefully.
 
-You can find further "frequently asked questions" as well as more detailed information about QR codes in the [FAQs](https://www.coronawarn.app/en/faq/).
+You can find further "frequently asked questions" as well as more detailed information about QR codes in the [FAQs](/en/faq/).

--- a/blog/2020-08-25-notes-qr-codes/index_de.md
+++ b/blog/2020-08-25-notes-qr-codes/index_de.md
@@ -11,7 +11,7 @@ Die Corona-Warn-App ist nun seit einigen Wochen aktiv und kann bereits über 17,
 <!-- overview -->
 
 
-Erhält eine getestete Personen einen QR-Code, ist sie dazu angehalten, diesen zu scannen und so die Ergebnisse an die App zu übermitteln. In einigen Fällen erscheinen dabei jedoch [Fehlermeldungen](https://www.coronawarn.app/de/faq/#qr_scan), in anderen kann das [Testergebnis nicht abgerufen werden](https://www.coronawarn.app/de/faq/#qr_test). Woran kann das liegen und was ist in diesen Fällen zu tun?
+Erhält eine getestete Personen einen QR-Code, ist sie dazu angehalten, diesen zu scannen und so die Ergebnisse an die App zu übermitteln. In einigen Fällen erscheinen dabei jedoch [Fehlermeldungen](/de/faq/#qr_scan), in anderen kann das [Testergebnis nicht abgerufen werden](/de/faq/#qr_test). Woran kann das liegen und was ist in diesen Fällen zu tun?
 
 Möglichkeit 1: Arzt oder Test-Personal haben beim Test nicht auf die notwendige Einwilligung zur Datenübertragung an die Corona-Warn-App hingewiesen. Der Haken auf dem [Formular](https://github.com/corona-warn-app/cwa-documentation/issues/400#issuecomment-669937832) zum „Einverständnis des Versicherten zum Übermitteln des Testergebnisses für Zwecke der Corona-Warn-App“ fehlt. Ohne diese Einwilligung kann der QR-Code im zuständigen Labor nicht weiterverarbeitet werden und es findet keine Übermittlung des Testergebnisses in die Corona-Warn-App statt.
 
@@ -19,6 +19,6 @@ Möglichkeit 2: Das Labor, das das Testergebnis des Arztes oder Testzentrums aus
 
 In beiden Fällen kontaktieren Sie bitte Ihren Arzt oder das Testzentrum, um Ihr Testergebnis zu erfragen. Wird Ihnen dabei ein positives Testergebnis mitgeteilt und möchten Sie über die Corona-Warn-App Ihre Risikobegegnungen warnen, rufen Sie die Hotline unter der [+49 800 7540002](tel:+498007540002) an und nehmen Sie am TeleTan-Verfahren teil.
 
-Falls [mehrere QR-Codes](https://www.coronawarn.app/de/faq/#QRcodes) gleichzeitig vorliegen, beispielsweise von mehreren Familienmitgliedern, sollte zunächst beachtet werden, dass lediglich ein Code pro Smartphone verwendet werden darf. Die übrigen Testergebnisse werden unabhängig von der Corona-Warn-App mitgeteilt. Um herauszufinden, welcher QR-Code der richtige ist, sollte außerdem das Merkblatt aufmerksam durchgelesen werden. 
+Falls [mehrere QR-Codes](/de/faq/#QRcodes) gleichzeitig vorliegen, beispielsweise von mehreren Familienmitgliedern, sollte zunächst beachtet werden, dass lediglich ein Code pro Smartphone verwendet werden darf. Die übrigen Testergebnisse werden unabhängig von der Corona-Warn-App mitgeteilt. Um herauszufinden, welcher QR-Code der richtige ist, sollte außerdem das Merkblatt aufmerksam durchgelesen werden. 
 
-Weitere „häufig gestellte Fragen“ sowie genauere Infos zum Thema QR-Codes gibt es in den [FAQs](https://www.coronawarn.app/de/faq/). 
+Weitere „häufig gestellte Fragen“ sowie genauere Infos zum Thema QR-Codes gibt es in den [FAQs](/de/faq/). 


### PR DESCRIPTION
This PR coverts the following blog entries from August 2020 to use relative paths instead of absolute paths to https://www.coronawarn.app:

- [blog/2020-08-12-ios-update-1-2-1](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2020-08-12-ios-update-1-2-1)
- [blog/2020-08-13-ios-betriebssystem-update](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2020-08-13-ios-betriebssystem-update)
- [blog/2020-08-25-notes-qr-codes](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2020-08-25-notes-qr-codes)

It follows from the issue https://github.com/corona-warn-app/cwa-website/issues/1819.

Subsequent PRs are planned to deal with later blog entries.