### PR TITLE
Prevent escaping in FAQ title

### DIFF
--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -34,7 +34,7 @@
       {{#each accordion}}
         <div id="{{anchor}}-div">
           <dt class="accordion-header{{#if active}} active{{/if}}">
-            <h3 class="accordion-item-title"{{#if anchor}} id="{{anchor}}"{{/if}}>{{title}}</h3>
+            <h3 class="accordion-item-title"{{#if anchor}} id="{{anchor}}"{{/if}}>{{{title}}}</h3>
             <span class="accordion-item-icon"></span>
           </dt>
           <dd class="accordion-body">

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -62,7 +62,7 @@
         <nav class=glossary-nav>
           <div class="nav nav-tabs pb-3" id="nav-tab" role="tablist">
           {{#each page-contents.glossary.glossaryWords as |letter|}}
-            {{#if @first}} 
+            {{#if @first}}
               <a class="nav-item nav-link active" id="{{@key}}-tab" data-toggle="tab" href="#{{@key}}" role="tab" aria-controls="{{@key}}" aria-selected="true">{{@key}}</a>
             {{else}}
               <a class="nav-item nav-link" id="{{@key}}-tab" data-toggle="tab" href="#{{@key}}" role="tab" aria-controls="{{@key}}" aria-selected="true">{{@key}}</a>
@@ -72,9 +72,9 @@
         </nav>
         <div class="tab-content" id="nav-tab-content">
         {{#each page-contents.glossary.glossaryWords as |letter|}}
-          {{#if @first}} 
+          {{#if @first}}
             <div class="tab-pane fade show active mt-4" id="{{@key}}" role="tabpanel" aria-labelledby="{{@key}}-tab">
-              <h4 class="headline headline-heavy px-3" >{{@key}}</h4>  
+              <h4 class="headline headline-heavy px-3" >{{@key}}</h4>
               {{#each letter as |content|}}
                 {{#if @last}}
                   <div>
@@ -97,7 +97,7 @@
             </div>
           {{else}}
             <div class="tab-pane fade show mt-4" id="{{@key}}" role="tabpanel" aria-labelledby="{{@key}}-tab">
-              <h4 class="headline headline-heavy px-3" >{{@key}}</h4>  
+              <h4 class="headline headline-heavy px-3" >{{@key}}</h4>
               {{#each letter as |content|}}
                 {{#if @last}}
                   <div>


### PR DESCRIPTION
This PR implements the change suggested in issue https://github.com/corona-warn-app/cwa-website/issues/2163 "nbsp HTML entity cannot be put into FAQ title".

It changes the [src/partials/page-faq.html](https://github.com/corona-warn-app/cwa-website/blob/master/src/partials/page-faq.html) partials page which processes FAQ json input through Panini, so that the contents of the "title" field are not escaped.

This means that HTML entities such as `&nbsp;` are passed through one-to-one into the HTML. Before this change the `&` character was being escaped in title text with the effect that `&nbsp;` appeared literally in the title instead of being used as a non-breaking space.

Text in the "textblock" field was already set up not to be escaped, so this change brings the two fields - "title" and "textblock" into alignment with each other.

### Reference

https://handlebarsjs.com/guide/#html-escaping

## Verification

1. Run the Cypress test suite
2. Revert commit https://github.com/corona-warn-app/cwa-website/commit/7a12ee369d8d015579afda5726cc6e40b2ab9e19 from PR https://github.com/corona-warn-app/cwa-website/pull/2159 and confirm that:
    - `&nbsp;` is  **not** displayed in the title of https://www.coronawarn.app/de/faq/#vac_cert_multiple_scan_possible
    - when the browser width is changed, the text `z. B.` is never split on two lines and always remains together