### PR TITLE
Fix analysis typo when is not data to show or user deactivate it

### DIFF
--- a/src/assets/js/analyse/chart/options.js
+++ b/src/assets/js/analyse/chart/options.js
@@ -103,7 +103,7 @@ export default {
 		}
 	},
 	noData: {
-		text: 'No Data to display'
+		text: (documentLang == "de") ? `Keine Daten`: 'No data to display'
 	},
 	dataLabels: {
 		enabled: false


### PR DESCRIPTION
Due to issue #2325 I have created this PR. This fix the capitalization error shown in analysis page when is not data to show or the user deactivate all the options to show in a graphic. The text used is from @MikeMcC399. Thanks, as always!