### PR TITLE
Move FAQ "Where can I get the app?" to start of Availability section

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1169,6 +1169,14 @@
                 "id": "availability",
                 "accordion": [
                     {
+                        "title": "Where can I get the app?",
+                        "anchor": "where_to_get",
+                        "active": true,
+                        "textblock": [
+                            "You can download the Corona-Warn-App from the <a href='https://apps.apple.com/de/app/corona-warn-app/id1512595757' target='_blank' rel='noopener noreferrer'>Apple App Store</a> or <a href='https://play.google.com/store/apps/details?id=de.rki.coronawarnapp' target='_blank' rel='noopener noreferrer'>Google Play Store</a>."
+                        ]
+                    },
+                    {
                         "title": "What are the minimum operating system requirements for my phone?",
                         "anchor": "minimum_requirements",
                         "active": true,
@@ -1308,14 +1316,6 @@
                             "Updates for the Corona-Warn-App are distributed using a so-called \"staged rollout\" over a timespan of 48 hours. This means that, instead of distributing the update immediately to every user, the update is gradually made available to a larger percentage of users over time. By using a staged rollout, critical bugs and crashes can be detected early and be addressed by the development team before they affect a large amount of users.",
                             "The order in which users receive the update is randomly determined for every release by the app store vendors. Therefore, you might receive the update up to two days after the official release date. The Corona-Warn-App development team has no influence on the order in which users receive the update.",
                             "<b>Please note:</b> On iOS, it is possible to manually trigger the update by visiting the App Store page of the Corona-Warn-App. This option does not exist on Android."
-                        ]
-                    },
-                    {
-                        "title": "Where can I get the app?",
-                        "anchor": "where_to_get",
-                        "active": true,
-                        "textblock": [
-                            "You can download the Corona-Warn-App from the <a href='https://apps.apple.com/de/app/corona-warn-app/id1512595757' target='_blank' rel='noopener noreferrer'>Apple App Store</a> or <a href='https://play.google.com/store/apps/details?id=de.rki.coronawarnapp' target='_blank' rel='noopener noreferrer'>Google Play Store</a>."
                         ]
                     }
                 ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1176,6 +1176,14 @@
                 "id": "availability",
                 "accordion": [
                     {
+                        "title": "Wo bekomme ich die App?",
+                        "anchor": "where_to_get",
+                        "active": true,
+                        "textblock": [
+                            "Sie können die Corona-Warn-App im <a href='https://apps.apple.com/de/app/corona-warn-app/id1512595757' target='_blank' rel='noopener noreferrer'>Apple App Store</a> bzw. im <a href='https://play.google.com/store/apps/details?id=de.rki.coronawarnapp' target='_blank' rel='noopener noreferrer'>Google Play Store</a> herunterladen."
+                        ]
+                    },
+                    {
                         "title": "Welche Systemvoraussetzungen muss mein Smartphone erfüllen?",
                         "anchor": "minimum_requirements",
                         "active": true,
@@ -1317,14 +1325,6 @@
                             "Updates für die Corona-Warn-App werden in einem sogenannten \"gestaffelten Rollout\" über eine Zeitspanne von 48 Stunden ausgeliefert. Dies bedeutet, dass das Update in der genannten Zeitspanne schrittweise einem immer größer werdenden Anteil an Nutzern zur Verfügung gestellt wird, anstatt es an alle Nutzer direkt auszuliefern. Durch den gestaffelten Rollouts können kritische Fehler und Abstürze früh erkannt und vom Entwicklungsteam adressiert werden, bevor sie eine große Zahl an Nutzern betreffen.",
                             "Die Reihenfolge in welcher die Nutzer das Update erhalten wird von den Anbietern der App-Stores für jedes Release zufällig festgelegt. Deswegen kann es sein, dass Sie das Update erst bis zu zwei Tage nach dem offiziellen Release-Datum erhalten. Das Entwicklungsteam der Corona-Warn-App hat keinen Einfluss auf die Reihenfolge, in der Nutzer das Update erhalten.",
                             "<b>Hinweis:</b> Unter iOS ist es möglich, das Update manuell auszulösen, indem Sie die App Store Seite der Corona-Warn-App besuchen. Diese Option gibt es unter Android nicht."
-                        ]
-                    },
-                    {
-                        "title": "Wo bekomme ich die App?",
-                        "anchor": "where_to_get",
-                        "active": true,
-                        "textblock": [
-                            "Sie können die Corona-Warn-App im <a href='https://apps.apple.com/de/app/corona-warn-app/id1512595757' target='_blank' rel='noopener noreferrer'>Apple App Store</a> bzw. im <a href='https://play.google.com/store/apps/details?id=de.rki.coronawarnapp' target='_blank' rel='noopener noreferrer'>Google Play Store</a> herunterladen."
                         ]
                     }
                 ]


### PR DESCRIPTION
This PR moves the FAQ article:

- https://www.coronawarn.app/en/faq/#where_to_get "Where can I get the app?"
- https://www.coronawarn.app/de/faq/#where_to_get "Wo bekomme ich die App?"

from the end of the Availability section to the beginning of this section where it is easier to find. The `#where_to_get` article is the top-level piece of information regarding availability and it deserves a place at the top of the section with the other details below it.

The Availability section is labelled as follows in English and German:

- https://www.coronawarn.app/en/faq/#availability "Availability" (EN)
- https://www.coronawarn.app/de/faq/#availability "Verfügbarkeit" (DE)

This suggestion is made after answering https://github.com/corona-warn-app/cwa-app-android/issues/4443 "where I can find the app".

The beginning of the English language https://www.coronawarn.app/en/faq/#availability "Availability" section will present as follows:

![image](https://user-images.githubusercontent.com/66998419/143769552-eff1b2b2-4a6d-41d3-9a7a-5f6fcafec802.png)
