### PR TITLE
Fix placeholder in FAQ entry (Addresses #2254)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -722,7 +722,7 @@
                         "active": true,
                         "textblock": [
                             "In case of a positive test result, you should share your test result and immediately take a PCR test to confirm or revise the result. In case of a positive PCR test, you should share the test result again to alert contacts you may have met between the two tests. This is provided that the contacts also use the Corona-Warn-App and the risk calculation determines a high risk, based on duration and distance of contact. If the PCR test is negative, you will not have the option to withdraw your positive rapid test and warning.",
-                            "<a href='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl.pdf' target='_blank'><img width= 300px src='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl-1.png' alt='PDF'></a>",
+                            "<a href='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl.pdf' target='_blank'><img width= 300px src='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl-1.PNG' alt='PDF'></a>",
                             "See also poster: <a href='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl.pdf' target='_blank'>Rapid antigen test? Here's how to share your result (German only).</a>"
                         ]
                     },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -723,7 +723,7 @@
                         "active": true,
                         "textblock": [
                             "In Fall eines positiven Testergebnisses sollten Sie Ihr Testergebnis teilen und umgehend einen PCR-Test machen, um das Ergebnis zu bestätigen oder zu widerlegen. Bei einem positiven PCR-Test sollten Sie das Testergebnis erneut teilen, um Kontakte zu warnen, die Sie möglicherweise zwischen den beiden Tests getroffen haben. Voraussetzung dabei ist, dass die Kontaktpersonen ebenfalls die Corona-Warn-App nutzen und die Risikoberechnung ein hohes Risiko bestimmt, basierend auf Dauer und Abstand des Kontakts. Sollte der PCR-Test negativ sein, haben Sie nicht die Möglichkeit, Ihren positiven Schnelltest und die Warnung zurückzuziehen.",
-                            "<a href='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl.pdf' target='_blank'><img width= 300px src='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl-1.png' alt='PDF'></a>",
+                            "<a href='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl.pdf' target='_blank'><img width= 300px src='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl-1.PNG' alt='PDF'></a>",
                             "Siehe auch Poster: <a href='../../assets/documents/DE_CWA_RKI-Plakat_Schnelltests_v2-kl.pdf' target='_blank'>Antigen-Schnelltest? So teilen Sie Ihr Ergebnis.</a>"
                         ]
                     },


### PR DESCRIPTION
This PR fixes an empty placeholder in the `rat_what_if_positive_result` FAQ entry.

Preview of the change:
<img width="879" alt="Bildschirmfoto 2021-12-28 um 12 07 22" src="https://user-images.githubusercontent.com/67682506/147560111-8b51ef46-e7c5-4328-ae56-a64e59a49fd7.png">

---

**Closes #2254**