### PR TITLE
Typo corrections in 2022-01-21 blog

### DIFF
--- a/blog/2022-01-21-cwa-uhrzeit-rote-kachel/index.md
+++ b/blog/2022-01-21-cwa-uhrzeit-rote-kachel/index.md
@@ -17,9 +17,8 @@ Die Corona-Warn-App greift auf die von Google und Apple im Betriebssystem eingeb
 
 Eine Angabe der Uhrzeit ist also nicht möglich. Der Grund dafür: Gewarnte Personen könnten unter Umständen zurückverfolgen, wer positiv auf Corona getestet wurde und die Warnung ausgelöst hätte. Damit wäre die **Anonymität dieser Person nicht mehr gewahrt**. Die Aufdeckung der Identität eines positiven Falles könnte zu persönlichen Nachteilen führen und damit die hohe Akzeptanz der Corona-Warn-App gefährden. 
 
-Auch die hin und wieder aufkommende Forderung, **Informationen zum Ort der Risikobegegnung** in der Corona-Warn-App aufzunehmen, ist aus datenschutzrechtlichen Gründen keine Option. Der Schutz privater Daten gilt nach wie vor als zentraler Bestandteilbei der (Weiter-)Entwicklung der Corona-Warn-App. 
+Auch die hin und wieder aufkommende Forderung, **Informationen zum Ort der Risikobegegnung** in der Corona-Warn-App aufzunehmen, ist aus datenschutzrechtlichen Gründen keine Option. Der Schutz privater Daten gilt nach wie vor als zentraler Bestandteil bei der (Weiter-)Entwicklung der Corona-Warn-App. 
 
 **Freiwilligkeit, Transparenz und das hohe Datenschutzniveau** der App sind nach wie vor die Grundvoraussetzungen für ihre breite Akzeptanz in der Bevölkerung (mehr als 40 Millionen Downloads/Stand Januar 2022). 
 
-Das Projektteam steht in einemregelmäßigen Austausch mit Apple und Google, diskutiert kontinuierlich mögliche Weiterentwicklungen sowie Anpassungen der ENF-V2-Schnittstelle.  
-
+Das Projektteam steht in einem regelmäßigen Austausch mit Apple und Google, diskutiert kontinuierlich mögliche Weiterentwicklungen sowie Anpassungen der ENF-V2-Schnittstelle.  

--- a/blog/2022-01-21-cwa-uhrzeit-rote-kachel/index_de.md
+++ b/blog/2022-01-21-cwa-uhrzeit-rote-kachel/index_de.md
@@ -15,9 +15,8 @@ Die Corona-Warn-App greift auf die von Google und Apple im Betriebssystem eingeb
 
 Eine Angabe der Uhrzeit ist also nicht möglich. Der Grund dafür: Gewarnte Personen könnten unter Umständen zurückverfolgen, wer positiv auf Corona getestet wurde und die Warnung ausgelöst hätte. Damit wäre die **Anonymität dieser Person nicht mehr gewahrt**. Die Aufdeckung der Identität eines positiven Falles könnte zu persönlichen Nachteilen führen und damit die hohe Akzeptanz der Corona-Warn-App gefährden. 
 
-Auch die hin und wieder aufkommende Forderung, **Informationen zum Ort der Risikobegegnung** in der Corona-Warn-App aufzunehmen, ist aus datenschutzrechtlichen Gründen keine Option. Der Schutz privater Daten gilt nach wie vor als zentraler Bestandteilbei der (Weiter-)Entwicklung der Corona-Warn-App. 
+Auch die hin und wieder aufkommende Forderung, **Informationen zum Ort der Risikobegegnung** in der Corona-Warn-App aufzunehmen, ist aus datenschutzrechtlichen Gründen keine Option. Der Schutz privater Daten gilt nach wie vor als zentraler Bestandteil bei der (Weiter-)Entwicklung der Corona-Warn-App. 
 
 **Freiwilligkeit, Transparenz und das hohe Datenschutzniveau** der App sind nach wie vor die Grundvoraussetzungen für ihre breite Akzeptanz in der Bevölkerung (mehr als 40 Millionen Downloads/Stand Januar 2022). 
 
-Das Projektteam steht in einemregelmäßigen Austausch mit Apple und Google, diskutiert kontinuierlich mögliche Weiterentwicklungen sowie Anpassungen der ENF-V2-Schnittstelle.  
-
+Das Projektteam steht in einem regelmäßigen Austausch mit Apple und Google, diskutiert kontinuierlich mögliche Weiterentwicklungen sowie Anpassungen der ENF-V2-Schnittstelle.  


### PR DESCRIPTION
This PR adds spaces where two words have run together in:
- https://www.coronawarn.app/en/blog/2022-01-21-cwa-uhrzeit-rote-kachel/ "Warum zeigt die Corona-Warn-App bei einer roten Kachel die genaue Uhrzeit und den Ort der Begegnung nicht an?" and
- https://www.coronawarn.app/de/blog/2022-01-21-cwa-uhrzeit-rote-kachel/ "Warum zeigt die Corona-Warn-App bei einer roten Kachel die genaue Uhrzeit und den Ort der Begegnung nicht an?"

"Bestandteilbei" => "Bestandteil bei" 
"einemregelmäßigen" => "einem regelmäßigen"

were missing spaces.