### PR TITLE
Remove wrong information reg. TAN hotline

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -95,7 +95,7 @@
                         "active": false,
                         "textblock": [
                             "The technical hotline (<a href='#international_phone_numbers' target='_blank' >click here to see the phone numbers</a>) will help you with technical questions about the Corona-Warn-App, for instance if you have problems with exposure logging. You can reach the technical hotline from Monday to Saturday from 7 a.m. to 10 p.m. (except on German national holidays), and it is free of charge for you within Germany.",
-                            "The TAN hotline (<a href='#international_phone_numbers' target='_blank' >click here to see the phone numbers</a>) will help you to enter the TAN if you have a positive PCR test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available Monday to Sunday from 7 a.m. to 8 p.m. German local time (except on German national holidays). The call is free of charge from within Germany.",
+                            "The TAN hotline (<a href='#international_phone_numbers' target='_blank' >click here to see the phone numbers</a>) will help you to enter the TAN if you have a positive PCR test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available Monday to Sunday from 7 a.m. to 8 p.m. German local time. The call is free of charge from within Germany.",
                             "If the test result is not available in the Corona-Warn-App, the relevant service personnel, test centre or health authority should be contacted to obtain the test result.  <br/>In order to make it easier for you to find the responsible health authority, the RKI has provided a corresponding tool. By entering the postal code or the city of residence, the responsible health authority (including contact details) is immediately displayed: <a href='https://tools.rki.de/PLZTool/en-GB'>Robert Koch Institute Tool: Health authority by postal code or place</a>",
                             "Further information on the PCR-Test QR Code procedure can be found in this FAQ entry: <a href='#qr_test'>I have scanned a PCR-Test QR code, but the test result could not be retrieved for days.</a>",
                             "The websites of the Federal Government are offering general information and videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch</a>.",
@@ -115,7 +115,7 @@
                             "<b>National:</b> 0800 7540001",
                             "<b>International:</b> +49 30 498 75401",
                             "<b>TAN Hotline</b>",
-                            "The TAN hotline will help you to enter the TAN if you have a positive PCR test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available Monday to Sunday from 7 a.m. to 8 p.m. German local time (except on German national holidays)",
+                            "The TAN hotline will help you to enter the TAN if you have a positive PCR test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available Monday to Sunday from 7 a.m. to 8 p.m. German local time",
                             "<b>National:</b> 0800 7540002",
                             "<b>International:</b> +49 30 498 75402"
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -93,7 +93,7 @@
                         "active": false,
                         "textblock": [
                             "Die technische Hotline (<a href='#international_phone_numbers' target='_blank'>klicken Sie hier um zu den Telefonnummern zu gelangen</a>) hilft Ihnen bei technischen Fragen rund um die Corona-Warn-App, zum Beispiel bei Problemen mit der Risiko-Ermittlung. Sie erreichen sie von Montag bis Samstag von 7 bis 22 Uhr (außer an bundesweiten Feiertagen), und sie ist für Sie innerhalb Deutschlands kostenfrei.",
-                            "Die TAN-Hotline (<a href='#international_phone_numbers' target='_blank'>klicken Sie hier um zu den Telefonnummern zu gelangen</a>) hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives PCR-Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Sie erreichen sie von Montag bis Sonntag von 7 bis 20 Uhr Ortszeit in Deutschland (außer an bundesweiten Feiertagen). Der Anruf ist innerhalb Deutschlands kostenfrei.",
+                            "Die TAN-Hotline (<a href='#international_phone_numbers' target='_blank'>klicken Sie hier um zu den Telefonnummern zu gelangen</a>) hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives PCR-Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Sie erreichen sie von Montag bis Sonntag von 7 bis 20 Uhr Ortszeit in Deutschland. Der Anruf ist innerhalb Deutschlands kostenfrei.",
                             "Falls das Testergebnis nicht in der Corona-Warn-App abrufbar ist, sollte das zuständige Fachpersonal, Testcenter oder Gesundheitsamt kontaktiert werden, um das Testergebnis zu erhalten. <br/>Um Ihnen die Suche nach dem zuständigen Gesundheitsamt zu erleichtern, hat das RKI ein entsprechendes Tool zur Verfügung gestellt. Durch die Angabe der Postleitzahl oder des Wohnortes, wird sofort das zuständige Gesundheitsamt inklusive der Kontaktdaten angezeigt: <a href='https://tools.rki.de/PLZTool'>Robert Koch-Institut Tool: Gesundheitsamt nach Postleitzahl oder Ort</a>",
                             "Weitere Hinweise zum PCR-Test-QR-Code Verfahren finden Sie in diesem FAQ Eintrag: <a href='#qr_test'>Ich habe einen PCR-Test-QR-Code eingescannt, aber das Testergebnis konnte über Tage nicht abgerufen werden.</a>",
                             "Die Webseiten der Bundesregierung bieten allgemeine Informationen und Videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app</a>.",
@@ -113,7 +113,7 @@
                             "<b>National:</b> 0800 7540001",
                             "<b>International:</b> +49 30 498 75401",
                             "<b>TAN-Hotline</b>",
-                            "Die TAN-Hotline hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives PCR-Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Sie erreichen sie von Montag bis Sonntag von 7 bis 20 Uhr Ortszeit in Deutschland (außer an bundesweiten Feiertagen).",
+                            "Die TAN-Hotline hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives PCR-Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Sie erreichen sie von Montag bis Sonntag von 7 bis 20 Uhr Ortszeit in Deutschland",
                             "<b>National:</b> 0800 7540002",
                             "<b>International:</b> +49 30 498 75402"
                         ]


### PR DESCRIPTION
This PR removes the wrong information that the TAN hotline is not available on German national holidays.

---

Addresses https://github.com/corona-warn-app/cwa-hotline/issues/14#issuecomment-1019152190.