### PR TITLE
Fixed scroll in IOS devices

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -3,15 +3,27 @@ import throttle from 'lodash.throttle';
 import 'slick-carousel';
 
 window.jQuery = $;
+const deviceType = () => {
+    const ua = navigator.userAgent;
+    if (/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i.test(ua)) {
+        return "tablet";
+    }
+    else if (/Mobile|Android|iP(hone|od)|IEMobile|BlackBerry|Kindle|Silk-Accelerated|(hpw|web)OS|Opera M(obi|ini)/.test(ua)) {
+        return "mobile";
+    }
+    return "desktop";
+};
 
 $(document).ready(function(){
-    $(window).on('resize', function(){
-        const { hash } = window.location;
-		if(hash) {
-            const contPos = $(hash).offset().top;;
-            $(window).scrollTop(contPos);
-        }
-	});
+    if(deviceType() === "desktop"){
+        $(window).on('resize', function(){
+            const { hash } = window.location;
+            if(hash) {
+                const contPos = $(hash).offset().top;;
+                $(window).scrollTop(contPos);
+            }
+        });
+    }   
     $('.js-accordion dt, .js-toggle').on('click tap', function(){
         $($(this).data('target') ? $(this).data('target') : $(this)).toggleClass('active');
     });


### PR DESCRIPTION
We discovered that the issue #2114  was caused because of the event listener that we added in pr #2053. We added a new function so that the event listener only works in desktop devices.