### PR TITLE
Remove underline from header whitespace (resolves #2122)

### DIFF
--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -46,7 +46,9 @@
           {{global.wherecanigettested.en.text}}
         {{/if}}
       </a>
+    </u>
       &nbsp;&nbsp;
+    <u>
       <a href="{{#if lang_de}}{{global.testissues.de.link}}{{else}}{{global.testissues.en.link}}{{/if}}" {{#if homepage}}class="whohelps"{{/if}}>
         {{#if lang_de}}
           {{global.testissues.de.text}}


### PR DESCRIPTION
This PR removes the underline on header pages of https://www.coronawarn.app such as on https://www.coronawarn.app/en/faq/ between "Where to get tested?" and "Missing test result/test certificate?". This resolves the issue #2122.

After applying the fix the header shows as follows, with no underline underneath the spaces:

---
EN

![Header fixed EN](https://user-images.githubusercontent.com/66998419/143190779-29f8d834-81e1-4070-b878-1c8b50231e66.png)

---
DE
![Header fixed DE](https://user-images.githubusercontent.com/66998419/143190802-421ebebc-3e94-4758-9b84-0057fa27be54.png)