### PR TITLE
Shorted text block under Analysis page title

### DIFF
--- a/src/assets/js/analyse/modal.js
+++ b/src/assets/js/analyse/modal.js
@@ -10,4 +10,14 @@ $(document).on("click",".analyseModal-close", function(e){
 	$(".analyseModal, .analyseModalBg").removeClass("active")
 });
 
+$(document).on("click",".analyseBoard-info.info-textblock", function(e){
+	e.preventDefault();
+	$(`.analyseModalInfo[rel="${$(this).attr("rel")}"], .analyseModalBg`).addClass("active")
+});
+
+$(document).on("click",".analyseModalInfo-close", function(e){
+	e.preventDefault()
+	$(".analyseModalInfo, .analyseModalBg").removeClass("active")
+});
+
 export default null;

--- a/src/assets/scss/_analyse.scss
+++ b/src/assets/scss/_analyse.scss
@@ -1029,3 +1029,8 @@
 	}
 
 }
+
+.info-textblock {
+	position: relative;
+    top: -1px
+}

--- a/src/assets/scss/_analyse.scss
+++ b/src/assets/scss/_analyse.scss
@@ -801,6 +801,68 @@
 			}
 		}
 	}
+
+	&ModalInfo {
+		display: none;
+		background: #fff;
+		flex-direction: column;
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		width: 800px;
+		max-width: 90%;
+		max-height: 90%;
+		z-index: 9999 + 1;
+		transform: translate(-50%, -50%);
+		padding: 32px 24px;
+		box-shadow: 0px 8px 25px -8px rgba(60, 69, 83, 0.538625);
+		border-radius: 6px;
+
+
+		&-title {}
+
+		&-content {
+			overflow: auto;
+
+			strong {
+				display: block;
+			}
+		}
+
+		&-close {
+			position: absolute;
+			top: 0;
+			right: 0;
+			padding: 24px;
+			font-size: inherit;
+			line-height: 1em;
+
+			img {
+				width: 1em;
+				height: 1em;
+			}
+		}
+
+		&.active {
+			display: flex;
+		}
+
+		&Bg {
+			position: fixed;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background: #3A3D3E;
+			opacity: 0.95;
+			z-index: 9999;
+			display: none;
+
+			&.active {
+				display: block;
+			}
+		}
+	}
 }
 
 

--- a/src/data/analyse_de.json
+++ b/src/data/analyse_de.json
@@ -4,7 +4,11 @@
 	"topic": "Analyse",
     "title": "Corona-Warn-App (CWA): Kennzahlen",
     "update": "Letzte Aktualisierung der Daten:",
