### PR TITLE
Fix anchor link Cypress test

### DIFF
--- a/cypress/integration/check_anchor_links.js
+++ b/cypress/integration/check_anchor_links.js
@@ -76,7 +76,7 @@ context("Check for broken anchor links on entries", () => {
         if (url.prop('href') && url.prop('href').includes("localhost") && url.prop('href').split("#")[1] !== "top" && url.prop('href').includes(sub) && !pagesToAvoid.includes(url.prop('href').replace('http://localhost:8000', '')))  {  
           cy.visit({log: false, url: url.prop('href')} )
           cy.get("a[href*='#']").each(link => {
-            if(link.prop('href').includes(url.prop('href'))) {
+            if(link.prop('href').includes(url.prop('href')) && link.prop('href').split('#')[1] !== 'top' && link.prop('href').split('#')[1] !== ''){
               cy.get("body").then($body => {
                 if ($body.find(parseUmlaut(`#${link.prop('href').split("#")[1]}`)).length > 0) {   
                   softExpect(true, "Link: " + parseUmlaut(link.prop('href'))).to.eq(true)


### PR DESCRIPTION
Due to issue #1986 I had added two more conditions to search for a container ID. Now the anchor must be different from 'top' and also apart from have a '#', the part behind '#' have to contains content. Let's see some examples:

Our test will check for:

- page.com/url#tag

Our test will avoid:

- page.com/url#top
- page.com/url#

### Why I included #top like a condition?
Because it is very common to use this tag to go to the top of the page without the necessity of exist a container with a 'top' ID

### Advantages
- The test will works for everyone without errors

### Disadvantages
- If an editor forgot to include content behind '#' the test will not detect it or can be confused by use '#' to go to the top of the page