### PR TITLE
Convert Glossary entries to use relative paths

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2259,7 +2259,7 @@
                 {
                     "term": "Data Donation",
                     "anchor": "data_donation",
-                    "description": "A voluntary and anonymous way to provide the RKI with data on the use of the CWA. Voluntary data donation can help experts evaluate the effectiveness of the app and further improve it. More information is summarized here: <a href='https://www.coronawarn.app/en/blog/2021-03-04-corona-warn-app-version-1-13/'>Science Blog: Users can provide data voluntarily to help improve the Corona-Warn-App further</a>."
+                    "description": "A voluntary and anonymous way to provide the RKI with data on the use of the CWA. Voluntary data donation can help experts evaluate the effectiveness of the app and further improve it. More information is summarized here: <a href='/en/blog/2021-03-04-corona-warn-app-version-1-13/'>Science Blog: Users can provide data voluntarily to help improve the Corona-Warn-App further</a>."
                 },
                 {
                     "term": "DCC",
@@ -2321,7 +2321,7 @@
                 {
                     "term": "Exposure Notification Express (ENE)",
                     "anchor": "ene",
-                    "description": "See FAQ: <a href='https://www.coronawarn.app/en/faq/#ene' target='_blank' rel='noopener noreferrer'>Exposure Notification Express (ENE)</a>"
+                    "description": "See FAQ: <a href='/en/faq/#ene' target='_blank' rel='noopener noreferrer'>Exposure Notification Express (ENE)</a>"
                 },
                 {
                     "term": "Exposure Notification Framework (ENF)",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2268,7 +2268,7 @@
                 {
                     "term": "Datenspende",
                     "anchor": "data_donation",
-                    "description": "Eine freiwillige und anonyme Möglichkeit dem RKI Daten über die Nutzung der CWA zukommen zu lassen. Die freiwillige Datenspende kann den Expert*innen helfen, die Wirksamkeit der App zu bewerten und sie weiter zu verbessern. Weitere Informationen sind hier zusammengefasst: <a href='https://www.coronawarn.app/de/blog/2021-03-04-corona-warn-app-version-1-13/'>Science Blog: Corona-Warn-App nun mit Datenspende und Link zu wissenschaftlicher Befragung</a>"
+                    "description": "Eine freiwillige und anonyme Möglichkeit dem RKI Daten über die Nutzung der CWA zukommen zu lassen. Die freiwillige Datenspende kann den Expert*innen helfen, die Wirksamkeit der App zu bewerten und sie weiter zu verbessern. Weitere Informationen sind hier zusammengefasst: <a href='/de/blog/2021-03-04-corona-warn-app-version-1-13/'>Science Blog: Corona-Warn-App nun mit Datenspende und Link zu wissenschaftlicher Befragung</a>"
                 },
                 {
                     "term": "DCC",
@@ -2315,7 +2315,7 @@
                 {
                     "term": "Exposure Notification Express (ENE)",
                     "anchor": "ene",
-                    "description": "Siehe FAQ: <a href='https://www.coronawarn.app/de/faq/#ene' target='_blank' rel='noopener noreferrer'>Exposure Notification Express (ENE)</a>"
+                    "description": "Siehe FAQ: <a href='/de/faq/#ene' target='_blank' rel='noopener noreferrer'>Exposure Notification Express (ENE)</a>"
                 },
                 {
                     "term": "Exposure Notification Framework (ENF)",


### PR DESCRIPTION
This PR coverts the following FAQ Glossary entries to use relative paths in hyperlinks:

- https://www.coronawarn.app/en/faq/#glossary_data_donation "Data Donation"
- https://www.coronawarn.app/de/faq/#glossary_data_donation "Datenspende"
- https://www.coronawarn.app/en/faq/#glossary_ene "Exposure Notification Express (ENE)"
- https://www.coronawarn.app/de/faq/#glossary_ene "Exposure Notification Express (ENE)"

It follows from the issue #1819.

This should be the last PR at the moment to covert absolute paths to relative paths.