### PR TITLE
Add 'am' for DE dates and 'on' for EN dates

### DIFF
--- a/src/services/blog-processor.js
+++ b/src/services/blog-processor.js
@@ -18,7 +18,7 @@ const blogHtmlPath = (lang) => path.join(rootFolder, 'src', 'pages', lang, data[
 const formatDate = (date, lang) => {
   const mom = moment(date);
   mom.locale(lang);
-  return mom.format('LL');
+  return (lang == "de" ? "am" : "on" )+" "+mom.format('LL');
 }
 
 const hasValidDate = (dateStr) => {


### PR DESCRIPTION
In this PR I had solved issue #1201 including 'am' for German dates and 'on' for English dates.

German:

![image](https://user-images.githubusercontent.com/44208107/137889050-500bf142-5ce3-47e1-8995-f95945c699b7.png)

English:

![image](https://user-images.githubusercontent.com/44208107/137889126-c66e9bc1-998d-4868-9ef1-5bbf704b96ac.png)
