### PR TITLE
Update vac_cert_verification to refer to eu_dcc_check (resolves #2075)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -466,11 +466,11 @@
                         ]
                     },
                     {
-                        "title": "How is the proof of vaccination verified?",
+                        "title": "How is a vaccination certificate verified?",
                         "anchor": "vac_cert_verification",
                         "active": true,
                         "textblock": [
-                            "The vaccination certificate (QR code) is used digitally via the CovPass-App or the Corona-Warn-App (CWA) or alternatively as a machine-readable print. The vaccination certificate contains only information about the vaccination status, the name of the vaccinated person, and the date of birth. For service providers who want to check the vaccination status, there will be a verification app to check the vaccination certificate. This allows the vaccination status to be scanned in a similar way to a barcode of a flight or train ticket. Alternatively, proof with the paper-based vaccination document is possible."
+                            "Please read the FAQ article: <a href='#eu_dcc_check' target='_blank'>How are certificates verified by third parties?</a>, which describes how EU digital COVID vaccination certificates can be verified by a third party or by yourself."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -466,11 +466,11 @@
                         ]
                     },
                     {
-                        "title": "Wie soll der Nachweis einer Impfung geprüft werden können?",
+                        "title": "Wie kann ein Impfzertifikat geprüft werden?",
                         "anchor": "vac_cert_verification",
                         "active": true,
                         "textblock": [
-                            "Das Impfzertifikat (QR-Code) wird z.&nbsp;B. über die CovPass-App oder die Corona-Warn-App (CWA) digital oder alternativ als maschinenlesbarer Ausdruck genutzt. Das Impfzertifikat enthält nur Informationen zum Impfstatus, den Namen des Geimpften und das Geburtsdatum. Für Dienstleister, die den Impfstatus überprüfen möchten, wird es eine Prüf-App zur Prüfung des Impfzertifikats geben. Damit kann der Impfstatus ähnlich wie ein Barcode eines Flug- oder Bahntickets gescannt werden. Alternativ ist ein Nachweis mit dem analogen Impfausweis möglich."
+                            "Bitte lesen Sie den FAQ-Artikel: <a href='#eu_dcc_check' target='_blank'>Wie werden Zertifikate durch Dritte geprüft?</a>, bei dem die Vorgehensweise zur Prüfung von digitalen COVID-Impfzertifikaten der EU durch Dritte oder durch Sie selbst erläutert wird."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2075 "Outdated vaccination check FAQ" by replacing the current text by a link to the more recent text in [#eu_dcc_check](https://www.coronawarn.app/en/faq/#eu_dcc_check).

This shortens and simplifies the FAQ whilst providing the reader with accurate information.

The title is also changed so that it clearly refers to vaccination certificates.

---
(EN) NEW https://www.coronawarn.app/en/faq/#vac_cert_verification "How is a vaccination certificate verified?"

![vac_cert_verification_EN_new](https://user-images.githubusercontent.com/66998419/141759421-64f33a0d-b99d-4301-b115-910dd4c99a76.jpg)

links to existing

![eu_dcc_check_EN](https://user-images.githubusercontent.com/66998419/141759580-0c3b1dcb-b192-48b3-8297-fe5e881b6a18.jpg)

---
(DE) NEW https://www.coronawarn.app/de/faq/#vac_cert_verification "Wie kann ein Impfzertifikat geprüft werden?"

![vac_cert_verification_DE_new](https://user-images.githubusercontent.com/66998419/141759834-963bf67a-10df-4ca6-8666-9e06a4394f35.jpg)

links to existing

![eu_dcc_check_DE](https://user-images.githubusercontent.com/66998419/141759888-d72c5005-6822-43ce-895f-0acc6ff04113.jpg)

---

It also makes issue https://github.com/corona-warn-app/cwa-website/issues/1810 "Reference to use of paper certificate for validation unclear / not always true" obsolete. This issue is covered by the FAQ [#vac_cert_voluntary](https://www.coronawarn.app/en/faq/#vac_cert_voluntary).