### PR TITLE
Fix responsive mobile breakpoint graphs in Analysis

### DIFF
--- a/src/assets/js/analyse/fullscreen.js
+++ b/src/assets/js/analyse/fullscreen.js
@@ -13,6 +13,18 @@ $(document).on("click",".analyseBoard-fullscreen", function(e){
 	if (screenfull.isEnabled) screenfull.toggle($e.first());
 });
 
-
+$(window).on("resize", function () {
+	const $e = document.querySelector(".analyseBoard.fullscreen");
+	if($e) {
+		const padding = $($e).css('padding-top').replace("px","").split(" ");
+		let tPadding = 0;
+		padding.forEach(element => {
+			tPadding += parseInt(element);
+		});
+		const spacing = $(".analyseBoard-head").height() + $(".analyseBoard-total").height() + $(".analyseChartLegend").height() + tPadding + 48;
+		const height = window.innerHeight - spacing;
+		ApexCharts.exec($(".analyseBoard-fullscreen").data("id"), "updateOptions", { chart: { height } }, true, false, false);
+	}
+});
 
 export default null;


### PR DESCRIPTION
In this PR I have solved the [problem commented](https://github.com/corona-warn-app/cwa-website/pull/2360#issuecomment-1017420086) in my last PR (#2360) related to Analysis.

Now, when we resize the screen using the mobile breakpoint, the graph height will adapt to the window.

