### PR TITLE
Add details for Node.js LTS version to README.md (resolves #1967)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This repository contains the source files of the official website for the Corona
 
 ### Requirements
 
-You need the LTS version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website. Optionally, you need an HTTP Server such as [http-server](https://github.com/http-party/http-server) to run and test the deployment of the website locally.
+You need the Node.js 14 Maintenance LTS version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website. ([cwa-website](https://github.com/corona-warn-app/cwa-website) is not ready for the Node.js 16 Active LTS version.) Downloads for Node.js 14.18.1 are available from the [Node.js - Previous Releases](https://nodejs.org/en/download/releases/) page.
+
+Optionally, you need an HTTP Server such as [http-server](https://github.com/http-party/http-server) to run and test the deployment of the website locally.
 
 ### Getting started
 


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/1967 and changes the [README.md](https://github.com/corona-warn-app/cwa-website/blob/master/README.md) advice about which version of Node.js to use to the following:

"You need the Node.js 14 Maintenance LTS version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website. ([cwa-website](https://github.com/corona-warn-app/cwa-website) is not ready for the Node.js 16 Active LTS version.) Downloads for Node.js 14.18.1 are available from the [Node.js - Previous Releases](https://nodejs.org/en/download/releases/) page."

### Explanation

The versions of `Node.js` and `npm` need to be aligned to:

- `Node 14.18.1`
- `Npm 6.14.15`

as specified by [GitHub virtual environments](https://github.com/actions/virtual-environments#available-environments) and `ubuntu-latest` which is equivalent to [Ubuntu2004](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md).

[cwa-website: deploy-master.yml](https://github.com/corona-warn-app/cwa-website/blob/master/.github/workflows/deploy-master.yml) specifies `runs-on: ubuntu-latest`.