### PR TITLE
Add non-breaking space to abbreviation in blog

### DIFF
--- a/blog/2021-11-22-cwa-2-14/index_de.md
+++ b/blog/2021-11-22-cwa-2-14/index_de.md
@@ -54,7 +54,7 @@ Nutzer*innen können außerdem weiterhin nur einen  aktiven Test in ihrer App re
 <br></br>
 <center> 
 <img src="./bin_another_test_ios_de.png" title="Zurückgerufenens, ungültiges Zertifikat" style="align: center" height=600px> 
-<figcaption aria-hidden="true"><em>Abb. 4: Die App kann maximal einen Schnelltest und einen PCR-Test gleichzeitig verwalten. Wenn Nutzer z. B. einen weiteren PCR-Test registrieren, wird der erste PCR-Test in den Papierkorb verschoben.</em></figcaption>
+<figcaption aria-hidden="true"><em>Abb. 4: Die App kann maximal einen Schnelltest und einen PCR-Test gleichzeitig verwalten. Wenn Nutzer z.&nbsp;B. einen weiteren PCR-Test registrieren, wird der erste PCR-Test in den Papierkorb verschoben.</em></figcaption>
 </center>
 <br></br>
 


### PR DESCRIPTION
This PR fixes one abbreviation in the German-language blog https://www.coronawarn.app/de/blog/2021-11-22-cwa-2-14/
    - "Abb. 4: Die App kann maximal einen Schnelltest und einen PCR-Test gleichzeitig verwalten. Wenn Nutzer z. B. einen weiteren PCR-Test registrieren, wird der erste PCR-Test in den Papierkorb verschoben."

See also issue https://github.com/corona-warn-app/cwa-website/issues/1689 and [DIN 5008](https://de.wikipedia.org/wiki/DIN_5008#Abk%C3%BCrzungen_(Abschnitt_4.5)).