### PR TITLE
Correct typo in Oct 4 2021 blog (DE) - PPA

### DIFF
--- a/blog/2021-10-04-dashboard/index_de.md
+++ b/blog/2021-10-04-dashboard/index_de.md
@@ -29,7 +29,7 @@ Diese Kennzahlen stammen aus verschiedenen Quellen:
 
 -	Downloads: Daten aus dem Google PlayStore und Apple App Store 
 -	Registrierung von Tests, Testergebnisse und Teilungsverhalten: Informationen aus der Backend-Datenbank, in der die Tests registriert werden, um eine Übermittlung der Ergebnisse und ggf. Warnung Anderer zu ermöglichen
--	Warnungen mit grünem und rotem Risiko: Daten aus der Privacy Preserving Analytics, PPA).
+-	Warnungen mit grünem und rotem Risiko: Daten aus der Privacy Preserving Analytics (PPA).
 
 **Wichtiger Hinweis:** Keine der Kennzahlen ermöglicht Rückschlüsse auf einzelne Nutzerinnen und Nutzer.
 


### PR DESCRIPTION
@dsarkar 
As requested: 🙂 

This PR corrects a typo in https://www.coronawarn.app/de/blog/2021-10-04-key-figures-dashboard/ "Kennzahlen-Dashboard zur Corona-Warn-App"

The sentence:

"Warnungen mit grünem und rotem Risiko: Daten aus der Privacy Preserving Analytics, PPA)."

is corrected to

"Warnungen mit grünem und rotem Risiko: Daten aus der Privacy Preserving Analytics (PPA)."

This follows on from https://github.com/corona-warn-app/cwa-website/pull/2038#issuecomment-965207757.