### PR TITLE
Additional linking hints for WRITE_BLOG_POSTS

### DIFF
--- a/docs/WRITE_BLOG_POSTS.md
+++ b/docs/WRITE_BLOG_POSTS.md
@@ -135,3 +135,21 @@ Example:
 ``` Markdown
 [Introduction](2018-08-01-introduction-to-cwa)
 ```
+
+### Link to other locations
+
+To link to other locations on the website use a relative path starting with `/en` or `/de` to refer to the location. Avoid including the absolute web path `https://www.coronawarn.app` in the link. Relative paths support testing weblinks correctly prior to publication.
+
+Note: Relative paths using `../` (go up one level) are not recommended in blog posts, since they are error prone in this situation. Blog sources are processed and published at two different levels: the blog overview and blog individual detail level.
+
+Example of links to the Screenshot section:
+
+In `index.md` of the blog post:
+``` Markdown
+[Take a Look](/en/screenshots)
+```
+
+In `index_de.md` of the blog post:
+``` Markdown
+[Machen Sie sich selbst ein Bild](/de/screenshots)
+```


### PR DESCRIPTION
This PR adds advice to the document [docs/WRITE_BLOG_POSTS.md](https://github.com/corona-warn-app/cwa-website/blob/master/docs/WRITE_BLOG_POSTS.md) in support of resolving the issue https://github.com/corona-warn-app/cwa-website/issues/1819 "Inconsistent use of absolute and relative paths to https://www.coronawarn.app".

The added text is:

![image](https://user-images.githubusercontent.com/66998419/137303402-6c6d04fb-1b19-4d12-b624-1da88494c53e.png)
