### PR TITLE
Use term "validation service" in 2.15 screenshots

### DIFF
--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -11,7 +11,7 @@
             "textblock": [
                 "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 2.15 (available since December 20th, 2021). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
                 "With this update we provide new and enhanced features:",
-                "<b>Certificate check for bookings:</b> You can already provide proof that you have been vaccinated, recovered or tested negative when booking a ticket. To do this, you scan a QR code displayed by the booking system and then select the appropriate certificate in the app. The result of the certificate check is transferred to the booking system by the testing partner.",
+                "<b>Certificate check for bookings:</b> You can already provide proof that you have been vaccinated, recovered or tested negative when booking a ticket. To do this, you scan a QR code displayed by the booking system and then select the appropriate certificate in the app. The result of the certificate check is transferred to the booking system by the validation service.",
                 "The images provided on this page are available for free use."
             ]
         }


### PR DESCRIPTION
In https://www.coronawarn.app/en/screenshots/ "Take a Look (Version 2.15)" this PR changes the term "testing partner" in the sentence "The result of the certificate check is transferred to the booking system by the testing partner." to "validation service".

This also conforms to the term used in the blog https://www.coronawarn.app/en/blog/2021-12-20-cwa-2-15/ "Corona-Warn-App simplifies certificate checks when booking tickets".

"Testing partner" may otherwise be confused with a partner who tests a person for an infection through a PCR or Rapid Antigen Test.



## Reference

[Guidelines on the use of Digital Covid Certificates in traveller and online booking scenarios](https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_traveller-onlinebooking_en.pdf) - Section 3 Booking and Ticketing Integration.

