### PR TITLE
Make link in 2.16 blog to 2.4 blog relative

### DIFF
--- a/blog/2022-01-17-cwa-2-16/index.md
+++ b/blog/2022-01-17-cwa-2-16/index.md
@@ -45,7 +45,7 @@ When users tap on their certificate, they also see **further information** that 
 <br></br>
 
 
-If users have a **valid vaccination or recovery certificate and a valid test certificate** stored in the app, these will be shown in a **combined display** from version 2.16 onwards. Users can then switch between the QR code of the “2G certificate (vaccination or recovery certificate) and that of the test certificate in order to quickly and easily provide 2G+ proof. Both QR codes must be verified on site by the CovPassCheck app along with presentation of the ID card if 2G+ proof is required. 
+If users have a **valid vaccination or recovery certificate and a valid test certificate** stored in the app, these will be shown in a **combined display** from version 2.16 onwards. Users can then switch between the QR code of the "2G certificate" (vaccination or recovery certificate) and that of the test certificate in order to quickly and easily provide 2G+ proof. Both QR codes must be verified on site by the CovPassCheck app along with presentation of the ID card if 2G+ proof is required. 
 
 **Please note:** For data protection reasons, it is not apparent whether the person has a vaccination or recovery certificate when the certificates are checked by the CovPassCheck-App. Those scanning the QR codes can only see whether the certificate is valid or not.
 
@@ -58,7 +58,7 @@ If users have a **valid vaccination or recovery certificate and a valid test cer
 
 **A negative test result is not a test certificate.** A test certificate officially confirms a negative test result in the form of a QR code in the Corona-Warn-App. Users can **request the official test certificate for PCR and rapid tests when registering a test in the Corona-Warn-App**. To do so, they can open the universal QR code scanner in the middle of the CWA’s tab bar and scan the QR code to register the test. They receive this QR code either during the booking of the test or during testing, given that the provider is connected to the Corona-Warn-App. 
 
-After scanning the QR code, a window opens automatically where users can request the test certificate. For more information, see this blog: [Project team releases rapid test partner search and Corona-Warn-App version 2.4 with digital test certificate](https://www.coronawarn.app/en/blog/2021-06-24-cwa-version-2-4/).
+After scanning the QR code, a window opens automatically where users can request the test certificate. For more information, see this blog: [Project team releases rapid test partner search and Corona-Warn-App version 2.4 with digital test certificate](/en/blog/2021-06-24-cwa-version-2-4/).
 
 ## Clear indication in the app when the risk status has changed 
 

--- a/blog/2022-01-17-cwa-2-16/index_de.md
+++ b/blog/2022-01-17-cwa-2-16/index_de.md
@@ -59,7 +59,7 @@ Nutzer\*innen können dann über den Schalter zwischen dem QR-Code des „2G-Zer
 
 **Ein negatives Testergebnis ist kein Testzertifikat.** Ein Testzertifikat bestätigt ein negatives Testergebnis offiziell in Form eines QR-Codes in der Corona-Warn-App. Nutzer*innen können das offizielle Testzertifikat für PCR- und Schnelltests anfordern, wenn sie einen **Test in der Corona-Warn-App registrieren.** Dafür können sie den universellen QR-Code-Scanner in der Mitte der Registerkarte der CWA öffnen und den QR-Code zur Test-Registrierung scannen. Den erhalten sie entweder schon während der Buchung des Tests oder vor Ort beim Testen, sofern der Anbieter an die Corona-Warn-App angeschlossen ist. 
 
-Nach dem Scannen des QR-Codes öffnet sich automatisch ein Fenster, in dem sie das **Testzertifikat anfordern** können. Mehr Informationen finden Sie in diesem Blog: [Projektteam veröffentlicht Online-Schnelltestpartnersuche und Corona-Warn-App Version 2.4 mit digitalem Testzertifikat](https://www.coronawarn.app/de/blog/2021-06-24-cwa-version-2-4/).
+Nach dem Scannen des QR-Codes öffnet sich automatisch ein Fenster, in dem sie das **Testzertifikat anfordern** können. Mehr Informationen finden Sie in diesem Blog: [Projektteam veröffentlicht Online-Schnelltestpartnersuche und Corona-Warn-App Version 2.4 mit digitalem Testzertifikat](/de/blog/2021-06-24-cwa-version-2-4/).
 
 ## Deutlicher Hinweis in der App bei Veränderung des Risikostatus
 


### PR DESCRIPTION
This PR converts a link in
https://www.coronawarn.app/en/blog/2022-01-17-cwa-2-16/ from
https://www.coronawarn.app/en/blog/2021-06-24-cwa-version-2-4/ (absolute) to
/en/blog/2021-06-24-cwa-version-2-4/ (relative) for better maintainability.

Similarly for the German language blog
https://www.coronawarn.app/de/blog/2022-01-17-cwa-2-16/ from
https://www.coronawarn.app/de/blog/2021-06-24-cwa-version-2-4/ (absolute) to
/de/blog/2021-06-24-cwa-version-2-4/ (relative) for better maintainability.

Also, since it was a very minor point I added missing quote character in the English language blog  after `“2G certificate` to match the German blog where this term was in quotes.