### PR TITLE
Update links in red tile blog (EN)

### DIFF
--- a/blog/2021-12-15-handlungsempfehlung-rote-kachel/index.md
+++ b/blog/2021-12-15-handlungsempfehlung-rote-kachel/index.md
@@ -7,12 +7,12 @@ author: CWA Team
 layout: blog
 ---
 
-In Germany, the number of Covid-19 infections is still very high. From December 1 to December 7 alone, an **estimated 1.1 million users received a “red tile”** in the Corona-Warn-App (CWA; [as of December 14, 2021](https://www.coronawarn.app/en/science/))*. However, many of these users have already been vaccinated or have recovered from a Covid-19 infection. So, what should you do if you see a red tile? And how and when does it disappear again?
+In Germany, the number of COVID-19 infections is still very high. From December 1 to December 7 alone, an **estimated 1.1 million users received a “red tile”** in the Corona-Warn-App (CWA; [as of December 14, 2021](/en/science/))*. However, many of these users have already been vaccinated or have recovered from a COVID-19 infection. So, what should you do if you see a red tile? And how and when does it disappear again?
 
 
 <!-- overview -->
 
-A “red warning” does not necessarily mean that you have been infected with Covid-19. The Corona-Warn-App simply warns you of an increased risk of infection and **does not differentiate between vaccinated, unvaccinated, and recovered users**. 
+A “red warning” does not necessarily mean that you have been infected with COVID-19. The Corona-Warn-App simply warns you of an increased risk of infection and **does not differentiate between vaccinated, unvaccinated, and recovered users**. 
 
 
 <br></br>
@@ -21,7 +21,7 @@ A “red warning” does not necessarily mean that you have been infected with C
 </center>
 <br></br>
 
-The reason: If the increased risk-status indicator appears on your smartphone, you’ve had at least one encounter with a person who later tested positive for Covid-19 in the past 14 days. Therefore, regardless of whether you are vaccinated, unvaccinated, or have recovered from an infection, we recommend that you behave as follows in case of a “red warning”:
+The reason: If the increased risk-status indicator appears on your smartphone, you’ve had at least one encounter with a person who later tested positive for COVID-19 in the past 14 days. Therefore, regardless of whether you are vaccinated, unvaccinated, or have recovered from an infection, we recommend that you behave as follows in case of a “red warning”:
 
 **<u>1) Go home</u>**
 
@@ -33,7 +33,7 @@ If **your employer** gives you the opportunity to work from home, do so. If this
 
 At the moment, it is recommended to **quarantine for 10 days** starting from the time of the risk exposure. The quarantine **can be shortened to 5 days** if you take a PCR test with a negative result. For this reason, the red tile in the CWA shows the date of the risk exposure. 
 
-For more information on the recommendations, visit the [Robert Koch-Institut's website](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Kontaktperson/Management.html;jsessionid=FA6467ABE90F33E7D9982350BA10FBAB.internet051?nn=13490888#doc13516162bodyText16). Under point 3.2.2, you can also find the information that people, who have been fully vaccinated or recovered from a COVID-19 infection, are excluded from quarantine measures if they’ve had contact with a confirmed SARS-CoV-2 case. This shows that users can make the decision to quarantine when having a red tile independently and on a voluntary basis. 
+For more information on the recommendations, visit the [Robert Koch Institute's website](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Kontaktperson/Management.html?nn=13490888#doc13516162bodyText16) (information in German). Under point 3.2.2, you can also find the information that people, who have been fully vaccinated or recovered from a COVID-19 infection, are excluded from quarantine measures if they’ve had contact with a confirmed SARS-CoV-2 case. This shows that users can make the decision to quarantine when having a red tile independently and on a voluntary basis. 
 
 The **red tile disappears 14 days after the risk exposure**. For more information, see the section below, “How and when does the red tile disappear again?". 
 
@@ -60,7 +60,7 @@ Until you get the result, you should stay home and adhere to the recommendations
 
 If you **experience symptoms, feel sick, or have risk factors**, you should consult with your general practitioner or the general practitioner’s on-call duty under the phone number 116 117. The doctor will ask you about your symptoms and risk factors and then decide how to test. 
 
-You can **find test options here**: [https://www.coronawarn.app/en/faq/#where_can_i_get_tested](/en/faq/#where_can_i_get_tested). For more information about the test procedure, see [https://www.coronawarn.app/en/faq/#red_card_how_to_test](/en/faq/#red_card_how_to_test).
+You can **find test options** under [Where can I get tested?](/en/faq/#where_can_i_get_tested). For more information about the test procedure, see [Red Card? How to go through Corona testing](/en/faq/#red_card_how_to_test).
 
 
 **<u>4) Positive Test Result: Self-isolate and share your test result</u>**
@@ -83,7 +83,7 @@ If your **PCR test is positive**, contact your responsible public health authori
 
 As soon as your rapid test or PCR test result is available, share it with the Corona-Warn-App. This allows you to warn your contacts and help to end the infection chain quickly. 
 
-For answers to frequently asked questions about the behavior in case of a red tile, also see the FAQs: [https://www.coronawarn.app/en/faq/#red_card_how_to_test](/en/faq/#red_card_how_to_test).
+For answers to frequently asked questions about the behavior in case of a red tile, also see the [FAQs on the website of CWA](/en/faq/#red_card_how_to_test).
 
 
 ### How and when does the red tile disappear again??
@@ -99,16 +99,15 @@ This is because the **time when you receive a warning depends on when a positive
 
 The red tile remains until the underlying risk exposure is more than 14 days in the past. This status does not change even if you register a negative antigen rapid test or PCR test in the app. This is because the red warning indicates that you have had contact with a person diagnosed positively with SARS-CoV-2 and may have been infected, too. The negative test result simply states that you did not prove a SARS-CoV-2 infection at the time of sampling. It is **not always possible to automatically decide** whether being "non-infectious" at this time excludes an infection at the time of exposure to the positively tested person.
 
-**For example**, if you receive a warning about a risk exposure that took place two days ago, and you have yourself tested immediately, this test may be negative. However, you may have been infected, but the viral load may not be that high until a few days later so that a new test will then be positive. For this reason, you should perform a **second test 3 to 5 days after the first test**. 
- 
+**For example**, if you receive a warning about a risk exposure that took place two days ago, and you have yourself tested immediately, this test may be negative. However, you may have been infected, but the viral load may not be that high until a few days later so that a new test will then be positive. For this reason, you should perform a **second test 3 to 5 days after the first test**.
+
 
 ### … and what about a green tile?
 
-Even with a green tile, there can be indications of encounters with people tested positively later. However, the Corona-Warn-App does not rate these encounters as an increased risk due to the circumstances (for example, short exposure period or long distance to that person). Therefore, it is not necessary for you to behave as stated above. 
+Even with a green tile, there can be indications of encounters with people tested positively later. However, the Corona-Warn-App does not rate these encounters as an increased risk due to the circumstances (for example, short exposure period or long distance to that person). Therefore, it is not necessary for you to behave as stated above.
 
-Nevertheless, you should **adhere to the usual hygiene rules**: When you encounter other people, wear a medical mask, keep distance from other people, sneeze or cough into your elbow or a handkerchief, wash your hands regularly with soap, and let fresh air in several times a day (see [here](https://www.gov.uk/government/news/public-reminded-to-let-in-fresh-air-when-meeting-others-indoors-to-reduce-the-spread-of-covid-19) for further information)
+Nevertheless, you should **adhere to the usual hygiene rules**: When you encounter other people, wear a medical mask, keep distance from other people, sneeze or cough into your elbow or a handkerchief, wash your hands regularly with soap, and let fresh air in several times a day (see [here](https://www.gov.uk/government/news/public-reminded-to-let-in-fresh-air-when-meeting-others-indoors-to-reduce-the-spread-of-covid-19) for further information).
 
 
 
-*_According to Privacy Preserving Analytics (PPA). More information here:_ [https://www.coronawarn.app/en/science/2021-10-15-science-blog-4/#3-privacy-preserving-analytics](/en/science/2021-10-15-science-blog-4/#3-privacy-preserving-analytics)
-
+*_According to Privacy Preserving Analytics (PPA). More information in the Science Blog: "Who is using the Corona-Warn-App, who is warned - and how fast?" in_ [Section 3 - Privacy-Preserving Analytics](/en/science/2021-10-15-science-blog-4/#3-privacy-preserving-analytics).


### PR DESCRIPTION
This PR resolves issue #2229 "Links in "What should you do if you see a red tile?" (EN)". It aligns https://www.coronawarn.app/en/blog/2021-12-15-cwa-red-tile-guidance/ with the changes made in the equivalent German language blog https://www.coronawarn.app/de/blog/2021-12-15-cwa-red-tile-guidance/ (see PR #2202).

