### PR TITLE
FAQ vac_cert_booster redirect

### DIFF
--- a/src/data/faq_redirects.json
+++ b/src/data/faq_redirects.json
@@ -3,5 +3,6 @@
     "10": "API10",
     "17": "cause_3",
     "beta_ios": "os_beta",
-    "incompatibility_warning": "part_incompat"
+    "incompatibility_warning": "part_incompat",
+    "vac_booster": "vac_cert_booster"
 }


### PR DESCRIPTION
In this PR I have redirected FAQ 'vac_booster' to 'vac_cert_booster'


---
Internal Tracking ID: [EXPOSUREAPP-10076](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10076)
