### PR TITLE
Convert 2.12 blog to use relative path

### DIFF
--- a/blog/2021-10-19-cwa-2-12/index.md
+++ b/blog/2021-10-19-cwa-2-12/index.md
@@ -53,8 +53,6 @@ The **7-day hospitalization incidence** refers to the number of people being hos
 
 Furthermore, the project team has **standardized the message settings**. As with other apps, users can now define settings for notifications from the Corona-Warn-App in the device settings of their smartphone. There, they can not only turn notifications on or off, but also define notification types.
 
-Another new feature is available for **iOS users**: They can now import QR codes from images or PDF documents. After opening the QR code scanner, they can select "Open file" at the bottom left and import a QR code from their image or file library. For Android users, [this function](https://www.coronawarn.app/en/blog/2021-10-06-cwa-version-2-11/) has already been available since version 2.11.
+Another new feature is available for **iOS users**: They can now import QR codes from images or PDF documents. After opening the QR code scanner, they can select "Open file" at the bottom left and import a QR code from their image or file library. For Android users, [this function](/en/blog/2021-10-06-cwa-version-2-11/) has already been available since version 2.11.
 
 Version 2.12 - like previous versions - will be delivered in a staged rollout and is made available for users in waves. While users can manually trigger an update in Apple’s App Store, this option is not available in the Google Play Store. There, the delivery of the Corona-Warn-App’s new version can take up to 48 hours.
-
-

--- a/blog/2021-10-19-cwa-2-12/index_de.md
+++ b/blog/2021-10-19-cwa-2-12/index_de.md
@@ -51,7 +51,6 @@ Des Weiteren hat das Projektteam die **Mitteilungseinstellungen vereinheitlicht*
 
 Zuvor konnten Nutzer\*innen die Benachrichtigungen in der Corona-Warn-App entweder zulassen oder nicht erlauben.
 
-Eine weitere Neuerung gibt es jetzt auch für **iOS-Nutzer\*innen**: Sie können nun ebenfalls **QR-Codes aus Bildern oder PDF-Dokumenten importieren**. Nachdem sie den QR-Code-Scanner geöffnet haben, können sie unten links „Datei öffnen“ auswählen und darüber einen QR-Code aus ihrer Bild- oder Dateibibliothek importieren. Für Android-Nutzer\*innen steht [diese Funktion](https://www.coronawarn.app/de/blog/2021-10-06-cwa-version-2-11/) bereits seit Version 2.11 zur Verfügung.
+Eine weitere Neuerung gibt es jetzt auch für **iOS-Nutzer\*innen**: Sie können nun ebenfalls **QR-Codes aus Bildern oder PDF-Dokumenten importieren**. Nachdem sie den QR-Code-Scanner geöffnet haben, können sie unten links „Datei öffnen“ auswählen und darüber einen QR-Code aus ihrer Bild- oder Dateibibliothek importieren. Für Android-Nutzer\*innen steht [diese Funktion](/de/blog/2021-10-06-cwa-version-2-11/) bereits seit Version 2.11 zur Verfügung.
 
 Version 2.12 wird, wie vorherige Versionen auch, schrittweise über 48 Stunden an alle Nutzer\*innen ausgerollt. iOS-Nutzer\*innen können sich die aktuelle App-Version ab sofort aus dem Store von Apple manuell herunterladen. Der Google Play Store bietet keine Möglichkeit, ein manuelles Update anzustoßen. Hier steht Nutzer\*innen die neue Version der Corona-Warn-App innerhalb der nächsten 48 Stunden zur Verfügung.
-


### PR DESCRIPTION
This PR converts the link to the [2.11 blog article](https://www.coronawarn.app/en/blog/2021-10-06-cwa-version-2-11/) in the [2.12 blog article](https://www.coronawarn.app/en/blog/2021-10-19-cwa-version-2-12/) to use a relative path instead of an absolute path.

It aligns the blog article with the newly-added recommendations in [WRITE_BLOG_POSTS.md#link-to-other-locations](https://github.com/corona-warn-app/cwa-website/blob/master/docs/WRITE_BLOG_POSTS.md#link-to-other-locations)

**EN**
`https://www.coronawarn.app/en/blog/2021-10-06-cwa-version-2-11/` is changed to
`/en/blog/2021-10-06-cwa-version-2-11/`

**DE**
`https://www.coronawarn.app/de/blog/2021-10-06-cwa-version-2-11/` is changed to
`/de/blog/2021-10-06-cwa-version-2-11/`

This follows from the publication PR https://github.com/corona-warn-app/cwa-website/pull/1923.

CC: @HannaHei 