### PR TITLE
Convert blogs 2021-07, -08 & -09 to relative paths

### DIFF
--- a/blog/2021-07-08_Risikioberechnung_Virusvarianten/index.md
+++ b/blog/2021-07-08_Risikioberechnung_Virusvarianten/index.md
@@ -17,4 +17,4 @@ At this point in time, the scientific evidence is not yet sufficient to make a c
 
 Currently, an encounter with a person testing positive for SARS-CoV-2 must have been measured for at least 9 weighted minutes in a defined proximity area to be considered by the app as an encounter with increased risk ("red tile").
 
-The adjustment of the parameters is done server-sided, so users do not have to do anything here. As soon as there will be a new adjustment, the project team will inform about changes on the blog (https://www.coronawarn.app/en/blog) and on Twitter (https://twitter.com/coronawarnapp).
+The adjustment of the parameters is done server-sided, so users do not have to do anything here. As soon as there will be a new adjustment, the project team will inform about changes on the [blog](/en/blog) and on Twitter (https://twitter.com/coronawarnapp).

--- a/blog/2021-07-08_Risikioberechnung_Virusvarianten/index_de.md
+++ b/blog/2021-07-08_Risikioberechnung_Virusvarianten/index_de.md
@@ -18,4 +18,4 @@ Zum jetzigen Zeitpunkt reicht die wissenschaftliche Evidenz noch nicht aus, um e
 
 Aktuell muss eine Begegnung mit einer positiv auf SARS-CoV-2 getesteten Person mindestens 9 gewichtete Minuten in einem definierten Nähebereich gemessen worden sein, um von der App als Begegnung mit erhöhtem Risiko („rote Kachel“) berücksichtigt zu werden.
 
-Die Anpassung der Parameter erfolgt serverseitig, so dass Nutzer*innen nichts weiter tun müssen. Sobald es eine neue Anpassung geben wird, wird das Projektteam im Rahmen des Blogs (https://www.coronawarn.app/de/blog/) und auf Twitter (https://twitter.com/coronawarnapp) dazu informieren.
+Die Anpassung der Parameter erfolgt serverseitig, so dass Nutzer*innen nichts weiter tun müssen. Sobald es eine neue Anpassung geben wird, wird das Projektteam im Rahmen des [Blogs](/de/blog/) und auf Twitter (https://twitter.com/coronawarnapp) dazu informieren.

--- a/blog/2021-07-12-cwa-2-5/index.md
+++ b/blog/2021-07-12-cwa-2-5/index.md
@@ -13,7 +13,7 @@ In addition, the section with statistics now contains **key figures on the vacci
 
 <!-- overview -->
 
-With version 2.5, users can add **certificates of recovery** to their Corona-Warn-App by going to the "Certificates" tab in the tab bar and selecting "Add Certificate." They can then scan the QR code they received from their family physician. For more information on adding vaccination certificates, click [here](https://www.coronawarn.app/en/blog/2021-06-10-cwa-version-2-3/). 
+With version 2.5, users can add **certificates of recovery** to their Corona-Warn-App by going to the "Certificates" tab in the tab bar and selecting "Add Certificate." They can then scan the QR code they received from their family physician. For more information on adding vaccination certificates, click [here](/en/blog/2021-06-10-cwa-version-2-3/). 
 
 Certificates of recovery are stored indefinitely in the app. However, it depends on federal regulations for how long they serve as official proof of recovery.  
 
@@ -41,7 +41,7 @@ At this point, they can also activate a slider under their own name to indicate 
 
 Users cannot define the QR code that is displayed first in the overview of the certificate wallet. If multiple certificates are available, test certificates automatically appear before vaccination certificates or certificates of recovery, as long as they are not older than 48 (PCR test) or 24 hours (rapid test).
 
-Users can add **digital test certificates for PCR and rapid tests** by registering a test in the Corona-Warn-App and requesting the test certificate during the registration process, just like it has been possible since version 2.4 of the CWA. If the test result is negative, the digital certificate will appear in the wallet under the individual's name. More detailed information on requesting digital test certificates can be found [here](https://www.coronawarn.app/en/blog/2021-06-24-cwa-version-2-4/). 
+Users can add **digital test certificates for PCR and rapid tests** by registering a test in the Corona-Warn-App and requesting the test certificate during the registration process, just like it has been possible since version 2.4 of the CWA. If the test result is negative, the digital certificate will appear in the wallet under the individual's name. More detailed information on requesting digital test certificates can be found [here](/en/blog/2021-06-24-cwa-version-2-4/). 
 
 As of version 2.5, they can also add test certificates to the app that they did not receive through the CWA by tapping "Add Certificate" under "Certificates" and scanning the QR code they received at the testing site. This may be the case, for example, for **test results from other countries** within the EU, as well as Iceland, Norway, Liechtenstein, and Switzerland.  
 
@@ -56,4 +56,3 @@ Under the key figures section in their Corona-Warn-App, users can now see how ma
 <br></br>
 
 Version 2.5 - like previous versions - will be delivered in a staged rollout and is made available for users in waves. While users can manually trigger an update in Apple’s App Store, this option is not available in the Google Play Store. There, the delivery of the Corona-Warn-App’s new version can take up to 48 hours.
-

--- a/blog/2021-07-12-cwa-2-5/index_de.md
+++ b/blog/2021-07-12-cwa-2-5/index_de.md
@@ -15,7 +15,7 @@ Außerdem werden in den Statistiken nun zusätzlich **Kennzahlen über den Forts
 
 <!-- overview -->
 
-Mit Version 2.5 können Nutzer\*innen **Genesenenzertifikate** in die Corona-Warn-App integrieren, indem sie, genau wie bei Impfzertifikaten, in der Registerkarte auf den Reiter „Zertifikate“ gehen und dort „Zertifikat hinzufügen“ auswählen. Anschließend können sie den QR-Code, den sie von ihrem Hausarzt/ihrer Hausärztin erhalten haben, scannen. Weitere Informationen zum Hinzufügen von Impfzertifikaten finden Sie [hier](https://www.coronawarn.app/de/blog/2021-06-10-cwa-version-2-3/). 
+Mit Version 2.5 können Nutzer\*innen **Genesenenzertifikate** in die Corona-Warn-App integrieren, indem sie, genau wie bei Impfzertifikaten, in der Registerkarte auf den Reiter „Zertifikate“ gehen und dort „Zertifikat hinzufügen“ auswählen. Anschließend können sie den QR-Code, den sie von ihrem Hausarzt/ihrer Hausärztin erhalten haben, scannen. Weitere Informationen zum Hinzufügen von Impfzertifikaten finden Sie [hier](/de/blog/2021-06-10-cwa-version-2-3/). 
 
 <br></br>
 <center> <img src="./Genesenenzertifikat (3).png" title="Genesenenzertifikat" style="align: center"> <img src="./Genesenenzertifikat (1).png" title="Genesenenzertifikat Details" style="align: center"> </center>
@@ -45,7 +45,7 @@ An dieser Stelle können Nutzer\*innen unter ihrem eigenen Namen einen Schiebere
 
 In der Übersicht des Zertifikats-Wallets wird pro Person das **relevanteste Zertifikat zuerst** angezeigt. Beispielsweise wird das Testzertifikat eines aktuellen PCR- oder Schnelltests angezeigt, selbst, wenn der oder die Nutzer\*in ein Impfzertifikat mit vollständigem Schutz hat. Sobald der Test nicht mehr aktuell ist (nach 24 beziehungsweise 48 Stunden), wird automatisch das Impfzertifikat an erster Stelle angezeigt.
 
-Wie schon in CWA-Version 2.4 möglich, können Nutzer\*innen **digitale Testzertifikate für PCR- und Schnelltests** hinzufügen, indem sie einen Test in der Corona-Warn-App registrieren und somit das Testzertifikat anfordern. Ist das Testergebnis negativ, erscheint das digitale Zertifikat im Wallet unter dem Namen der jeweiligen Person. Genauere Informationen zur Anforderung digitaler Testzertifikate finden Sie [hier](https://www.coronawarn.app/de/blog/2021-06-24-cwa-version-2-4/), Information zum Buchen und Integrieren von Schnelltests [hier](https://www.coronawarn.app/de/blog/2021-05-11-how-to-rapid-test-integration/). 
+Wie schon in CWA-Version 2.4 möglich, können Nutzer\*innen **digitale Testzertifikate für PCR- und Schnelltests** hinzufügen, indem sie einen Test in der Corona-Warn-App registrieren und somit das Testzertifikat anfordern. Ist das Testergebnis negativ, erscheint das digitale Zertifikat im Wallet unter dem Namen der jeweiligen Person. Genauere Informationen zur Anforderung digitaler Testzertifikate finden Sie [hier](/de/blog/2021-06-24-cwa-version-2-4/), Information zum Buchen und Integrieren von Schnelltests [hier](/de/blog/2021-05-11-how-to-rapid-test-integration/). 
 
 Ab Version 2.5 können Nutzer\*innen außerdem Testzertifikate in die App integrieren, die sie nicht über die Corona-Warn-App erhalten haben, indem sie unter „Zertifikate“ auf „Zertifikat hinzufügen“ tippen und den QR-Code scannen, den sie an der Teststelle erhalten haben. Das kann zum Beispiel bei **Testergebnissen aus anderen Ländern** innerhalb der EU sowie Island, Norwegen, Liechtenstein und der Schweiz der Fall sein. 
 

--- a/blog/2021-07-28-cwa-2-6/index.md
+++ b/blog/2021-07-28-cwa-2-6/index.md
@@ -77,7 +77,7 @@ A certificate may also be invalid for various reasons. One reason may be that **
 
 From version 2.6 onwards, users can manage all important functions related to their tests via **"Manage Your Tests”** on their app’s home screen. In that section, they can now find a **test center in their vicinity** that is connected to the app’s infrastructure by tapping "Find Testing Center". They will be redirected to the rapid test center search on the CWA website. 
 
-Additionally, users can now **edit their rapid test profile** in that section to change their specified data. You can find more information about the rapid test profile [here](https://www.coronawarn.app/en/blog/2021-05-12-corona-warn-app-version-2-2/).
+Additionally, users can now **edit their rapid test profile** in that section to change their specified data. You can find more information about the rapid test profile [here](/en/blog/2021-05-12-corona-warn-app-version-2-2/).
 
 
 Version 2.6 - like previous versions - will be delivered in a staged rollout and is made available for users in waves. While users can manually trigger an update in Apple’s App Store, this option is not available in the Google Play Store. There, the delivery of the Corona-Warn-App’s new version can take up to 48 hours.

--- a/blog/2021-07-28-cwa-2-6/index_de.md
+++ b/blog/2021-07-28-cwa-2-6/index_de.md
@@ -84,7 +84,7 @@ Ein Zertifikat kann aber auch aus verschiedenen Gründen ungültig sein. Zum Bei
 
 Ab Version 2.6 können Nutzer\*innen über die Kachel **„Sie lassen sich testen?“** auf der Startseite ihrer App alle wichtigen Funktionen rund um ihre Tests verwalten. In der **Testverwaltung** haben sie ab dieser Version die Möglichkeit, eine **Teststelle in ihrer Nähe** zu finden, die an die Infrastruktur der Corona-Warn-App angebunden ist: Gehen die Nutzer\*innen auf „Testmöglichkeit finden“, werden sie zur Schnellteststellensuche auf der Website der Corona-Warn-App weitergeleitet. 
 
-Außerdem können sie in der Testverwaltung nun auch ein bereits angelegtes **Schnelltest-Profil bearbeiten**, um ihre angegebenen Daten zu ändern. Mehr Informationen zum Schnelltest-Profil finden Sie [hier](https://www.coronawarn.app/de/blog/2021-05-12-corona-warn-app-version-2-2/).
+Außerdem können sie in der Testverwaltung nun auch ein bereits angelegtes **Schnelltest-Profil bearbeiten**, um ihre angegebenen Daten zu ändern. Mehr Informationen zum Schnelltest-Profil finden Sie [hier](/de/blog/2021-05-12-corona-warn-app-version-2-2/).
 
 
 Version 2.6 wird, wie vorherige Versionen auch, schrittweise über 48 Stunden an alle Nutzer*innen ausgerollt. iOS-Nutzer\*innen können sich die aktuelle App-Version ab sofort aus dem Store von Apple manuell herunterladen. Der Google Play Store bietet keine Möglichkeit, ein manuelles Update anzustoßen. Hier steht Nutzer\*innen die neue Version der Corona-Warn-App innerhalb der nächsten 48 Stunden zur Verfügung.

--- a/blog/2021-08-25-CWA-2-8/index.md
+++ b/blog/2021-08-25-CWA-2-8/index.md
@@ -25,7 +25,7 @@ In addition, the project team has adapted the **EU certificate check**. If a cou
 
 Previously, the app indicated in this case that the certificate is valid in the selected country. In the text below, however, it was pointed out that there are currently no entry rules available for the selected country. With version 2.8, users can clearly see that the certificate's validity could not be checked because the relevant country has not defined any entry rules. 
 
-Since [version 2.6](https://www.coronawarn.app/en/blog/2021-07-28-cwa-version-2-6/) of the Corona-Warn-App, users can check whether their certificates are valid in their destination country before travelling.  
+Since [version 2.6](/en/blog/2021-07-28-cwa-version-2-6/) of the Corona-Warn-App, users can check whether their certificates are valid in their destination country before travelling.  
 
 <br></br>
 <center> <img src="./validity-new-en.png" title="certificate cannot be validated" style="align: center"></center>
@@ -41,4 +41,3 @@ Since [version 2.6](https://www.coronawarn.app/en/blog/2021-07-28-cwa-version-2-
 Generally, every European country that supports EU digital COVID certificates has the option to store rules on the corresponding EU server that the Corona-Warn-App can compare for verification.
 
 Version 2.8 - like previous versions - will be delivered in a staged rollout and is made available for users in waves. While users can manually trigger an update in Apple’s App Store, this option is not available in the Google Play Store. There, the delivery of the Corona-Warn-App’s new version can take up to 48 hours.
-

--- a/blog/2021-08-25-CWA-2-8/index_de.md
+++ b/blog/2021-08-25-CWA-2-8/index_de.md
@@ -28,7 +28,7 @@ Die Länder, die unter der Zertifikatsprüfung in der Corona-Warn-App aufgeliste
 
 Zuvor hat die App in diesem Fall angezeigt, dass das Zertifikat im gewählten Land gültig sei. Im Text darunter wies sie aber darauf hin, dass für das Zertifikat derzeit keine Einreiseregeln für das gewählte Land vorhanden sind. Mit Version 2.8 wird für die Nutzer\*innen klar erkennbar, dass die Gültigkeit nicht überprüft werden konnte, da das entsprechende Land keine Einreiseregeln hinterlegt hat. 
 
-Nutzer\*innen können mit der Zertifikatsprüfung seit [Version 2.6](https://www.coronawarn.app/de/blog/2021-07-28-cwa-version-2-6/) vor einer Reise prüfen, ob ihre Zertifikate in dem Land, in das sie reisen, gültig sind. 
+Nutzer\*innen können mit der Zertifikatsprüfung seit [Version 2.6](/de/blog/2021-07-28-cwa-version-2-6/) vor einer Reise prüfen, ob ihre Zertifikate in dem Land, in das sie reisen, gültig sind. 
 
 <br></br>
 <center> <img src="./gültigkeit-neu-de.png" title="Zertifikat nicht prüfbar" style="align: center"></center>

--- a/blog/2021-09-08-CWA-2-9/index.md
+++ b/blog/2021-09-08-CWA-2-9/index.md
@@ -63,7 +63,7 @@ Furthermore, users who have received a **booster vaccination** can transfer thei
 
 With the update, users who have had a PCR or rapid test can access the EU's digital COVID test certificate directly from their test result. The certificate serves as official proof of a negative test result.
 
-Users can select the test result on their app’s home screen and then tap on "Test Certificate" under the test result to directly navigate to the certificate – provided they’ve requested it in advance when registering the test (for more information see [here](https://www.coronawarn.app/en/blog/2021-06-24-cwa-version-2-4/)). 
+Users can select the test result on their app’s home screen and then tap on "Test Certificate" under the test result to directly navigate to the certificate – provided they’ve requested it in advance when registering the test (for more information see [here](/en/blog/2021-06-24-cwa-version-2-4/)). 
 
 
 <br></br>

--- a/blog/2021-09-08-CWA-2-9/index_de.md
+++ b/blog/2021-09-08-CWA-2-9/index_de.md
@@ -62,7 +62,7 @@ Des Weiteren können Nutzer\*innen, die eine **Auffrischungsimpfung** erhalten h
 <center> <img src="./booster-impfung_v2.png" title="Auffrischungsimpfung" style="align: center" width=250> </center>
 <br></br>
 
-Außerdem können nun sowohl Android- als auch iOS-Nutzer\*innen, die einen PCR- oder Schnelltest durchgeführt haben, direkt aus ihrem Testergebnis heraus das **digitale COVID-Testzertifikat der EU aufrufen**. Dazu wählen sie das Testergebnis auf der Startseite ihrer App. Anschließend können sie darunter „Testzertifikat“ auswählen. Voraussetzung ist, dass sie das Zertifikat vorab bei der Registrierung des Tests beantragt haben (mehr Informationen dazu finden Sie [hier](https://www.coronawarn.app/de/blog/2021-06-24-cwa-version-2-4/)).
+Außerdem können nun sowohl Android- als auch iOS-Nutzer\*innen, die einen PCR- oder Schnelltest durchgeführt haben, direkt aus ihrem Testergebnis heraus das **digitale COVID-Testzertifikat der EU aufrufen**. Dazu wählen sie das Testergebnis auf der Startseite ihrer App. Anschließend können sie darunter „Testzertifikat“ auswählen. Voraussetzung ist, dass sie das Zertifikat vorab bei der Registrierung des Tests beantragt haben (mehr Informationen dazu finden Sie [hier](/de/blog/2021-06-24-cwa-version-2-4/)).
 
 Das Testzertifikat dient Nutzer\*innen als offizieller Nachweis für das Vorliegen eines negativen Testergebnisses. 
 


### PR DESCRIPTION
This PR coverts the following blog entries from April, May and June 2021 to use relative paths instead of absolute paths to https://www.coronawarn.app:

### July 2021

- [blog/2021-07-08_Risikioberechnung_Virusvarianten](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-07-08_Risikioberechnung_Virusvarianten)
- [blog/2021-07-12-cwa-2-5](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-07-12-cwa-2-5)
- [blog/2021-07-28-cwa-2-6](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-07-28-cwa-2-6)

### August 2021

- [blog/2021-08-25-CWA-2-8](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-08-25-CWA-2-8)

### September 2021

- [blog/2021-09-08-CWA-2-9](https://github.com/corona-warn-app/cwa-website/tree/master/blog/2021-09-08-CWA-2-9)

It follows from the issue #1819.