### PR TITLE
Fix analyse page title

### DIFF
--- a/src/data/analyse_de.json
+++ b/src/data/analyse_de.json
@@ -137,7 +137,7 @@
         "analyseBoardTitleTitle":{
             "0": "Downloads",
             "1": [
-                "Registrierte Tests",
+                "Übermittelte und registrierte Testergebnisse",
                 "Testergebnisse",
                 "Testergebnisse"
             ],

--- a/src/data/analyse_en.json
+++ b/src/data/analyse_en.json
@@ -137,7 +137,7 @@
         "analyseBoardTitleTitle":{
             "0": "Downloads",
             "1": [
-                "Registered tests",
+                "Transmitted and registered test results",
                 "Test results",
                 "Test results"
             ],


### PR DESCRIPTION
Hello, due to issue #2171 I have created this pull request. The problem was that the title was first loaded from translations section from the json at line 140 and then is replaced from the board's title, at line 81.