### PR TITLE
Remove wrong free of charge PCR test information from the FAQ (Addresses #1867)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -449,7 +449,7 @@
                         "anchor": "vac_cert_red_warning",
                         "active": true,
                         "textblock": [
-                            "If a fully vaccinated person is shown an encounter with increased risk (red tile), quarantine is not necessary at first if there are no symptoms. If symptoms occur in the further course, you should get tested immediately and go into immediate quarantine. Notification by the Corona-Warn-App about an increased risk allows for a free PCR test. In the case of unfinished basic immunization as well as in the first 14 days after the last dose, the vaccination protection is significantly lower, so that the same recommendations apply here as for unvaccinated."
+                            "If a fully vaccinated person is shown an encounter with increased risk (red tile), quarantine is not necessary at first if there are no symptoms. If symptoms occur in the further course, you should get tested immediately and go into immediate quarantine. If you want to get tested, please confer with your doctor for the futher procedure. In the case of unfinished basic immunization as well as in the first 14 days after the last dose, the vaccination protection is significantly lower, so that the same recommendations apply here as for unvaccinated."
                         ]
                     },
                     {
@@ -569,7 +569,7 @@
                         "active": true,
                         "textblock": [
                             "If the Corona-Warn-App shows you an encounter with increased risk (red tile), you should take a PCR test and quarantine yourself.",
-                            "An encounter with increased risk in the Corona-Warn-App allows you to take a free PCR test. Please confer with your doctor for the further procedure."
+                            "Please confer with your doctor for the further procedure."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -449,7 +449,7 @@
                         "anchor": "vac_cert_red_warning",
                         "active": true,
                         "textblock": [
-                            "Wenn eine vollständig geimpfte Person eine Begegnung mit erhöhtem Risiko (rote Kachel) angezeigt bekommt, ist zunächst keine Quarantäne nötig, solange keine Symptome auftreten. Falls im weiteren Verlauf Symptome auftreten, sollten Sie sich unmittelbar testen lassen und in sofortige Quarantäne begeben. Die Benachrichtigung durch die Corona-Warn-App über ein erhöhtes Risiko ermöglicht einen kostenlosen PCR-Test. Bei nicht abgeschlossener Grundimmunisierung sowie in den ersten 14 Tagen nach der letzten Dosis ist der Impfschutz deutlich geringer, so dass hier dieselben Empfehlungen wie bei Ungeimpften gelten."
+                            "Wenn eine vollständig geimpfte Person eine Begegnung mit erhöhtem Risiko (rote Kachel) angezeigt bekommt, ist zunächst keine Quarantäne nötig, solange keine Symptome auftreten. Falls im weiteren Verlauf Symptome auftreten, sollten Sie sich unmittelbar testen lassen und in sofortige Quarantäne begeben. Wenn Sie sich testen lassen wollen, konsultieren Sie bitte Ihren Arzt bzw. Ihre Ärztin für die weiteren Schritte. Die Benachrichtigung durch die Corona-Warn-App über ein erhöhtes Risiko ermöglicht einen kostenlosen PCR-Test. Bei nicht abgeschlossener Grundimmunisierung sowie in den ersten 14 Tagen nach der letzten Dosis ist der Impfschutz deutlich geringer, so dass hier dieselben Empfehlungen wie bei Ungeimpften gelten."
                         ]
                     },
                     {
@@ -569,7 +569,7 @@
                         "active": true,
                         "textblock": [
                             "Wenn die Corona-Warn-App Ihnen eine Begegnung mit erhöhtem Risiko (rote Kachel) anzeigt, sollten Sie einen PCR-Test machen und sich in Quarantäne begeben.",
-                            "Eine Begegnung mit erhöhtem Risiko in der Corona-Warn-App ermöglicht Ihnen einen kostenlosen PCR-Test. Bitte konsultieren Sie Ihren Arzt bzw. Ihre Ärztin für die weiteren Schritte."
+                            "Bitte konsultieren Sie Ihren Arzt bzw. Ihre Ärztin für die weiteren Schritte."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR is a first effort to remove the wrong information that a notification about an encounter with increased risk from the CWA allows for a free of charge PCR test. This statement is wrong, see #1867.

The information is replaced with the recommendation to confer with the doctor, who will decide how to proceed.

---

Closes #1867