### PR TITLE
Fix broken link  on '/de/eventregistration/'

### DIFF
--- a/src/data/eventregistration_de.json
+++ b/src/data/eventregistration_de.json
@@ -47,7 +47,7 @@
                 "invalidtime": "Ungültiges Zeitformat",
                 "filerequired": "Sie müssen eine CSV-Datei importieren",
                 "wrongfileextension": "Die Dateierweiterung ist ungültig. Akzeptiert werden nur .csv Dateien",
-                "wrongfileheaders": "Die Header der .csv-Datei entsprechen nicht den Headern der entsprechenden Vorlage, Sie können sie <a href='. /event-qr-code-guide/'>hier überprüfen.</a>",
+                "wrongfileheaders": "Die Header der .csv-Datei entsprechen nicht den Headern der entsprechenden Vorlage, Sie können sie <a href='../event-qr-code-guide/'>hier überprüfen.</a>",
                 "wrongfileformatfields": "Einige Felder in Ihrer CSV-Datei sind nicht korrekt ausgefüllt. Bitte überprüfen Sie Ihre .csv und versuchen Sie es erneut",
                 "filewithnodata": "Ihre .csv Felder sind nicht ausgefüllt",
                 "fileoverloaded": "Die Erstellung von QR-Codes ist auf 100 begrenzt."


### PR DESCRIPTION
Due to issue #2138, I fixed the broken link by removing the blank space and adding one more dot to the url.