### PR TITLE
Bump current Android version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -422,7 +422,7 @@ function replaceVersionNumbers() {
     .pipe(replace('[ios.latest-os-version]', '15.0.2'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.12.1'))
-    .pipe(replace('[android.latest-os-version]', '11'))
+    .pipe(replace('[android.latest-os-version]', '12'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '2.12.1'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))


### PR DESCRIPTION
This PR bumps the current Android version from 11 to 12.


Blog post on this: https://android-developers.googleblog.com/2021/10/android-12-is-live-in-aosp.html?m=1