### PR TITLE
Add question mark to eu_dcc_validity EN title

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -150,7 +150,7 @@
                         ]
                     },
                     {
-                        "title": "How long is my certificate valid​",
+                        "title": "How long is my certificate valid?​",
                         "anchor": "eu_dcc_validity",
                         "active": true,
                         "textblock": [


### PR DESCRIPTION
This PR adds a missing "?" to the title of `eu_dcc_validity`.

"How long is my certificate valid​" is changed to
"How long is my certificate valid​?".

