### PR TITLE
Release 2.16.1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -434,10 +434,10 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '15.2'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.15.1'))
+    .pipe(replace('[ios.current-app-version]', '2.16.1'))
     .pipe(replace('[android.latest-os-version]', '12'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.15.1'))
+    .pipe(replace('[android.current-app-version]', '2.16.1'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
- Gulpfile: 2.16.1



---
Internal Tracking ID: [EXPOSUREAPP-11096](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11096)
