### PR TITLE
Fix typos and formatting for blog recalled certificates

### DIFF
--- a/blog/2021-11-15-cwa-recalled-certificates/index.md
+++ b/blog/2021-11-15-cwa-recalled-certificates/index.md
@@ -23,9 +23,9 @@ In the past, there were a few pharmacies that issued fake vaccination certificat
 <br></br>
 
 
-**Important:** The certificates are only checked on the users own smartphones. A recalled certificate will show as invalid when checked with the CovPassCheck app though.
+**Important:** The certificates are only checked on the users' own smartphones. A recalled certificate will show as invalid when checked with the CovPassCheck app though.
 
-This affects all users who have received a certificate from a pharmacy in question, even if their certificate is valid and genuine. These users can get a new digital certificate at pharmacy for free. In order to get one, they should bring their yellow vaccination booklet an ID.
+This affects all users who have received a certificate from a pharmacy in question, even if their certificate is valid and genuine. These users can get a new digital certificate at a pharmacy for free. In order to get one, they should bring their yellow vaccination booklet and ID.
 
 The Corona-Warn-App informs users as usual with a push notification. The red dot directs users to the certificate under which they find further information. 
 
@@ -39,13 +39,4 @@ The Corona-Warn-App informs users as usual with a push notification. The red dot
 <br></br>
 
 
-The project team recommends all users to update the app to version 2.13.3 (Android) or 2.13.2 (iOS). 
-
-
-
-
-
-
-
-
-
+The project team recommends all users to **update the app to version 2.13.3 (Android) or 2.13.2 (iOS)**. 

--- a/blog/2021-11-15-cwa-recalled-certificates/index_de.md
+++ b/blog/2021-11-15-cwa-recalled-certificates/index_de.md
@@ -7,13 +7,13 @@ author: Hanna Heine
 layout: blog
 ---
 
-Um Nutzer*innen über Missbrauch und Fälschungen von Impfzertifikaten informieren zu können, hat das Projektteam aus Robert Koch-Institut, Deutscher Telekom und SAP eine Erweiterung zu CWA Version 2.13 veröffentlicht. Der Hotfix ermöglicht es, **digitale Impfzertifikate von bestimmten Apotheken zurückzurufen** und in der Corona-Warn-App als ungültig zu kennzeichnen.
+Um Nutzer\*innen über Missbrauch und Fälschungen von Impfzertifikaten informieren zu können, hat das Projektteam aus Robert Koch-Institut, Deutscher Telekom und SAP eine Erweiterung zu CWA Version 2.13 veröffentlicht. Der Hotfix ermöglicht es, **digitale Impfzertifikate von bestimmten Apotheken zurückzurufen** und in der Corona-Warn-App als ungültig zu kennzeichnen.
 
 <!-- overview -->
 
 In der Vergangenheit gab es einige wenige Apotheken, die gefälschte Impfzertifikate herausgegeben haben. Zertifikate der betroffenen Apotheken wurden daraufhin zurückgerufen. Mit dem Hotfix 2.13.3 (Android) beziehungsweise 2.13.2 (iOS) kann die Corona-Warn-App die Zertifikatskennung aller Zertifikate kontrollieren und prüfen, ob das Zertifikat von einer entsprechenden Apotheke ausgestellt wurde. Ist das der Fall, wird es als **ungültig dargestellt**.
 
-**Wichtig:** Die Überprüfung der Zertifikate erfolgt nur auf den jeweils eigenen Smartphones der Nutzer*innen. Bei der Kontrolle mit der CovPassCheck-App wird ein zurückgerufenen Zertifikat entsprechend als ungültig angezeigt. 
+**Wichtig:** Die Überprüfung der Zertifikate erfolgt nur auf den jeweils eigenen Smartphones der Nutzer\*innen. Bei der Kontrolle mit der CovPassCheck-App wird ein zurückgerufenes Zertifikat entsprechend als ungültig angezeigt.
 
 
 <br></br>
@@ -38,4 +38,4 @@ Die Corona-Warn-App informiert die betroffenen Nutzer\*innen wie gewohnt mit ein
 </center>
 <br></br>
 
-Das Projektteam empfiehlt allen Nutzer\*innen das **Update auf Version 2.13.3 beziehungsweise 2.13.2** durchzuführen. 
+Das Projektteam empfiehlt allen Nutzer\*innen das **Update auf Version 2.13.3 (Android) beziehungsweise 2.13.2 (iOS)** durchzuführen. 


### PR DESCRIPTION
@dsarkar 
This PR is for:

EN https://www.coronawarn.app/en/blog/2021-11-15-cwa-recalled-vaccination-certificates/ "Corona-Warn-App informs users about recalled vaccination certificates"

- grammar: users => users' (possessive) 
- at pharmacy = at a pharmacy
- booklet an ID => booklet and ID
- Highlight text to update in last line, like in the German version.

---
DE https://www.coronawarn.app/de/blog/2021-11-15-cwa-recalled-vaccination-certificates/ "Corona-Warn-App informiert Nutzer*innen über zurückgerufene Impfzertifikate"

- escape asterisks "*" => "`\*`", otherwise the text is interpreted as italics
- ein zurückgerufenen Zertifikat => ein zurückgerufenes Zertifikat
- Added operating system next to version numbers in last line, like in the English version.
