### PR TITLE
Change 2.16 EN blog timestamp from "Uhr" to "am"

### DIFF
--- a/blog/2022-01-17-cwa-2-16/index.md
+++ b/blog/2022-01-17-cwa-2-16/index.md
@@ -3,7 +3,7 @@ page-title: "Corona-Warn-App version 2.16 shows users’ current status evidence
 page-description: "Corona-Warn-App version 2.16 shows users’ current status evidence"
 page-name: cwa-2-16
 page-name_de: cwa-2-16
-author: Hanna Heine, 10 Uhr
+author: Hanna Heine, 10 am
 layout: blog
 ---
 


### PR DESCRIPTION
This PR corrects the language of the timestamp on the English language blog

- https://www.coronawarn.app/en/blog/2022-01-17-cwa-2-16/ "Corona-Warn-App version 2.16 shows users’ current status evidence"

from

"Hanna Heine, 10 Uhr, on January 17, 2022"

to

"Hanna Heine, 10 am, on January 17, 2022"

"Uhr" is German and does not belong on a English blog page.
