### PR TITLE
Redirect from FAQ "vac_cert_verification" to "eu_dcc_check"

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -466,14 +466,6 @@
                         ]
                     },
                     {
-                        "title": "How is the proof of vaccination verified?",
-                        "anchor": "vac_cert_verification",
-                        "active": true,
-                        "textblock": [
-                            "The vaccination certificate (QR code) is used digitally via the CovPass-App or the Corona-Warn-App (CWA) or alternatively as a machine-readable print. The vaccination certificate contains only information about the vaccination status, the name of the vaccinated person, and the date of birth. For service providers who want to check the vaccination status, there will be a verification app to check the vaccination certificate. This allows the vaccination status to be scanned in a similar way to a barcode of a flight or train ticket. Alternatively, proof with the paper-based vaccination document is possible."
-                        ]
-                    },
-                    {
                         "title": "Why has no joint EU-wide project been called out for proposal for a certificate?",
                         "anchor": "vac_cert_eu",
                         "active": true,

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -466,14 +466,6 @@
                         ]
                     },
                     {
-                        "title": "Wie soll der Nachweis einer Impfung geprüft werden können?",
-                        "anchor": "vac_cert_verification",
-                        "active": true,
-                        "textblock": [
-                            "Das Impfzertifikat (QR-Code) wird z.&nbsp;B. über die CovPass-App oder die Corona-Warn-App (CWA) digital oder alternativ als maschinenlesbarer Ausdruck genutzt. Das Impfzertifikat enthält nur Informationen zum Impfstatus, den Namen des Geimpften und das Geburtsdatum. Für Dienstleister, die den Impfstatus überprüfen möchten, wird es eine Prüf-App zur Prüfung des Impfzertifikats geben. Damit kann der Impfstatus ähnlich wie ein Barcode eines Flug- oder Bahntickets gescannt werden. Alternativ ist ein Nachweis mit dem analogen Impfausweis möglich."
-                        ]
-                    },
-                    {
                         "title": "Warum wurde kein EU-weites Projekt für ein Zertifikat ausgeschrieben?",
                         "anchor": "vac_cert_eu",
                         "active": true,

--- a/src/data/faq_redirects.json
+++ b/src/data/faq_redirects.json
@@ -5,5 +5,6 @@
     "beta_ios": "os_beta",
     "incompatibility_warning": "part_incompat",
     "vac_booster": "vac_cert_booster",
-    "vac_cert_invalid_211111": "vac_cert_invalid_21_1"
+    "vac_cert_invalid_211111": "vac_cert_invalid_21_1",
+    "vac_cert_verification": "eu_dcc_check"
 }


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2075 "Outdated vaccination check FAQ" by redirecting [#vac_cert_verification](https://www.coronawarn.app/en/faq/#vac_cert_verification) to the more recent text in [#eu_dcc_check](https://www.coronawarn.app/en/faq/#eu_dcc_check).

It replaces PR https://github.com/corona-warn-app/cwa-website/pull/2076.

---

In addition, it makes issue https://github.com/corona-warn-app/cwa-website/issues/1810 "Reference to use of paper certificate for validation unclear / not always true" obsolete, since paper certificates are not mentioned in [#eu_dcc_check](https://www.coronawarn.app/en/faq/#eu_dcc_check). 

Paper certificates are however covered by the FAQ [#vac_cert_voluntary](https://www.coronawarn.app/en/faq/#vac_cert_voluntary).