### PR TITLE
Fixed the z-index of the board title in analyse

### DIFF
--- a/src/assets/scss/_analyse.scss
+++ b/src/assets/scss/_analyse.scss
@@ -473,7 +473,7 @@
 			font-weight: bold;
 			font-size: 16px;
 			line-height: 1.2;
-			z-index: 100;
+			z-index: 1;
 		}
 
 		&-export {


### PR DESCRIPTION
Due to issue #2028 I changed the z-index of the board titles so they dont appear on top of the main menu