### PR TITLE
Update README to Node.js 14.18.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the source files of the official website for the Corona
 
 ### Requirements
 
-You need the Node.js 14 Maintenance LTS version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website. ([cwa-website](https://github.com/corona-warn-app/cwa-website) is not ready for the Node.js 16 Active LTS version.) Downloads for Node.js 14.18.2 are available from the [Node.js - Previous Releases](https://nodejs.org/en/download/releases/) page.
+You need the Node.js 14 Maintenance LTS version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website. ([cwa-website](https://github.com/corona-warn-app/cwa-website) is not ready for the Node.js 16 Active LTS version.) Downloads for Node.js 14.18.3 are available from the [Node.js - Previous Releases](https://nodejs.org/en/download/releases/) page.
 
 ### Getting started
 


### PR DESCRIPTION
This PR updates the recommended version of [Node.js](https://nodejs.org/en/) in the [README.md](https://github.com/corona-warn-app/cwa-website/blob/master/README.md) file from 14.18.2 to 14.18.3.

The GitHub virtual environment [Ubuntu 20.04 LTS](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md) now uses the Node.js version 14.18.3 of the [Node.js 14 (lts/fermium)](https://nodejs.org/download/release/latest-fermium/) release as listed in the [Cached Tools: Node.js section](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#nodejs) of the virtual environment configuration.