### PR TITLE
Bump current iOS version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -432,7 +432,7 @@ function createFaqRedirects() {
 function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html"])
-    .pipe(replace('[ios.latest-os-version]', '15.2'))
+    .pipe(replace('[ios.latest-os-version]', '15.2.1'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.15.1'))
     .pipe(replace('[android.latest-os-version]', '12'))


### PR DESCRIPTION
This PR bumps the current iOS version from 15.2 to 15.2.1.

---

Apple Release: https://developer.apple.com/news/releases/?id=01122022f