### PR TITLE
Update FAQ #numbers_RKI

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1577,11 +1577,12 @@
                         ]
                     },
                     {
-                        "title": "Where do I find numbers and statistics about the Corona-Warn-App?",
+                        "title": "Where can I find numbers and statistics about the Corona-Warn-App?",
                         "anchor": "numbers_RKI",
                         "active": true,
                         "textblock": [
-                            "The Robert Koch Institute provides current numbers and statistics <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html' target='_blank' rel='noopener noreferrer'>on their website</a> (in German)."
+                            "An overview of key figures for the Corona-Warn-App is available in the form of a <a href='/en/analysis/' target='_blank'>digital dashboard</a>. The app displays selected statistics including <a href='/en/blog/2021-08-05-statistictiles/#tile-warnings-by-app-users' target='_blank'>Warnings by App Users</a>.",
+                            "The previous weekly reports provided by the Robert Koch Institute are archived <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html' target='_blank' rel='noopener noreferrer'>on their website</a> (in German)."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1590,7 +1590,8 @@
                         "anchor": "numbers_RKI",
                         "active": true,
                         "textblock": [
-                            "Aktuelle Zahlen und Statistiken stellt das Robert Koch-Institut <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html' target='_blank' rel='noopener noreferrer'> auf seiner Webseite</a> zur Verfügung."
+                            "Eine Übersicht zu wichtigen Kennzahlen der Corona-Warn-App in Form eines <a href='/de/analysis' target='_blank'>digitalen Dashboards</a> steht zur Verfügung. Die App stellt ausgewählte Statistiken zur Verfügung, u.&nbsp;a. zu <a href='/de/blog/2021-08-05-statistictiles/#kachel-warnende-personen' target='_blank'>Warnende Personen</a>.",
+                            "Archivierte Zahlen und Statistiken des Robert Koch-Instituts befinden sich <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Archiv_Kennzahlen/WarnApp_KennzahlenTab.html' target='_blank' rel='noopener noreferrer'>auf seiner Webseite</a>."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR address issue https://github.com/corona-warn-app/cwa-website/issues/1903 "Retirement of weekly reports" by updating the FAQ only (no change to the Blog):

- https://www.coronawarn.app/en/faq/#numbers_RKI "Where do I find numbers and statistics about the Corona-Warn-App?"
- https://www.coronawarn.app/de/faq/#numbers_RKI "Wo finde ich Zahlen und Statistiken über die Nutzung der Corona-Warn-App?"

to add information that:

- Statistics are available from the the [Analysis dashboard](https://www.coronawarn.app/en/analysis/)
- there are in-app statistics available

also:
- the weekly reports (which were last updated on Oct 1, 2021) are now called archived reports. This is consistent with the message on RKI's web page ["Infektionsketten digital unterbrechen mit der Corona-Warn-App"](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Warn_App.html) the weekly report is retired and replaced by the ([Analysis](https://www.coronawarn.app/de/analysis/)) dashboard. (See screenshot at bottom of this PR)


---
EN
https://www.coronawarn.app/en/faq/#numbers_RKI "Where do I find numbers and statistics about the Corona-Warn-App?" changes to:

![numbers_RKI_EN](https://user-images.githubusercontent.com/66998419/138850985-3d5b03fa-5789-41c8-8eb7-5533f88446af.jpg)

---
DE
https://www.coronawarn.app/de/faq/#numbers_RKI "Wo finde ich Zahlen und Statistiken über die Nutzung der Corona-Warn-App?" changes to:

![numbers_RKI_DE](https://user-images.githubusercontent.com/66998419/138851021-9b12ecd7-fced-4117-acf8-8c810b08ac1b.jpg)

### Statement from RKI

From  ["Infektionsketten digital unterbrechen mit der Corona-Warn-App"](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/WarnApp/Warn_App.html) 

![Kennzahlen-Dashboard zur Corona-Warn-App](https://user-images.githubusercontent.com/66998419/137714787-b44f1ab1-139b-4961-8dde-3b75d05d9244.jpg)
