### PR TITLE
Write out Vaccination Certificate in full for FAQ section title

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -335,7 +335,7 @@
                 ]
             },
             {
-                "title": "Vaccination Cert.",
+                "title": "Vaccination Certificate",
                 "id": "vac_cert",
                 "accordion": [
                     {


### PR DESCRIPTION
This PR removes a workaround which was put in place when the left menu for FAQ section names did not scroll.

It changes the section title from "Vaccination Cert." to "Vaccination Certificate". This matches the German "Impfzertifikat" and the line above, which says "Test Certificate".

This is a cosmetic change only.

## OLD
![Vaccination title old](https://user-images.githubusercontent.com/66998419/147823937-9b520a24-221a-4ce2-8ede-68e6d001c891.png)

## NEW
![Vaccination title](https://user-images.githubusercontent.com/66998419/147823947-9d91fbc5-0093-40a7-9ac0-ab6400650dcc.png)