-    "updateNotice": "Die Daten des CWA-Dashboards werden in der Regel täglich um 10:30 (MEZ) für den Vortag aktualisiert. Die Daten zu den Downloads werden nur arbeitstäglich aktualisiert. Montags werden die Daten für Freitag, Samstag und Sonntag aktualisiert.",
+    "updateNotice": "Die Daten des CWA-Dashboards werden in der Regel täglich um 10:30 (MEZ) für den Vortag aktualisiert.",
+    "updateNoticeIcon": {
+        "title": "Aktualisierung der Daten",
+        "content": "Die Daten zu den Downloads werden nur arbeitstäglich aktualisiert. Montags werden die Daten für Freitag, Samstag und Sonntag aktualisiert."
+    },
     "range":{
         "picker": {
             "timerange": "Zeitraum",

--- a/src/data/analyse_de.json
+++ b/src/data/analyse_de.json
@@ -4,10 +4,9 @@
 	"topic": "Analyse",
     "title": "Corona-Warn-App (CWA): Kennzahlen",
     "update": "Letzte Aktualisierung der Daten:",
-    "updateNotice": "Die Daten des CWA-Dashboards werden in der Regel täglich um 10:30 (MEZ) für den Vortag aktualisiert.",
     "updateNoticeIcon": {
         "title": "Aktualisierung der Daten",
-        "content": "Die Daten zu den Downloads werden nur arbeitstäglich aktualisiert. Montags werden die Daten für Freitag, Samstag und Sonntag aktualisiert."
+        "content": "Die Daten des CWA-Dashboards werden in der Regel täglich um 10:30 (MEZ) für den Vortag aktualisiert. Die Daten zu den Downloads werden nur arbeitstäglich aktualisiert. Montags werden die Daten für Freitag, Samstag und Sonntag aktualisiert."
     },
     "range":{
         "picker": {

--- a/src/data/analyse_en.json
+++ b/src/data/analyse_en.json
@@ -6,7 +6,7 @@
     "update": "Last update of the data:",
     "updateNoticeIcon": {
         "title": "Update of the data",
-        "content": "The CWA dashboard data is usually updated daily at 10:30 AM (CET) for the previous day. Downloads data is updated only on working days. On Mondays, the data for Friday, Saturday and Sunday are updated."
+        "content": "The CWA dashboard data is usually updated daily at 10:30 AM (CET) for the previous day. Data regarding downloads is updated only on working days. On Mondays, the data for Friday, Saturday and Sunday are updated."
     },
     "range":{
         "picker": {

--- a/src/data/analyse_en.json
+++ b/src/data/analyse_en.json
@@ -4,7 +4,11 @@
 	"topic": "Analysis",
     "title": "Corona-Warn-App (CWA): Key performance indicators",
     "update": "Last update of the data:",
-    "updateNotice": "The CWA dashboard data is usually updated daily at 10:30 AM (CET) for the previous day. Downloads data is updated only on working days. On Mondays, the data for Friday, Saturday and Sunday are updated.",
+    "updateNotice": "The CWA dashboard data is usually updated daily at 10:30 AM (CET) for the previous day.",
+    "updateNoticeIcon": {
+        "title": "Update of the data",
+        "content": "Downloads data is updated only on working days. On Mondays, the data for Friday, Saturday and Sunday are updated."
+    },
     "range":{
         "picker": {
             "timerange": "Time range",

--- a/src/data/analyse_en.json
+++ b/src/data/analyse_en.json
@@ -4,10 +4,9 @@
 	"topic": "Analysis",
     "title": "Corona-Warn-App (CWA): Key performance indicators",
     "update": "Last update of the data:",
-    "updateNotice": "The CWA dashboard data is usually updated daily at 10:30 AM (CET) for the previous day.",
     "updateNoticeIcon": {
         "title": "Update of the data",
-        "content": "Downloads data is updated only on working days. On Mondays, the data for Friday, Saturday and Sunday are updated."
+        "content": "The CWA dashboard data is usually updated daily at 10:30 AM (CET) for the previous day. Downloads data is updated only on working days. On Mondays, the data for Friday, Saturday and Sunday are updated."
     },
     "range":{
         "picker": {

--- a/src/partials/page-analyse.html
+++ b/src/partials/page-analyse.html
@@ -43,7 +43,9 @@
 	<div class="analyseUpdate">
 		{{page-contents.update}}
 		<span class="analyseUpdate-timestamp"></span>.
-		{{page-contents.updateNotice}}
+		<button class="btn analyseBoard-iconBtn analyseBoard-info info-textblock"  rel="{{page-contents.updateNoticeIcon.title}}">
+			<img src="{{root}}assets/img/icons/info.svg">
+		</button>
 	</div>
 	
 
@@ -229,6 +231,18 @@
 			</div>
 		</div>
 	{{/each}}
+
+	<div class="analyseModalInfo" rel="{{page-contents.updateNoticeIcon.title}}">
+		<h2 class="headline analyseModal-title">
+			<button class="btn analyseModalInfo-close">
+				<img src="{{root}}assets/img/icons/Close.svg">
+			</button>
+			{{page-contents.updateNoticeIcon.title}}
+		</h2>
+		<div class="analyseModal-content">
+			{{page-contents.updateNoticeIcon.content}}
+		</div>
+	</div>
 
 
 


### PR DESCRIPTION
In this PR, I have shortened the text block under the title on Analysis page. The second part of the text block had been inserted on a modal message, looking like: 

**English**

![image](https://user-images.githubusercontent.com/44208107/143239562-05afe92a-4fba-4dc2-a684-7fbc318e05f1.png)
![image](https://user-images.githubusercontent.com/44208107/143239575-d2276098-57b7-44e6-8d64-9e6471c27497.png)

**German**

![image](https://user-images.githubusercontent.com/44208107/143239583-d4d3dcdb-0796-48b2-b042-bbc9f53d2849.png)
![image](https://user-images.githubusercontent.com/44208107/143239585-d6c356b8-b5ef-4d9c-a93f-53054d173746.png)
