### PR TITLE
Change booster blog link to STIKO recommendations

### DIFF
--- a/blog/2021-11-04-booster-notifications/index_de.md
+++ b/blog/2021-11-04-booster-notifications/index_de.md
@@ -43,7 +43,7 @@ Wenn die aktuellen Empfehlungen auf den oder die Nutzer\*in zutreffen, weist die
 
 Falls die App Nutzer\*innen benachrichtigt, auf die die Bedingungen nicht zutreffen, weil sie beispielsweise schon eine Auffrischimpfung erhalten haben oder doch eine nachgewiesene COVID-19-Infektion durchgemacht haben, können sie die Benachrichtigung ignorieren. Das Projektteam empfiehlt in diesem Fall allerdings, die entsprechenden Impf- oder Genesenenzertifikate in die App einzuscannen. 
 
-Die STIKO empfiehlt Auffrischimpfungen auch Personen mit bestimmten Vorerkrankungen oder Berufen. Diese Informationen kann die Corona-Warn-App allerdings nicht aus den Zertifikaten ableiten, weshalb sie nicht auf solche Empfehlungen hinweisen kann. **Mehr Informationen zu den STIKO-Empfehlungen** finden Sie auf der [Seite des RKI](https://www.rki.de/DE/Content/Infekt/Impfen/ImpfungenAZ/COVID-19/COVID-19.html). 
+Die STIKO empfiehlt Auffrischimpfungen auch Personen mit bestimmten Vorerkrankungen oder Berufen. Diese Informationen kann die Corona-Warn-App allerdings nicht aus den Zertifikaten ableiten, weshalb sie nicht auf solche Empfehlungen hinweisen kann. **Mehr Informationen zu den STIKO-Empfehlungen** finden Sie auf der [Seite des RKI](https://www.rki.de/DE/Content/Infekt/Impfen/ImpfungenAZ/COVID-19/Impfempfehlung-Zusfassung.html). 
 
 ### So können Nutzer\*innen die Auffrischimpfung in der App hinzufügen
 


### PR DESCRIPTION
This PR follows on from issue https://github.com/corona-warn-app/cwa-website/issues/2013 "Links to rki vaccination page in Booster blog".

It changes the link in https://www.coronawarn.app/de/blog/2021-11-04-cwa-booster-notification/ "Corona-Warn-App informiert zu Booster-Impfungen" to https://www.rki.de/DE/Content/Infekt/Impfen/ImpfungenAZ/COVID-19/Impfempfehlung-Zusfassung.html "STIKO-Empfehlung zur COVID-19-Impfung".

This target link is already used in the English language blog https://www.coronawarn.app/en/blog/2021-11-04-cwa-booster-notification/ "Corona-Warn-App notifies users about a booster vaccination", so the change aligns the two language versions of the blog.

The text is not changed, only the link. The new link is better suited to provide the information being looked for. The old link https://www.rki.de/DE/Content/Infekt/Impfen/ImpfungenAZ/COVID-19/COVID-19.html "COVID-19 und Impfen" is a much more general page, containing about 28 other links, and it is not dedicated to providing information about booster vaccinations.

---
**NEW**

"Die STIKO empfiehlt Auffrischimpfungen auch Personen mit bestimmten Vorerkrankungen oder Berufen. Diese Informationen kann die Corona-Warn-App allerdings nicht aus den Zertifikaten ableiten, weshalb sie nicht auf solche Empfehlungen hinweisen kann. Mehr Informationen zu den STIKO-Empfehlungen finden Sie auf der [Seite des RKI](https://www.rki.de/DE/Content/Infekt/Impfen/ImpfungenAZ/COVID-19/Impfempfehlung-Zusfassung.html)."
