### PR TITLE
add luca-undefined bug into FAQ

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -861,7 +861,9 @@
                             "The luca app, on the other hand, is mainly used to digitally collect contact data of the participants of an event. In the event of infection, the person who tests positive for SARS-CoV-2 transfers his or her contact data to the responsible health department. This department then contacts all persons who have scanned the same QR code.",
                             "In the respective state ordinances on infection protection, it is stipulated whether and how contact tracking must take place at events.",
                             "<b>15. Do users need to install both apps for it to work?</b>",
-                            "No, in order to scan QR codes from the luca app with the Corona-Warn-App, the luca app does not need to be installed."
+                            "No, in order to scan QR codes from the luca app with the Corona-Warn-App, the luca app does not need to be installed.",
+                            "<b>16. Event shows undefined for Adress and Location Owner</b>",
+                            "This is a bug in Luca QR Codes which were imediatly generated, they are unpleasent but have no effect on the functionality of the checkin. You may correct Event Times, since Luca hardcoded them to 120 minutes."
                        ]
                     }
                 ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -862,7 +862,7 @@
                             "In den jeweiligen Länderverordnungen zum Infektionsschutz ist festgeschrieben, ob und wie eine Kontaktnachverfolgung bei Veranstaltungen stattfinden muss.",
                             "<b>15. Müssen Nutzende beide Apps installieren, damit es funktioniert?</b>",
                             "Nein, um mit der Corona-Warn-App QR-Codes der luca-App zu scannen, muss die luca-App nicht installiert sein.",
-                            "<b>16. Der angezeigte Event zeigt mehrfach undefined statt dem Ort und Betreiber an?</b>,
+                            "<b>16. Der angezeigte Event zeigt mehrfach undefined statt dem Ort und Betreiber an?</b>",
                             "QR Code die im Luca System unmittelbar erstellt wurden enthalten zum Teil einen Bug, so dass Betreiber und Adresse, zum Teil auch der Titel als undefined angezeigt werden. Das ist unschön, hat aber keinen Einfluss auf die Funktionialität des QR Code Checkin. Evtl solltet ihr die Länge des Events anpassen, der ist mit 120 Minuten bei Luca fest eingesetzt."
                         ]
                      }

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -861,7 +861,9 @@
                             "Die luca-App hingegen dient hauptsächlich der digitalen Erfassung von Kontaktdaten der Teilnehmenden einer Veranstaltung. Im Infektionsfall übergibt die positiv auf SARS-CoV-2 getestete Person ihre Kontaktdaten an das zuständige Gesundheitsamt. Dieses kontaktiert dann alle Personen, die denselben QR-Code gescannt haben.",
                             "In den jeweiligen Länderverordnungen zum Infektionsschutz ist festgeschrieben, ob und wie eine Kontaktnachverfolgung bei Veranstaltungen stattfinden muss.",
                             "<b>15. Müssen Nutzende beide Apps installieren, damit es funktioniert?</b>",
-                            "Nein, um mit der Corona-Warn-App QR-Codes der luca-App zu scannen, muss die luca-App nicht installiert sein."
+                            "Nein, um mit der Corona-Warn-App QR-Codes der luca-App zu scannen, muss die luca-App nicht installiert sein.",
+                            "<b>16. Der angezeigte Event zeigt mehrfach undefined statt dem Ort und Betreiber an?</b>,
+                            "QR Code die im Luca System unmittelbar erstellt wurden enthalten zum Teil einen Bug, so dass Betreiber und Adresse, zum Teil auch der Titel als undefined angezeigt werden. Das ist unschön, hat aber keinen Einfluss auf die Funktionialität des QR Code Checkin. Evtl solltet ihr die Länge des Events anpassen, der ist mit 120 Minuten bei Luca fest eingesetzt."
                         ]
                      }
                 ]


### PR DESCRIPTION
add info to faq for Luca QR Code undefined Bug
Background info : https://gitlab.com/lucaapp/cwa-event/-/issues/1
this hardcoded "undefined" strings occur if QR Code is downloaded while freshly made. This is an Bug produced by the Luca Backend System (cwa-event) resulting buggy location/adress Strings.
also mention the hardcoded 120 Minutes, which even may be adjusted inside the luca system - but is hardcoded in the QR Code without notice to the Location Owner/QR Code creator.