### PR TITLE
2022Create Fehler 3 Coronwarnapp

### DIFF
--- a/Fehler 3 Coronwarnapp
+++ b/Fehler 3 Coronwarnapp
@@ -1,0 +1,13 @@
+HALLO, 
+seit ca 10 Tagen immer die Meldung, dass ich die Corona-warn-app nachsehen soll.
+Dann beim öffnen immer Fehler 3 in Corona Warnapp und letzte Aktualisierung
+war laut App am 13.01 2022 Meine Version 2.16.2,
+ Kein Status abfragbar. 
+Wie kann ich den Fehler beheben?
+Habe ich die neuste Version auf meinem Android Handy?
+Kann ich manuell die Version updaten?
+Schon Mal danke für die Hilfe
+Lila
+
+
+


### PR DESCRIPTION
HALLO, 
seit ca 10 Tagen immer die Meldung, dass ich die Corona-warn-app nachsehen soll.
Dann beim öffnen immer Fehler 3 in Corona Warnapp und letzte Aktualisierung
war laut App am 13.01 2022 Meine Version 2.16.2,
 Kein Status abfragbar. 
Wie kann ich den Fehler beheben?
Habe ich die neuste Version auf meinem Android Handy?
Kann ich manuell die Version updaten?
Schon Mal danke für die Hilfe
Lila