### PR TITLE
Rename "Analysis" to "Analyse" in German menu (Alignment to page name)

### DIFF
--- a/src/data/global.json
+++ b/src/data/global.json
@@ -370,7 +370,7 @@
                 },
                 {
                     "id": "analysis",
-                    "title": "Analysis",
+                    "title": "Analyse",
                     "url": "/de/analysis/"
                 },
                 {


### PR DESCRIPTION
This PR renames "Analysis" to "Analyse" in the German menu of the page.

Analysis is a German word, but it is not correct in this context, see https://www.duden.de/rechtschreibung/Analysis:

> Teil der Mathematik, in dem mit Grenzwerten gearbeitet, die Infinitesimalrechnung angewendet wird

OR

> Voruntersuchung beim Lösen geometrischer Aufgaben

I tested this change locally & everything was still correct. 

---

Here is a preview of this change:

![Unknown](https://user-images.githubusercontent.com/67682506/149639029-2f0199ae-fa6f-4816-9487-70a1047b0b23.png)

