### PR TITLE
Convert blogs 2020-09 to relative paths

### DIFF
--- a/blog/2020-09-04-cwa-1-3-post/index.md
+++ b/blog/2020-09-04-cwa-1-3-post/index.md
@@ -14,5 +14,4 @@ Important new features include **additional information on the risk status**. If
 
 In addition, Corona-Warn-App version 1.3 contains a **link to a contact form** by the Robert Koch-Institut, which makes it easier for users to ask questions and make suggestions. 
 
-On iOS devices, the app displays the status “Unknown Risk” if the risk status has not been updated for 48 hours. This can be the case if the [background app refresh](https://www.coronawarn.app/en/faq/#no_risk_update_ios) has not been activated. Users can then manually update the risk status in the app.
-  
+On iOS devices, the app displays the status “Unknown Risk” if the risk status has not been updated for 48 hours. This can be the case if the [background app refresh](/en/faq/#no_risk_update_ios) has not been activated. Users can then manually update the risk status in the app.

--- a/blog/2020-09-04-cwa-1-3-post/index_de.md
+++ b/blog/2020-09-04-cwa-1-3-post/index_de.md
@@ -18,4 +18,4 @@ Wesentliche Neuerungen sind **zusätzliche Informationen zum Risikostatus**. Fal
 
 Darüber hinaus enthält Corona-Warn-App Version 1.3 im Impressum einen **Link zu einem Kontaktformular** des Robert Koch-Instituts, über das Nutzerinnen und Nutzern die Kontaktaufnahme bei Fragen und Anregungen erleichtert wird. 
 
-Auf iOS-Geräten zeigt die App zudem den Status „Unbekanntes Risiko“ an, falls der Risikostatus seit 48 Stunden nicht aktualisiert wurde. Das kann beispielsweise der Fall sein, wenn die [Hintergrundaktualisierung](https://www.coronawarn.app/de/faq/#no_risk_update_ios) nicht aktiviert wurde. Nutzerinnen und Nutzer können den Risikostatus dann in der App manuell aktualisieren.  
+Auf iOS-Geräten zeigt die App zudem den Status „Unbekanntes Risiko“ an, falls der Risikostatus seit 48 Stunden nicht aktualisiert wurde. Das kann beispielsweise der Fall sein, wenn die [Hintergrundaktualisierung](/de/faq/#no_risk_update_ios) nicht aktiviert wurde. Nutzerinnen und Nutzer können den Risikostatus dann in der App manuell aktualisieren.

--- a/blog/2020-09-17-ios-13-7-fix/index.md
+++ b/blog/2020-09-17-ios-13-7-fix/index.md
@@ -8,11 +8,7 @@ layout: blog
 ---
 
 
-In close cooperation with Apple, the developers could fix the [problem in Apple’s iOS 13.7 operating system](https://www.coronawarn.app/en/blog/2020-09-10-ios-13-bug/) that was identified a few days ago. Affected users should now receive a correctly calculated risk assessment under iOS 13.7 again.
-The adjustments were made directly on the server. This means that the Corona-Warn-App does not have to be updated and users do not have to do anything
-
+In close cooperation with Apple, the developers could fix the [problem in Apple’s iOS 13.7 operating system](/en/blog/2020-09-10-ios-13-bug/) that was identified a few days ago. Affected users should now receive a correctly calculated risk assessment under iOS 13.7 again.
+The adjustments were made directly on the server. This means that the Corona-Warn-App does not have to be updated and users do not have to do anything.
 
 <!-- overview -->
-
-
-

--- a/blog/2020-09-17-ios-13-7-fix/index_de.md
+++ b/blog/2020-09-17-ios-13-7-fix/index_de.md
@@ -7,7 +7,7 @@ author: Hanna Heine
 layout: blog
 ---
 
-Die Entwickler/innen konnten in enger Zusammenarbeit mit Apple das vor einigen Tagen erkannte [Problem im Apple-Betriebssystem iOS 13.7](https://www.coronawarn.app/de/blog/2020-09-10-ios-13-bug/) beheben, sodass potenziell alle betroffenen Nutzer\*innen wieder eine korrekt berechnete Risiko-Ermittlung unter iOS 13.7 erhalten. 
+Die Entwickler/innen konnten in enger Zusammenarbeit mit Apple das vor einigen Tagen erkannte [Problem im Apple-Betriebssystem iOS 13.7](/de/blog/2020-09-10-ios-13-bug/) beheben, sodass potenziell alle betroffenen Nutzer\*innen wieder eine korrekt berechnete Risiko-Ermittlung unter iOS 13.7 erhalten. 
 Die Anpassungen konnten direkt auf dem Server durchgeführt werden. Das bedeutet, es ist kein Update der Corona-Warn-App nötig und Nutzer\*innen müssen nichts weiter tun. 
 
 <!-- overview -->

--- a/blog/2020-09-23-bilanz-100-tage/index.md
+++ b/blog/2020-09-23-bilanz-100-tage/index.md
@@ -9,9 +9,6 @@ layout: blog
 
 The developers at SAP and Deutsche Telekom regard the first 100 days since the Corona-Warn-App’s launch as a success. Since its release on June 16,  the app has been downloaded more than 18.3 million times. This high number of downloads compared to other European countries shows that the population is giving the app a chance and is willing to use an intelligent technology to fight the spread of the pandemic.
 
-In this [document](https://www.coronawarn.app/assets/documents/2020-09-23-cwa-daten-fakten.pdf) (German only), based on the current data status, you will find further facts and figures about the Corona-Warn-App, the laboratory connection and the test results transmitted. 
+In this [document](/assets/documents/2020-09-23-cwa-daten-fakten.pdf) (German only), based on the current data status, you will find further facts and figures about the Corona-Warn-App, the laboratory connection and the test results transmitted. 
 
 <!-- overview -->
-
-
-


### PR DESCRIPTION
This PR coverts the following blog entries from September 2020 to use relative paths instead of absolute paths to https://www.coronawarn.app:

- [blog/2020-09-04-cwa-1-3-post](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2020-09-04-cwa-1-3-post)
- [blog/2020-09-17-ios-13-7-fix](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2020-09-17-ios-13-7-fix)
- [blog/2020-09-23-bilanz-100-tage](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2020-09-23-bilanz-100-tage)

It follows from the issue https://github.com/corona-warn-app/cwa-website/issues/1819.

I will groups the changes to following months into quarters of 3 months each. I wanted to avoid changing all blogs at once, just in case there is an error anywhere.