### PR TITLE
Link blog to risk reduction information from BMG

### DIFF
--- a/blog/2021-12-15-handlungsempfehlung-rote-kachel/index.md
+++ b/blog/2021-12-15-handlungsempfehlung-rote-kachel/index.md
@@ -106,7 +106,7 @@ The red tile remains until the underlying risk exposure is more than 14 days in 
 
 Even with a green tile, there can be indications of encounters with people tested positively later. However, the Corona-Warn-App does not rate these encounters as an increased risk due to the circumstances (for example, short exposure period or long distance to that person). Therefore, it is not necessary for you to behave as stated above.
 
-Nevertheless, you should **adhere to the usual hygiene rules**: When you encounter other people, wear a medical mask, keep distance from other people, sneeze or cough into your elbow or a handkerchief, wash your hands regularly with soap, and let fresh air in several times a day (see [here](https://www.gov.uk/government/news/public-reminded-to-let-in-fresh-air-when-meeting-others-indoors-to-reduce-the-spread-of-covid-19) for further information).
+Nevertheless, you should **adhere to the usual hygiene rules**: When you encounter other people, wear a medical mask, keep your distance from other people, sneeze or cough into your elbow or a handkerchief, wash your hands regularly with soap, and let fresh air in several times a day (see also [Coronavirus infection - this is how the coronavirus spreads](https://www.zusammengegencorona.de/en/ansteckung-mit-corona-so-wird-das-coronavirus-uebertragen/) for background information about reducing your risk of infection).
 
 
 


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2236 "Link to UK Government site in blog" by replacing the link https://www.gov.uk/government/news/public-reminded-to-let-in-fresh-air-when-meeting-others-indoors-to-reduce-the-spread-of-covid-19 to a page of the UK Government by https://www.zusammengegencorona.de/en/ansteckung-mit-corona-so-wird-das-coronavirus-uebertragen/ from the German Federal Ministry of Health.

It changes the blog page https://www.coronawarn.app/en/blog/2021-12-15-cwa-red-tile-guidance/ "What should you do if you see a red tile?".