### PR TITLE
Bump current iOS version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -423,7 +423,7 @@ function createFaqRedirects() {
 function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html"])
-    .pipe(replace('[ios.latest-os-version]', '15.1'))
+    .pipe(replace('[ios.latest-os-version]', '15.1.1'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.13.2'))
     .pipe(replace('[android.latest-os-version]', '12'))


### PR DESCRIPTION
This PR bumps the current iOS version from 15.1 to 15.1.1.

---

Apple release: https://developer.apple.com/news/releases/?id=11172021