### PR TITLE
Remove wrong information from "vac_cert_red_warning" (Follow up to #1872)

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -449,7 +449,7 @@
                         "anchor": "vac_cert_red_warning",
                         "active": true,
                         "textblock": [
-                            "Wenn eine vollständig geimpfte Person eine Begegnung mit erhöhtem Risiko (rote Kachel) angezeigt bekommt, ist zunächst keine Quarantäne nötig, solange keine Symptome auftreten. Falls im weiteren Verlauf Symptome auftreten, sollten Sie sich unmittelbar testen lassen und in sofortige Quarantäne begeben. Wenn Sie sich testen lassen wollen, konsultieren Sie bitte Ihren Arzt bzw. Ihre Ärztin für die weiteren Schritte. Die Benachrichtigung durch die Corona-Warn-App über ein erhöhtes Risiko ermöglicht einen kostenlosen PCR-Test. Bei nicht abgeschlossener Grundimmunisierung sowie in den ersten 14 Tagen nach der letzten Dosis ist der Impfschutz deutlich geringer, so dass hier dieselben Empfehlungen wie bei Ungeimpften gelten."
+                            "Wenn eine vollständig geimpfte Person eine Begegnung mit erhöhtem Risiko (rote Kachel) angezeigt bekommt, ist zunächst keine Quarantäne nötig, solange keine Symptome auftreten. Falls im weiteren Verlauf Symptome auftreten, sollten Sie sich unmittelbar testen lassen und in sofortige Quarantäne begeben. Wenn Sie sich testen lassen wollen, konsultieren Sie bitte Ihren Arzt bzw. Ihre Ärztin für die weiteren Schritte. Bei nicht abgeschlossener Grundimmunisierung sowie in den ersten 14 Tagen nach der letzten Dosis ist der Impfschutz deutlich geringer, so dass hier dieselben Empfehlungen wie bei Ungeimpften gelten."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR is a follow up to the PR https://github.com/corona-warn-app/cwa-website/pull/1872 which removed wrong information from the FAQ. 
In #1872 I removed from information reg. free of charge PCR test from the FAQ, however, I forgot to remove  the information from the German entry as well. I only added the note reg. the doctor.

This PR fixes this.