### PR TITLE
Fix links in Rote Kachel blog DE

### DIFF
--- a/blog/2021-12-15-handlungsempfehlung-rote-kachel/index_de.md
+++ b/blog/2021-12-15-handlungsempfehlung-rote-kachel/index_de.md
@@ -7,12 +7,12 @@ author: CWA Team
 layout: blog
 ---
 
-In Deutschland bewegen sich die Covid-19-Infektionszahlen auf sehr hohem Niveau. Allein vom 1. bis einschließlich 7. Dezember haben geschätzt **mehr als 1,1 Millionen Nutzer\*innen der Corona-Warn-App (CWA) eine rote Kachel erhalten** ([Stand 14.12.2021](https://www.coronawarn.app/de/science/))*. Davon sind viele aber bereits geimpft oder genesen. Was also tun bei einer roten Kachel? Und wie beziehungsweise wann verschwindet sie wieder?
+In Deutschland bewegen sich die COVID-19-Infektionszahlen auf sehr hohem Niveau. Allein vom 1. bis einschließlich 7.&nbsp;Dezember haben geschätzt **mehr als 1,1 Millionen Nutzer\*innen der Corona-Warn-App (CWA) eine rote Kachel erhalten** ([Stand 14.12.2021](/de/science/))*. Davon sind viele aber bereits geimpft oder genesen. Was also tun bei einer roten Kachel? Und wie beziehungsweise wann verschwindet sie wieder?
 
 
 <!-- overview -->
 
-Eine rote Warnung bedeutet nicht automatisch, dass Sie sich mit Covid-19 infiziert haben. Die Corona-Warn-App warnt Sie damit lediglich vor einem erhöhten Ansteckungsrisiko und **unterscheidet dabei nicht zwischen geimpften, ungeimpften und genesenen Nutzer*innen**. 
+Eine rote Warnung bedeutet nicht automatisch, dass Sie sich mit COVID-19 infiziert haben. Die Corona-Warn-App warnt Sie damit lediglich vor einem erhöhten Ansteckungsrisiko und **unterscheidet dabei nicht zwischen geimpften, ungeimpften und genesenen Nutzer*innen**. 
 
 <br></br>
 <center> 
@@ -30,9 +30,9 @@ Wenn Sie sich **krank fühlen, Symptome auftreten oder Sie Risikofaktoren** wie 
 
 Wenn Ihr **Arbeitgeber** Ihnen die Möglichkeit gibt, von zu Hause aus zu arbeiten, tun Sie das. Sollte das nicht möglich sein, sollten Sie die Quarantäne-Vorgaben in Ihrem Landkreis prüfen, da die **Quarantäne-Regelungen von Landkreis** zu Landkreis verschieden sein können. Wenn es keine entsprechenden Regelungen gibt, wenden Sie sich an Ihr zuständiges Gesundheitsamt. Das kann eine Quarantäne anordnen. Ihr zuständiges Gesundheitsamt können Sie hier ermitteln: [https://tools.rki.de/plztool/ ](https://tools.rki.de/plztool/)
 
-Momentan wird ab dem Zeitpunkt der Risikobegegnung eine **Quarantäne von 10 Tagen ohne abschließenden Test** und von **5 Tagen mit PCR-Test empfohlen**. Aus diesem Grund steht auch das Datum der Risikobegegnung als Referenz auf der roten Kachel in der CWA.  Mehr zu den Empfehlungen finden Sie auf der [Website des Robert Koch-Instituts](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Kontaktperson/Management.html;jsessionid=FA6467ABE90F33E7D9982350BA10FBAB.internet051?nn=13490888#doc13516162bodyText16). Dort finden Sie unter Punkt 3.2.2 auch den Hinweis, dass vollständig gegen COVID-19 geimpfte oder genesene Personen, die Kontakt zu einem bestätigten SARS-CoV-2-Fall hatten, von Quarantäne-Maßnahmen ausgenommen sind. Die Entscheidung, sich bei einer roten Kachel dennoch in Quarantäne zu begeben, erfolgt also **eigenverantwortlich und auf freiwilliger Basis.**
+Momentan wird ab dem Zeitpunkt der Risikobegegnung eine **Quarantäne von 10 Tagen ohne abschließenden Test** und von **5 Tagen mit PCR-Test empfohlen**. Aus diesem Grund steht auch das Datum der Risikobegegnung als Referenz auf der roten Kachel in der CWA.  Mehr zu den Empfehlungen finden Sie auf der [Website des Robert Koch-Instituts](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Kontaktperson/Management.html?nn=13490888#doc13516162bodyText16). Dort finden Sie unter Punkt 3.2.2 auch den Hinweis, dass vollständig gegen COVID-19 geimpfte oder genesene Personen, die Kontakt zu einem bestätigten SARS-CoV-2-Fall hatten, von Quarantäne-Maßnahmen ausgenommen sind. Die Entscheidung, sich bei einer roten Kachel dennoch in Quarantäne zu begeben, erfolgt also **eigenverantwortlich und auf freiwilliger Basis.**
 
-Weitere Informationen zu Quarantäne-Maßnahmen und dazu, wieso die freiwillige Quarantäne empfohlen wird, finden Sie hier: [https://www.coronawarn.app/de/faq/#voluntary_self_quarantine](/de/faq/#voluntary_self_quarantine) und hier: [https://www.coronawarn.app/de/faq/#quarantine_measures](/de/faq/#quarantine_measures)
+Weitere Informationen zu den Themen [Warum wird die freiwillige Selbstquarantäne empfohlen?](/de/faq/#voluntary_self_quarantine) und [Fragen zu Quarantäne-Maßnahmen](/de/faq/#quarantine_measures) erhalten Sie im FAQ-Bereich.
 
 
 Die rote Kachel verschwindet 14 Tage nach der Risikobegegnung. Mehr dazu finden Sie unten im Abschnitt „Wie verschwindet die rote Kachel wieder?“.
@@ -58,8 +58,7 @@ Bis Sie das Ergebnis erhalten, sollten Sie nach Möglichkeit zu Hause bleiben un
 
 Wenn bei Ihnen **Symptome auftreten, Sie sich krank fühlen, oder Sie Risikofaktoren** haben, sollten Sie Rücksprache mit Ihrer Hausarztpraxis oder dem kassenärztlichen Bereitschaftsdienst unter der Nummer 116 117 halten. Die Ärztin oder der Arzt wird Sie nach Ihren Symptomen und Risikofaktoren fragen und dann entscheiden, wie getestet werden soll. 
 
-**Testmöglichkeiten** finden Sie hier: [https://www.coronawarn.app/de/faq/#where_can_i_get_tested](https://www.coronawarn.app/de/faq/#where_can_i_get_tested). Weitere Informationen zum Testablauf hier: [https://www.coronawarn.app/de/faq/#red_card_how_to_test](https://www.coronawarn.app/de/faq/#red_card_how_to_test.
-).
+**Testmöglichkeiten** finden Sie unter [Wo kann ich mich testen lassen?](/de/faq/#where_can_i_get_tested). Weitere Informationen zum Testablauf hier: [Rote Karte? So geht es zum Corona Test](/de/faq/#red_card_how_to_test).
 
 **<u>4) Positives Testergebnis: Begeben Sie sich in Isolation und teilen Sie Ihr Testergebnis</u>**
 
@@ -79,7 +78,7 @@ Im Falle eines **positiven PCR-Tests** kontaktieren Sie Ihr zuständiges Gesundh
 </center>
 <br></br>
 
-Antworten auf häufig gestellte Fragen rund um das Verhalten bei einer roten Kachel finden Sie auch in den [FAQs auf der Website der CWA](https://www.coronawarn.app/de/faq/#red_card_how_to_test).
+Antworten auf häufig gestellte Fragen rund um das Verhalten bei einer roten Kachel finden Sie auch in den [FAQs auf der Website der CWA](/de/faq/#red_card_how_to_test).
 
 ### Wie und wann verschwindet die rote Kachel wieder?
 
@@ -101,7 +100,4 @@ Auch bei einer grünen Kachel kann es Hinweise auf Begegnungen mit später posit
 
 Deshalb sind die oben genannten Verhaltensweisen in diesem Fall nicht nötig. Sie sollten dennoch die **üblichen Hygieneregeln einhalten:** Tragen Sie bei Begegnungen mit anderen Personen eine medizinische Maske, halten Sie Abstand zu anderen Personen, niesen oder husten Sie in die Armbeuge oder in ein Taschentuch, waschen Sie sich regelmäßig mit Seife die Hände und lüften Sie Innenräume mehrmals täglich.
 
-
-
-*_Laut Privacy Preserving Analytics (PPA). Mehr dazu hier:_ [https://www.coronawarn.app/de/science/2021-10-15-science-blog-4/#3-privacy-preserving-analytics](https://www.coronawarn.app/de/science/2021-10-15-science-blog-4/#3-privacy-preserving-analytics 
-)
+*_Laut Privacy Preserving Analytics (PPA). Mehr dazu im Science-Blog:_ "Wer nutzt die Corona-Warn-App, wen warnt sie – und wie schnell?" im [Abschnitt 3 - Privacy Preserving Analytics](/de/science/2021-10-15-science-blog-4/#3-privacy-preserving-analytics).


### PR DESCRIPTION
This PR corrects some links in 
https://www.coronawarn.app/de/blog/2021-12-15-cwa-red-tile-guidance/ "Was tun bei einer roten Kachel?"

as described in issue https://github.com/corona-warn-app/cwa-website/issues/2198.

- remove jsessionid
- make absolute links relative
- hide literal target of links for www.coronawarn.app
- correct some other minor errors