### PR TITLE
Typo in page description of "Why the Corona-Warn-App is important right now"

### DIFF
--- a/blog/2021-10-11-wichtigste-Funktionen/index.md
+++ b/blog/2021-10-11-wichtigste-Funktionen/index.md
@@ -1,6 +1,6 @@
 ---
 page-title: "Why the Corona-Warn-App is important right now"
-page-description: "WWhy the Corona-Warn-App is important right now"
+page-description: "Why the Corona-Warn-App is important right now"
 page-name: cwa-most-important-features
 page-name_de: cwa-most-important-features
 author: Hanna Heine


### PR DESCRIPTION
This PR corrects a typo of text used in the meta-data of

https://www.coronawarn.app/en/blog/2021-10-11-cwa-most-important-features/

It removes the extra character "W" from 
`page-description: "WWhy the Corona-Warn-App is important right now"` in
https://github.com/corona-warn-app/cwa-website/blob/master/blog/2021-10-11-wichtigste-Funktionen/index.md

Search engines may use this meta-data so it should be corrected.