### PR TITLE
Create header and separator for '7 day moving' in Analysis page

### DIFF
--- a/src/assets/js/analyse/chart/options.js
+++ b/src/assets/js/analyse/chart/options.js
@@ -131,7 +131,9 @@ export default {
 
 			seriesArray = seriesArray.map((e,i) => {
 				const value = e.data[dataPointIndex]
-				return `
+				const header = i === 0 && seriesArray.length === 6 ? `<b>${translate("legendLabelMean")}</b>` : "";
+				const separator = i === 3 ? `<hr/><b>${translate("legendLabelDaily")}</b>` : "";
+				return header+separator+`
 					<div class="apexcharts-tooltip-series-group">
 						<span class="apexcharts-tooltip-marker" style="background-color: ${e.color};"></span>
 						<div class="apexcharts-tooltip-text">


### PR DESCRIPTION
Due to issue #2149 I have added a header and a separator for '7 day moving' to split it from 'daily'

**English version**

![Screenshot 2021-12-20 at 09 38 49](https://user-images.githubusercontent.com/44208107/146737685-f3864a48-eb41-405f-897d-c70272e63ffd.png)

**German version**

![Screenshot 2021-12-20 at 10 01 07](https://user-images.githubusercontent.com/44208107/146740800-fa4a50c9-c00e-4524-826c-a07ccb7b26ed.png)

