### PR TITLE
Convert blogs 2021-04, -05 & -06 to relative paths

### DIFF
--- a/blog/2021-04-16-anpassung-risikoberechnung/index.md
+++ b/blog/2021-04-16-anpassung-risikoberechnung/index.md
@@ -16,5 +16,4 @@ The Corona-Warn-App's project team continuously improves the app's performance w
 
 For app users, this means: Previously, an encounter between two people had to last at least 13 minutes in order to be considered for an **encounter with an increased risk (red tile)**. Now, the app considers encounters of at least 9 minutes. Thus, encounters that represent an actual relevant contact with COVID-19 infected persons can be detected even more accurately and represented accordingly in the app as a warning about an encounter with increased risk. This **increases the number of warnings** by approximately 16 percent. The parameters are adjusted on the server. Users don't have to do anything.
  
-Most recently, the project team adjusted the risk calculation at the [end of March](https://www.coronawarn.app/en/blog/2021-03-19-risk-calculation-improvement/) in response to a virus mutation. It continues to work on improving the measurements and the resulting configuration parameters. 
-
+Most recently, the project team adjusted the risk calculation at the [end of March](/en/blog/2021-03-19-risk-calculation-improvement/) in response to a virus mutation. It continues to work on improving the measurements and the resulting configuration parameters.

--- a/blog/2021-04-16-anpassung-risikoberechnung/index_de.md
+++ b/blog/2021-04-16-anpassung-risikoberechnung/index_de.md
@@ -14,10 +14,4 @@ Mit Blick auf die Corona-Lage in Deutschland verfolgt das Projektteam der Corona
 
 Für Nutzer\*innen der Corona-Warn-App bedeutet das: Bisher musste eine Begegnung zwischen zwei Personen mindestens 13 Minuten dauern, um von der App für eine **Begegnung mit erhöhtem Risiko (rote Kachel)** berücksichtigt zu werden. Nun sind bereits Begegnungen von mindestens 9 Minuten ausreichend. So können Begegnungen, die einen tatsächlich relevanten Kontakt mit COVID-19 infizierten Personen darstellen, noch genauer erkannt und in der App entsprechend als Warnung über eine **Begegnung mit erhöhtem Risiko** darstellt werden. Die **Anzahl der Risikowarnungen** erhöht sich damit um circa 16 Prozent. Die Anpassung der Parameter erfolgt serverseitig, sodass Nutzer*innen nichts weiter tun müssen.  
  
-Zuletzt hat das Projektteam die Risikoberechnung [Ende März](https://www.coronawarn.app/de/blog/2021-03-19-risk-calculation-improvement/) angepasst, um mutierte Virusvarianten zu berücksichtigen. Die Projektbeteiligten arbeiten auch weiterhin an einer Verbesserung der Messungen und der daraus resultierenden Konfigurationsparameter. 
- 
- 
-
-
-
-
+Zuletzt hat das Projektteam die Risikoberechnung [Ende März](/de/blog/2021-03-19-risk-calculation-improvement/) angepasst, um mutierte Virusvarianten zu berücksichtigen. Die Projektbeteiligten arbeiten auch weiterhin an einer Verbesserung der Messungen und der daraus resultierenden Konfigurationsparameter.

--- a/blog/2021-04-23-qr-code-generator-website/index.md
+++ b/blog/2021-04-23-qr-code-generator-website/index.md
@@ -7,7 +7,7 @@ author: Hanna Heine
 layout: blog
 ---
 
-The Corona-Warn-App community has developed a QR code generator for the app's website, which is now available at http://coronawarn.app/en/eventregistration/. Event organizers, retailers and private individuals have the opportunity to generate QR codes independently of the Corona-Warn-App. In addition, the project team has published a Node.js-based command-line interface on GitHub, allowing larger organizations to build their own customized solutions.
+The Corona-Warn-App community has developed a QR code generator for the app's website, which is now available at [https://coronawarn.app/en/eventregistration/](/en/eventregistration/). Event organizers, retailers and private individuals have the opportunity to generate QR codes independently of the Corona-Warn-App. In addition, the project team has published a Node.js-based command-line interface on GitHub, allowing larger organizations to build their own customized solutions.
 
 <!-- overview -->
 

--- a/blog/2021-04-23-qr-code-generator-website/index_de.md
+++ b/blog/2021-04-23-qr-code-generator-website/index_de.md
@@ -7,7 +7,7 @@ author: Hanna Heine
 layout: blog
 ---
  
-Für die neue Funktion der Eventregistrierung hat die Community der Corona-Warn-App in Eigeninitiative einen **QR-Code-Generator** für die Website der Corona-Warn-App entwickelt, der ab sofort unter http://coronawarn.app/de/eventregistration/ zur Verfügung steht. Veranstalter\*innen, Einzelhändler\*innen und Privatpersonen haben damit die Möglichkeit, unabhängig von der Corona-Warn-App QR-Codes zu erzeugen. Zudem hat das Projektteam auf GitHub ein **Kommandozeilen-Werkzeug auf Node.js Basis** veröffentlicht, wodurch größere Organisationen die Möglichkeit haben, eigene, zugeschnittene Lösungen zu bauen.
+Für die neue Funktion der Eventregistrierung hat die Community der Corona-Warn-App in Eigeninitiative einen **QR-Code-Generator** für die Website der Corona-Warn-App entwickelt, der ab sofort unter [https://coronawarn.app/de/eventregistration/](/de/eventregistration/) zur Verfügung steht. Veranstalter\*innen, Einzelhändler\*innen und Privatpersonen haben damit die Möglichkeit, unabhängig von der Corona-Warn-App QR-Codes zu erzeugen. Zudem hat das Projektteam auf GitHub ein **Kommandozeilen-Werkzeug auf Node.js Basis** veröffentlicht, wodurch größere Organisationen die Möglichkeit haben, eigene, zugeschnittene Lösungen zu bauen.
 
 <!-- overview -->
 

--- a/blog/2021-05-02-cwa-2-1-schnelltests/index.md
+++ b/blog/2021-05-02-cwa-2-1-schnelltests/index.md
@@ -9,7 +9,7 @@ layout: blog
 
 ### Eight partners participate from the beginning
 
-Deutsche Telekom and SAP’s project team have integrated the [announced rapid COVID-19 tests](https://www.coronawarn.app/en/blog/2021-03-31-corona-warn-app-test-integration/) in the Corona-Warn-App’s latest version (2.1) launching today. Users can now break infection chains and warn their fellow citizens even faster. The update will be available to all users within the next 48 hours.
+Deutsche Telekom and SAP’s project team have integrated the [announced rapid COVID-19 tests](/en/blog/2021-03-31-corona-warn-app-test-integration/) in the Corona-Warn-App’s latest version (2.1) launching today. Users can now break infection chains and warn their fellow citizens even faster. The update will be available to all users within the next 48 hours.
 
 <!-- overview -->
 
@@ -49,7 +49,7 @@ In case of a positive rapid test result, users should share their test result an
 <center> <img src="./positive-test.png" title="Positive test result" style="align: center"></center>
 <br></br>
 
-Users who tested positive for COVID-19 and previously checked in to an event or at a location through the [**event registration feature**](https://www.coronawarn.app/en/blog/2021-04-21-corona-warn-app-version-2-0/) can share their check-ins along with the positive rapid test and/or PCR test result.
+Users who tested positive for COVID-19 and previously checked in to an event or at a location through the [**event registration feature**](/en/blog/2021-04-21-corona-warn-app-version-2-0/) can share their check-ins along with the positive rapid test and/or PCR test result.
 
 A **negative test result** in the app may serve users as evidence that they’ve obtained a negative rapid test result, if specified by law. However, the recognition of test evidence may vary from state to state. Users should therefore inform themselves about the respective criteria in their federal state.
 

--- a/blog/2021-05-02-cwa-2-1-schnelltests/index_de.md
+++ b/blog/2021-05-02-cwa-2-1-schnelltests/index_de.md
@@ -9,7 +9,7 @@ layout: blog
 
 ### Acht Partner sind zum Start dabei
 
-In der neuesten Version der Corona-Warn-App (2.1) hat das Projektteam aus Deutscher Telekom und SAP die [angekündigten Schnelltests](https://www.coronawarn.app/de/blog/2021-03-31-corona-warn-app-test-integration/) integriert, sodass Nutzer\*innen ihre Mitmenschen nun noch schneller warnen und Infektionsketten noch schneller unterbrechen können. Das Update steht allen Nutzer\*innen innerhalb der nächsten 48 Stunden zur Verfügung.
+In der neuesten Version der Corona-Warn-App (2.1) hat das Projektteam aus Deutscher Telekom und SAP die [angekündigten Schnelltests](/de/blog/2021-03-31-corona-warn-app-test-integration/) integriert, sodass Nutzer\*innen ihre Mitmenschen nun noch schneller warnen und Infektionsketten noch schneller unterbrechen können. Das Update steht allen Nutzer\*innen innerhalb der nächsten 48 Stunden zur Verfügung.
 
 <!-- overview -->
 
@@ -44,7 +44,7 @@ Zwar werden die persönliche Daten der Nutzer\*innen an den Teststellen gespeich
 
 In Fall eines **positiven Schnelltest-Ergebnisses** sollten Nutzer\*innen außerdem umgehend einen PCR-Test machen, um das Ergebnis zu bestätigen oder zu widerlegen. Bei einem positiven PCR-Test, sollten Nutzer*innen auch dieses Testergebnis teilen. So können sie Kontaktpersonen warnen, denen sie möglicherweise seit Teilen des Schnelltest-Ergebnisses bis zum Teilen des PCR-Test-Ergebnisses begegnet sind. Sollte der PCR-Test negativ sein, haben sie aber nicht die Möglichkeit, ihren positiven Schnelltest und die Warnung zurückzuziehen.
 
-Positiv auf COVID-19 getestete Nutzer\*innen, die zuvor über die [**Funktion der Eventregistrierung**](https://www.coronawarn.app/de/blog/2021-04-21-corona-warn-app-version-2-0/) bei einem Event oder an einem Ort eingecheckt waren, können ihre  Check-ins gemeinsam mit dem positiven Schnelltest- und/oder PCR-Testergebnis teilen.
+Positiv auf COVID-19 getestete Nutzer\*innen, die zuvor über die [**Funktion der Eventregistrierung**](/de/blog/2021-04-21-corona-warn-app-version-2-0/) bei einem Event oder an einem Ort eingecheckt waren, können ihre  Check-ins gemeinsam mit dem positiven Schnelltest- und/oder PCR-Testergebnis teilen.
 
 Ein **negatives Testergebnis** in der App kann Nutzer\*innen, falls gesetzlich festgelegt, als **Nachweis** für das Vorliegen eines negativen Schnelltest-Ergebnisses dienen. Die Anerkennung von Test-Nachweisen kann allerdings von Bundesland zu Bundesland variieren. Nutzer*innen sollten sich deshalb über die jeweiligen Kriterien in ihrem Bundesland informieren.
 

--- a/blog/2021-06-24 CWA 2.4 Testzertifikat/index.md
+++ b/blog/2021-06-24 CWA 2.4 Testzertifikat/index.md
@@ -57,7 +57,7 @@ Once the test result is available, it is now automatically added to the **contac
 <center> <img src="./contact-journal-tests.png" title="Tests in contact journal" style="align: center"></center>
 <br></br>
 
-The **voluntary data donation** now also includes alerts that users share due to a positive rapid test. For PCR tests, this is already possible since [version 1.13](https://www.coronawarn.app/en/blog/2021-03-04-corona-warn-app-version-1-13/) of the Corona-Warn-App. Furthermore, the data donation captures data points on warnings from the event registration feature (similar to the capturing of warnings that users receive based on the distance measurement via Bluetooth). The project team also records whether users share their event check-ins. A prerequisite for the recording is that users have activated the voluntary donation of data.
+The **voluntary data donation** now also includes alerts that users share due to a positive rapid test. For PCR tests, this is already possible since [version 1.13](/en/blog/2021-03-04-corona-warn-app-version-1-13/) of the Corona-Warn-App. Furthermore, the data donation captures data points on warnings from the event registration feature (similar to the capturing of warnings that users receive based on the distance measurement via Bluetooth). The project team also records whether users share their event check-ins. A prerequisite for the recording is that users have activated the voluntary donation of data.
 
 ### Rapid test partner search allows users to quickly find test providers that support the CWA
 

--- a/blog/2021-06-24 CWA 2.4 Testzertifikat/index_de.md
+++ b/blog/2021-06-24 CWA 2.4 Testzertifikat/index_de.md
@@ -59,7 +59,7 @@ Das Testergebnis wird nun automatisch dem **Kontakt-Tagebuch** hinzugefügt, sob
 <center> <img src="./tests-kontakt-tagebuch.png" title="Tests im Kontakt-Tagebuch" style="align: center"></center>
 <br></br>
 
-In die **freiwillige Datenspende** fließen nun auch Warnungen ein, die Nutzer\*innen aufgrund eines positiven Schnelltests teilen, wie es seit [Version 1.13](https://www.coronawarn.app/de/blog/2021-03-04-corona-warn-app-version-1-13/) schon für PCR-Tests möglich ist. Des Weiteren erfasst die Datenspende Datenpunkte zu Warnungen, die auf die Funktion der Event-Registrierung zurückzuführen sind - analog dazu, wie bereits erfasst wird, dass Nutzer\*innen auf Basis der Abstandsmessung durch Bluetooth eine Warnung erhalten. Das Projektteam erfasst außerdem, ob Nutzer\*innen ihre Event-Check-Ins mit freigeben. Voraussetzung für die Erfassung ist, dass Nutzer\*innen die freiwillige Datenspende aktiviert haben.
+In die **freiwillige Datenspende** fließen nun auch Warnungen ein, die Nutzer\*innen aufgrund eines positiven Schnelltests teilen, wie es seit [Version 1.13](/de/blog/2021-03-04-corona-warn-app-version-1-13/) schon für PCR-Tests möglich ist. Des Weiteren erfasst die Datenspende Datenpunkte zu Warnungen, die auf die Funktion der Event-Registrierung zurückzuführen sind - analog dazu, wie bereits erfasst wird, dass Nutzer\*innen auf Basis der Abstandsmessung durch Bluetooth eine Warnung erhalten. Das Projektteam erfasst außerdem, ob Nutzer\*innen ihre Event-Check-Ins mit freigeben. Voraussetzung für die Erfassung ist, dass Nutzer\*innen die freiwillige Datenspende aktiviert haben.
 
 ### Schnelltestpartnersuche online ermöglicht Nutzer*innen Testanbieter zu finden, die die CWA unterstützen
 


### PR DESCRIPTION
This PR coverts the following blog entries from April, May and June 2021 to use relative paths instead of absolute paths to http://coronawarn.app or to https://www.coronawarn.app:

### April 2021

- [blog/2021-04-16-anpassung-risikoberechnung](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-04-16-anpassung-risikoberechnung)
- [2021-04-23-qr-code-generator-website](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-04-23-qr-code-generator-website)

### May 2021

- [blog/2021-05-02-cwa-2-1-schnelltests](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-05-02-cwa-2-1-schnelltests)

### June 2021

- [blog/2021-06-24 CWA 2.4 Testzertifikat](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-06-24 CWA 2.4 Testzertifikat)

It follows from the issue #1819.