### PR TITLE
Fix reference on show test result

### DIFF
--- a/cypress/integration/check_links.js
+++ b/cypress/integration/check_links.js
@@ -74,11 +74,11 @@ context("Check for broken links on entries", () => {
                 log: false,
                 url: entry.prop('href')
               }).then((response) => {
-                softExpect(response.status == 200 || response.status == 429 ? true : false, "Link: " + url.prop('href')).to.eq(true)
+                softExpect(response.status == 200 || response.status == 429 ? true : false, "Link: " + entry.prop('href')).to.eq(true)
                 if(response.status != 200 && response.status != 429) {
                   cy.readFile("cypress/logs/broken_links_result.txt")
                   .then((text) => {
-                    cy.writeFile("cypress/logs/broken_links_result.txt", `${text}\n[RESPONSE ${response.status}] ${url.prop('href')} on '${page}' `, {flags: 'as+'})
+                    cy.writeFile("cypress/logs/broken_links_result.txt", `${text}\n[RESPONSE ${response.status}] ${entry.prop('href')} on '${url.prop('href')}' `, {flags: 'as+'})
                   })
                 }
               })


### PR DESCRIPTION
In this PR, I had solved an issue that occurred to me making tests for other task. The text show on softExpects in entries code block had bad references to vars used on the previous code block. The test functionality was correct, but the text shown not.