### PR TITLE
Use "Robert Koch Institute" in EN blogs

### DIFF
--- a/blog/2020-09-04-cwa-1-3-post/index.md
+++ b/blog/2020-09-04-cwa-1-3-post/index.md
@@ -12,6 +12,6 @@ We have updated the Corona-Warn-App to version 1.3, which is available for downl
 
 Important new features include **additional information on the risk status**. If a low-risk encounter took place, users can now find a brief explanation in the risk status details about why the risk of infection is considered low despite one or more encounters with a person tested positive for COVID-19. The recommendation to open the Corona-Warn-App preventively once a day is now displayed in the app, too.
 
-In addition, Corona-Warn-App version 1.3 contains a **link to a contact form** by the Robert Koch-Institut, which makes it easier for users to ask questions and make suggestions. 
+In addition, Corona-Warn-App version 1.3 contains a **link to a contact form** by the Robert Koch Institute, which makes it easier for users to ask questions and make suggestions. 
 
 On iOS devices, the app displays the status “Unknown Risk” if the risk status has not been updated for 48 hours. This can be the case if the [background app refresh](/en/faq/#no_risk_update_ios) has not been activated. Users can then manually update the risk status in the app.

--- a/blog/2021-01-28-cwa-1-11/index.md
+++ b/blog/2021-01-28-cwa-1-11/index.md
@@ -13,7 +13,7 @@ Within the next 48 hours, users will be able to download the Corona-Warn-App’s
 
 The new feature gives the more than 25 million users the opportunity to find out about the current Corona situation in Germany directly in the app and encourages them to warn others in case they’ve been tested positive. 
 
-While the figures on the infection numbers come from the Robert Koch-Institut, the number of transmitted warnings comes from the Corona-Warn-App’s IT system. The numbers are updated hourly and edited for the app. The statistics show changes as soon as new information is available. 
+While the figures on the infection numbers come from the Robert Koch Institute, the number of transmitted warnings comes from the Corona-Warn-App’s IT system. The numbers are updated hourly and edited for the app. The statistics show changes as soon as new information is available. 
 
 With a **swipe to the left**, users can scroll through the figures. The app first shows them the number of people who have tested positive for COVID-19 recently and the number of total infections. Users can also see the average number of people who have tested positive for COVID-19 over the past seven days.
 

--- a/blog/2021-02-23-risk-calculation/index.md
+++ b/blog/2021-02-23-risk-calculation/index.md
@@ -7,7 +7,7 @@ author: Hanna Heine
 layout: blog
 ---
  
-Deutsche Telekom and SAP’s project team continue to adapt the Corona-Warn-App’s risk calculation in collaboration with the Robert Koch-Institut (RKI) following extensive tests by the Fraunhofer Institute for Integrated Circuits (IIS). As a result, the app can now identify encounters with increased risk even better. and will show even more precisely when users have had encounters with people who later tested positive for COVID-19. 
+Deutsche Telekom and SAP’s project team continue to adapt the Corona-Warn-App’s risk calculation in collaboration with the Robert Koch Institute (RKI) following extensive tests by the Fraunhofer Institute for Integrated Circuits (IIS). As a result, the app can now identify encounters with increased risk even better. and will show even more precisely when users have had encounters with people who later tested positive for COVID-19. 
 
 Now, the app considers short contacts between two people that lasted at least 5 minutes, not 10 minutes as it was the case before. The relevant data for this adjustment is only available because Apple and Google developed their interface further. Measurements based on version 2 of the interface confirmed that warnings can be better and more accurate through the adjustment. 
 

--- a/blog/2021-03-04-cwa-1-13/index.md
+++ b/blog/2021-03-04-cwa-1-13/index.md
@@ -7,7 +7,7 @@ author: Hanna Heine
 layout: blog
 ---
  
-Deutsche Telekom and SAP’s project team have released the Corona-Warn-App’s next update that will be available to users within the next 48 hours. With version 1.13, users now have the option to **voluntarily donate data** to help improve the app. In addition, the app now includes a link to a **scientific survey** conducted by the Robert Koch-Institut (RKI).
+Deutsche Telekom and SAP’s project team have released the Corona-Warn-App’s next update that will be available to users within the next 48 hours. With version 1.13, users now have the option to **voluntarily donate data** to help improve the app. In addition, the app now includes a link to a **scientific survey** conducted by the Robert Koch Institute (RKI).
 
 <!-- overview -->
 

--- a/blog/2021-03-19-parameteraenderung-risikoberechnung/index.md
+++ b/blog/2021-03-19-parameteraenderung-risikoberechnung/index.md
@@ -8,7 +8,7 @@ layout: blog
 ---
 
 
-The project team continuously tests the Corona-Warn-App's performance to configure it optimally - especially in respect to the Corona situation in Germany with increasing case numbers and higher infectivity due to the mutated virus variants. In recent weeks, the Fraunhofer Institute for Integrated Circuits (IIS) and the Robert Koch-Institut **tested and evaluated the app's measurement accuracy** (using version 2 of the Google-Apple exposure notification framework).
+The project team continuously tests the Corona-Warn-App's performance to configure it optimally - especially in respect to the Corona situation in Germany with increasing case numbers and higher infectivity due to the mutated virus variants. In recent weeks, the Fraunhofer Institute for Integrated Circuits (IIS) and the Robert Koch Institute **tested and evaluated the app's measurement accuracy** (using version 2 of the Google-Apple exposure notification framework).
 
 <!-- overview -->
  
@@ -28,4 +28,4 @@ Thus, **short contact times** with individuals who later test positive will no l
 
 In addition, the experts adjusted the configuration of the optimization procedure: the correct detection of actually exposed persons (true positives) is given a higher priority than the correct exclusion of actually non-exposed persons (true negatives). This will moderately increase both red warnings (high-risk encounters) and green warnings (low-risk encounters).
 
-The project participants (Robert Koch-Institut, Deutsche Telekom, SAP, Fraunhofer Institute for Integrated Circuits (IIS)) are continuously working on improving the measurements and the resulting configuration parameters.
+The project participants (Robert Koch Institute, Deutsche Telekom, SAP, Fraunhofer Institute for Integrated Circuits (IIS)) are continuously working on improving the measurements and the resulting configuration parameters.

--- a/blog/2021-04-16-anpassung-risikoberechnung/index.md
+++ b/blog/2021-04-16-anpassung-risikoberechnung/index.md
@@ -8,7 +8,7 @@ layout: blog
 ---
  
 
-The Corona-Warn-App's project team continuously improves the app's performance with regard to the coronavirus situation in Germany. In response to virus mutations, the team members from the Robert Koch-Institut, Deutsche Telekom, SAP and the Fraunhofer Institute for Integrated Circuits (IIS) have therefore further improved the risk calculation and reduced the **duration of a critical encounter** from 13 minutes to 9 minutes. 
+The Corona-Warn-App's project team continuously improves the app's performance with regard to the coronavirus situation in Germany. In response to virus mutations, the team members from the Robert Koch Institute, Deutsche Telekom, SAP and the Fraunhofer Institute for Integrated Circuits (IIS) have therefore further improved the risk calculation and reduced the **duration of a critical encounter** from 13 minutes to 9 minutes. 
 
 
 <!-- overview -->

--- a/blog/2021-05-12-cwa-2-2/index.md
+++ b/blog/2021-05-12-cwa-2-2/index.md
@@ -35,7 +35,7 @@ Once created, the profile remains and can be shown again whenever it’s needed.
 
 ### Users can create error reports in the Corona-Warn-App
 
-Furthermore, users can now create an **error analysis** in the Corona-Warn-App if they notice an error and technical support requests a detailed report. This way, the individual technical steps and events during your usage of the app can be recorded in detail and sent to the technical support of the Robert Koch-Institut (RKI). With this function, the analysis of possible errors can be facilitated, and users can quickly assist in troubleshooting. 
+Furthermore, users can now create an **error analysis** in the Corona-Warn-App if they notice an error and technical support requests a detailed report. This way, the individual technical steps and events during your usage of the app can be recorded in detail and sent to the technical support of the Robert Koch Institute (RKI). With this function, the analysis of possible errors can be facilitated, and users can quickly assist in troubleshooting. 
 
 **Reporting an error**
 

--- a/blog/2021-06-10 CWA 2.3 digitaler Impfnachweis/index.md
+++ b/blog/2021-06-10 CWA 2.3 digitaler Impfnachweis/index.md
@@ -35,5 +35,5 @@ Users can scan the QR code after the first vaccination to integrate the vaccinat
 
 **Please note**: In the Corona-Warn-App, users can only **scan and add vaccination certificates from one person**. It is not possible to add their own and, for example, their partner's vaccination certificate. 
 
-All information and data remain on the user's smartphone. Transfer to third parties only takes place when users show the vaccination certificate in the form of the QR code for verification. Information from vaccination certificates also doesn’t appear in the error report that users have been able to create and send to the Robert Koch-Institut since version 2.2 of the app. 
+All information and data remain on the user's smartphone. Transfer to third parties only takes place when users show the vaccination certificate in the form of the QR code for verification. Information from vaccination certificates also doesn’t appear in the error report that users have been able to create and send to the Robert Koch Institute since version 2.2 of the app. 
 

--- a/blog/2021-06-24 CWA 2.4 Testzertifikat/index.md
+++ b/blog/2021-06-24 CWA 2.4 Testzertifikat/index.md
@@ -43,7 +43,7 @@ Users requesting a test certificate for a PCR test must provide their date of bi
 <center> <img src="./request-certificate-birthday.png" title="Date of birth" style="align: center"></center>
 <br></br>
 
-**Please note**: To create the test certificate, the data is encrypted end-to-end and transmitted from the lab or the rapid test site to the Corona-Warn-App. For this purpose, the encrypted data is transmitted to the Robert Koch-Institut (RKI) in order to digitally sign it and thus confirm the certificate’s validity. The RKI cannot decrypt the data, which will be deleted after the certificate has been delivered.
+**Please note**: To create the test certificate, the data is encrypted end-to-end and transmitted from the lab or the rapid test site to the Corona-Warn-App. For this purpose, the encrypted data is transmitted to the Robert Koch Institute (RKI) in order to digitally sign it and thus confirm the certificate’s validity. The RKI cannot decrypt the data, which will be deleted after the certificate has been delivered.
 
 Test certificates are stored in the app for an unlimited period. However, users can delete them by going to the "Certificates" tab, selecting the respective test certificate, and then selecting "Remove test certificate" at the bottom. How long the certificate can serve as proof of a negative test result depends on the regulations of the respective state or municipality.  
   

--- a/blog/2021-06-29-twitter-account/index.md
+++ b/blog/2021-06-29-twitter-account/index.md
@@ -7,7 +7,7 @@ author: Wolfgang Scheida
 layout: blog
 ---
 
-Anyone who wants to find out more about the Corona-Warn-App and get quick details can now do so on Twitter. The project partners Robert Koch-Institut, SAP and Deutsche Telekom have set up a channel for the CWA.
+Anyone who wants to find out more about the Corona-Warn-App and get quick details can now do so on Twitter. The project partners Robert Koch Institute, SAP and Deutsche Telekom have set up a channel for the CWA.
 
 
 <!-- overview -->

--- a/blog/2021-10-06-cwa-2-11/index.md
+++ b/blog/2021-10-06-cwa-2-11/index.md
@@ -7,7 +7,7 @@ author: Hanna Heine, 10 am
 layout: blog
 ---
 
-The project team of the Robert Koch-Institut, Deutsche Telekom, and SAP have **released Corona-Warn-App version 2.11**, which contains a **universal QR code scanner**. Android users also have the option of importing QR codes from photos or PDF files using the QR code scanner. iOS users will be able to use this feature as of version 2.12.
+The project team of the Robert Koch Institute, Deutsche Telekom, and SAP have **released Corona-Warn-App version 2.11**, which contains a **universal QR code scanner**. Android users also have the option of importing QR codes from photos or PDF files using the QR code scanner. iOS users will be able to use this feature as of version 2.12.
 
 The update will be available to users within the next 48 hours.
 

--- a/blog/2021-10-11-wichtigste-Funktionen/index.md
+++ b/blog/2021-10-11-wichtigste-Funktionen/index.md
@@ -19,7 +19,7 @@ But **what about the fall** when life shifts from outdoors to indoors again? The
 
 <!-- overview -->
 
-For that purpose, the project team of Deutsche Telekom, SAP and Robert Koch-Institut are constantly adapting the Corona-Warn-App to the current pandemic situation. We give you **quick instructions on the app’s most important (new) functions** and how they work: 
+For that purpose, the project team of Deutsche Telekom, SAP and Robert Koch Institute are constantly adapting the Corona-Warn-App to the current pandemic situation. We give you **quick instructions on the app’s most important (new) functions** and how they work: 
 
 ### Event registration (check-in function)
 

--- a/blog/2021-10-19-cwa-2-12/index.md
+++ b/blog/2021-10-19-cwa-2-12/index.md
@@ -8,7 +8,7 @@ layout: blog
 ---
 
 
-The project team of the Robert Koch-Institut, Deutsche Telekom and SAP have released version 2.12 of the Corona-Warn-App. Users now have **direct access to the universal QR code scanner**. In addition, the **7-day hospitalization incidence** and the **number of COVID-19 patients in intensive care units** are now available in the statistics. 
+The project team of the Robert Koch Institute, Deutsche Telekom and SAP have released version 2.12 of the Corona-Warn-App. Users now have **direct access to the universal QR code scanner**. In addition, the **7-day hospitalization incidence** and the **number of COVID-19 patients in intensive care units** are now available in the statistics. 
 
 The update will be available to users over the next 48 hours.
 

--- a/blog/2021-11-03-cwa-2-13/index.md
+++ b/blog/2021-11-03-cwa-2-13/index.md
@@ -8,7 +8,7 @@ layout: blog
 ---
 
 
-The project team of the Robert Koch-Institut, Deutsche Telekom, and SAP have **released version 2.13 of the Corona-Warn-App**. With the update, they have added a **recycle bin functionality for certificates**. In addition, the 7-day hospitalization incidence is available at the local level and the project team improved the assignment of certificates to people.
+The project team of the Robert Koch Institute, Deutsche Telekom, and SAP have **released version 2.13 of the Corona-Warn-App**. With the update, they have added a **recycle bin functionality for certificates**. In addition, the 7-day hospitalization incidence is available at the local level and the project team improved the assignment of certificates to people.
 
 The update is available to users over the next 48 hours.
 

--- a/blog/2021-11-04-booster-notifications/index.md
+++ b/blog/2021-11-04-booster-notifications/index.md
@@ -17,7 +17,7 @@ First, all persons who are **at least 70 years old** and who have not been diagn
 
 ### Here's how the app finds the right users to notify
 
-Based on the recommendations of the STIKO, the Robert Koch-Institut (RKI) has created **rules that the Corona-Warn-App can match with the certificates** stored in the app. To be able to inform the affected users about the recommendations, the Corona-Warn app regularly checks all certificates.
+Based on the recommendations of the STIKO, the Robert Koch Institute (RKI) has created **rules that the Corona-Warn-App can match with the certificates** stored in the app. To be able to inform the affected users about the recommendations, the Corona-Warn app regularly checks all certificates.
 
 **Please note:** This check is performed directly in the app, so that **no data leaves the smartphone**. The rules used and the possible recommendation texts are downloaded from the rule server beforehand, so that no individual information about the users or their certificates (or about other people and their certificates) is revealed. 
 

--- a/blog/2021-11-15-cwa-recalled-certificates/index.md
+++ b/blog/2021-11-15-cwa-recalled-certificates/index.md
@@ -8,7 +8,7 @@ layout: blog
 ---
 
 
-To help inform users about **misuse and counterfeiting of vaccination certificates**, the project team of the Robert Koch-Institut, Deutsche Telekom, and SAP have released an enhancement to the Corona-Warn-App version 2.13. The hotfix allows digital vaccination certificates from certain pharmacies to be recalled and marked as invalid in the app.
+To help inform users about **misuse and counterfeiting of vaccination certificates**, the project team of the Robert Koch Institute, Deutsche Telekom, and SAP have released an enhancement to the Corona-Warn-App version 2.13. The hotfix allows digital vaccination certificates from certain pharmacies to be recalled and marked as invalid in the app.
 
 
 <!-- overview -->

--- a/blog/2021-11-22-cwa-2-14/index.md
+++ b/blog/2021-11-22-cwa-2-14/index.md
@@ -7,7 +7,7 @@ author: Hanna Heine, 10 am
 layout: blog
 ---
 
-The project team of the Robert Koch-Institut, Deutsche Telekom, and SAP have released version 2.14 of the Corona-Warn-App. With the update, users can now **restore deleted PCR and rapid tests**.
+The project team of the Robert Koch Institute, Deutsche Telekom, and SAP have released version 2.14 of the Corona-Warn-App. With the update, users can now **restore deleted PCR and rapid tests**.
 
 <!-- overview -->
 

--- a/blog/2021-12-20-cwa-2-15/index.md
+++ b/blog/2021-12-20-cwa-2-15/index.md
@@ -9,7 +9,7 @@ layout: blog
 
 *Updated on December 21, 2021 at 10 am*
 
-The project team of Robert Koch-Institut, Deutsche Telekom, and SAP have released version 2.15 of the Corona-Warn-App. The update enables users to provide their proof of vaccination or recovery or a negative test result while booking tickets. With that feature, the new version also makes it easier for event organizers, companies, and vendors to check Covid certificates and thus contributes to reliable access management in accordance with legal requirements.
+The project team of Robert Koch Institute, Deutsche Telekom, and SAP have released version 2.15 of the Corona-Warn-App. The update enables users to provide their proof of vaccination or recovery or a negative test result while booking tickets. With that feature, the new version also makes it easier for event organizers, companies, and vendors to check Covid certificates and thus contributes to reliable access management in accordance with legal requirements.
 
 <!-- overview -->
 


### PR DESCRIPTION
This PR harmonizes the English language naming of RKI to use the official name "Robert Koch Institute" in blog postings on https://www.coronawarn.app/en/blog/.

It resolves the issue #2226 "Inconsistent full name of RKI in EN blogs".