### PR TITLE
Add ":" to `international_phone_numbers`

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -111,11 +111,11 @@
                         "textblock": [
                             "You can reach us by phone from within Germany and from abroad. The national numbers are free of charge, but are only available from within Germany. The international numbers are <b>not free of charge</b> - the cost of the international call is based on the contract with your provider.",
                             "<b>Technical Hotline</b>",
-                            "The technical hotline will help you with technical questions about the Corona-Warn-App, for instance if you have problems with the exposure logging. It is available Monday to Saturday from 7 a.m. to 10 p.m. German local time (except on German national holidays)",
+                            "The technical hotline will help you with technical questions about the Corona-Warn-App, for instance if you have problems with the exposure logging. It is available Monday to Saturday from 7 a.m. to 10 p.m. German local time (except on German national holidays):",
                             "<b>National:</b> 0800 7540001",
                             "<b>International:</b> +49 30 498 75401",
                             "<b>TAN Hotline</b>",
-                            "The TAN hotline will help you to enter the TAN if you have a positive PCR test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available Monday to Sunday from 7 a.m. to 8 p.m. German local time",
+                            "The TAN hotline will help you to enter the TAN if you have a positive PCR test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available Monday to Sunday from 7 a.m. to 8 p.m. German local time:",
                             "<b>National:</b> 0800 7540002",
                             "<b>International:</b> +49 30 498 75402"
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -109,11 +109,11 @@
                         "textblock": [
                             "Sie können uns per Telefon von inner- und außerhalb Deutschlands erreichen. Die nationalen Telefonnummern sind für Sie kostenfrei, können jedoch nur aus dem deutschen Telefonnetz erreicht werden. Die internationalen Rufnummern sind <b>nicht kostenfrei</b> - die Kosten für den internationalen Anruf richten sich nach dem Vertrag mit Ihrem Provider.",
                             "<b>Technische Hotline</b>",
-                            "Die technische Hotline hilft Ihnen bei technischen Fragen rund um die Corona-Warn-App, zum Beispiel bei Problemen mit der Risiko-Ermittlung. Sie erreichen sie von Montag bis Samstag von 7 bis 22 Uhr Ortszeit in Deutschland (außer an bundesweiten Feiertagen)",
+                            "Die technische Hotline hilft Ihnen bei technischen Fragen rund um die Corona-Warn-App, zum Beispiel bei Problemen mit der Risiko-Ermittlung. Sie erreichen sie von Montag bis Samstag von 7 bis 22 Uhr Ortszeit in Deutschland (außer an bundesweiten Feiertagen):",
                             "<b>National:</b> 0800 7540001",
                             "<b>International:</b> +49 30 498 75401",
                             "<b>TAN-Hotline</b>",
-                            "Die TAN-Hotline hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives PCR-Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Sie erreichen sie von Montag bis Sonntag von 7 bis 20 Uhr Ortszeit in Deutschland",
+                            "Die TAN-Hotline hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives PCR-Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Sie erreichen sie von Montag bis Sonntag von 7 bis 20 Uhr Ortszeit in Deutschland:",
                             "<b>National:</b> 0800 7540002",
                             "<b>International:</b> +49 30 498 75402"
                         ]


### PR DESCRIPTION
This PR adds ":" to the `international_phone_numbers` FAQ entry.

See https://github.com/corona-warn-app/cwa-website/pull/2368#issuecomment-1019248073.