### PR TITLE
analysis page: minor text changes

### DIFF
--- a/src/data/analyse_de.json
+++ b/src/data/analyse_de.json
@@ -116,7 +116,7 @@
                     "label": "QR-Codes"
                 },
                 {
-                    "label": "teleTAN"
+                    "label": "teleTANs"
                 }
             ]
         },
@@ -153,7 +153,7 @@
 
 
         "legendLabelMean": "7-Tage-Mittelwert:",
-        "legendLabelDaily": "Tagliche Anzahl:",
+        "legendLabelDaily": "Tägliche Anzahl:",
 
         "total": "Gesamt",
 


### PR DESCRIPTION
This PR fix the following minor wordings on the analysis page:

- change "teleTAN" to "teleTANs" on tab label
- change "Tagliche Anzahl" to "Tägliche Anzahl"