### PR TITLE
Fixed link styles and link names

### DIFF
--- a/src/assets/scss/_analyse.scss
+++ b/src/assets/scss/_analyse.scss
@@ -322,7 +322,7 @@
 		margin-right: -10px;
 
 		a {
-			font-size: 14px;
+			font-size: 13px;
 			line-height: 18px;
 			font-weight: 700;
 			padding: 5px;

--- a/src/data/analyse_de.json
+++ b/src/data/analyse_de.json
@@ -281,32 +281,32 @@
     "moreHeadline": "Weitere Dashboards",
     "moreLinks": [
     	{
-    		"title": "RKI: COVID-19-Dashboard",
+    		"title": "RKI: COVID-19-Dashboard (DE)",
             "desc": "Tagesaktuelle Informationen zum Infektionsgeschehen in Deutschland nach Landkreisen und Bundesländern.",
     		"link": "https://experience.arcgis.com/experience/478220a4c454480e823b17327b2bf1d4"
     	},
     	{
-    		"title": "RKI: Covid-19-Trends",
+    		"title": "RKI: Covid-19-Trends (DE)",
             "desc": "Trend-Übersicht zur Entwicklung des Infektionsgeschehens in Deutschland.",
     		"link": "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Situationsberichte/COVID-19-Trends/COVID-19-Trends.html?__blob=publicationFile#/home"
     	},
     	{
-    		"title": "BMG: Impfdashboard",
+    		"title": "BMG: Impfdashboard (DE)",
             "desc": "Arbeitstägliche Informationen über den Impfstatus und Impffortschritt in Deutschland von der Website ‘Zusammen gegen Corona‘ des Bundesministeriums für Gesundheit (BMG).",
     		"link": "https://impfdashboard.de/"
     	},
     	{
-    		"title": "WHO: COVID-19-Dashboard",
+    		"title": "WHO: COVID-19-Dashboard (EN)",
             "desc": "Tagesaktuelle Informationen zum weltweiten Infektionsgeschehen von der World Health Organisation (WHO).",
     		"link": "https://covid19.who.int/"
     	},
     	{
-    		"title": "CSSE (JHU): COVID-19-Dashboard",
+    		"title": "CSSE (JHU): COVID-19-Dashboard (EN)",
             "desc": "Tagesaktuelle Informationen zum weltweiten Infektionsgeschehen vom Center for Systems Science and Engineering (CSSE) der Johns Hopkins University (JHU) Baltimore (Maryland, USA).",
     		"link": "https://gisanddata.maps.arcgis.com/apps/dashboards/bda7594740fd40299423467b48e9ecf6"
     	},
         {
-    		"title": "OWID: COVID-19",
+    		"title": "OWID: COVID-19 (EN)",
             "desc": "Tagesaktuelle Informationen zum weltweiten Infektionsgeschehen in der Online-Publikation Our World in Data (OWID).",
     		"link": "https://ourworldindata.org/coronavirus"
     	}


### PR DESCRIPTION
Reduced the font size of the Further dashboards links in the analysis section so they all show up in one line and added (DE/EN) at the end of the links in the german version
<img width="1440" alt="Screenshot 2021-11-18 at 12 57 11" src="https://user-images.githubusercontent.com/50143339/142411447-035d2915-ee7c-46fd-bab0-be735f0d055f.png">

<img width="1440" alt="Screenshot 2021-11-18 at 12 57 02" src="https://user-images.githubusercontent.com/50143339/142411432-b0deee28-383a-42e0-9228-415a3aa5e967.png">
