### PR TITLE
Remove "." from `vac_cert_booster` FAQ title to be consistent with other FAQ entry titles

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -324,7 +324,7 @@
                         ]
                     },
                     {
-                        "title": "Questions and answers about the booster vaccination and notifications regarding my vaccination certificate.",
+                        "title": "Questions and answers about the booster vaccination and notifications regarding my vaccination certificate",
                         "anchor": "vac_cert_booster",
                         "active": true,
                         "textblock": [

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -324,7 +324,7 @@
                         ]
                     },
                     {
-                        "title": "Fragen und Antworten zur Auffrischungsimpfung und Benachrichtigungen zum Impfzertifikat.",
+                        "title": "Fragen und Antworten zur Auffrischungsimpfung und Benachrichtigungen zum Impfzertifikat",
                         "anchor": "vac_cert_booster",
                         "active": "true",
                         "textblock": [


### PR DESCRIPTION
This PR removes a "." from the `vac_cert_booster` FAQ title to be consistent with other FAQ entry titles, e.g. the [Questions and answers about the event registration](https://www.coronawarn.app/en/faq/#check_in_index) entry.