### PR TITLE
Fix broken links to 2.13 blog

### DIFF
--- a/blog/2022-02-02-cwa-2-17/index.md
+++ b/blog/2022-02-02-cwa-2-17/index.md
@@ -23,7 +23,7 @@ As of version 2.17, users can see the number of people in Germany who have recei
 
 ### Recycle bin shows exact date of deletion
 
-In addition, users can now see the deletion date for each item in their recycle bin. As of [CWA version 2.13](en/blog/2021-11-03-cwa-version-2-13/), all certificates and tests that have been deleted are initially moved to the recycle bin for 30 days. Users can now see when the 30 days will expire, i.e., **when the respective certificate will be permanently deleted**. 
+In addition, users can now see the deletion date for each item in their recycle bin. As of [CWA version 2.13](/en/blog/2021-11-03-cwa-version-2-13/), all certificates and tests that have been deleted are initially moved to the recycle bin for 30 days. Users can now see when the 30 days will expire, i.e., **when the respective certificate will be permanently deleted**. 
 
 <br></br>
 <center> 

--- a/blog/2022-02-02-cwa-2-17/index_de.md
+++ b/blog/2022-02-02-cwa-2-17/index_de.md
@@ -23,7 +23,7 @@ Ab Version 2.17 können Nutzer\*innen neben den Statistiken für geimpfte Person
 
 ### Papierkorb zeigt Löschdatum an
 
-Außerdem können Nutzer\*innen nun für jedes Element in ihrem Papierkorb das **Löschdatum** sehen. Seit [Version 2.13 der CWA](de/blog/2021-11-03-cwa-version-2-13/) werden alle Zertifikate und Tests, die gelöscht wurden, zunächst für 30 Tage in den Papierkorb verschoben. Dort sehen Nutzer\*innen nun, wann die 30 Tage abgelaufen sind und das jeweilige Zertifikat endgültig gelöscht wird. 
+Außerdem können Nutzer\*innen nun für jedes Element in ihrem Papierkorb das **Löschdatum** sehen. Seit [Version 2.13 der CWA](/de/blog/2021-11-03-cwa-version-2-13/) werden alle Zertifikate und Tests, die gelöscht wurden, zunächst für 30 Tage in den Papierkorb verschoben. Dort sehen Nutzer\*innen nun, wann die 30 Tage abgelaufen sind und das jeweilige Zertifikat endgültig gelöscht wird. 
 
 <br></br>
 <center> 


### PR DESCRIPTION
This PR fixes broken links in
- https://www.coronawarn.app/en/blog/2022-02-02-cwa-2-17/ "Booster vaccination statistics, date of deletion in recycle bin, and link to social media channels"
- https://www.coronawarn.app/de/blog/2022-02-02-cwa-2-17/ "Statistik zur Auffrischimpfung, Link zu Social-Media-Kanälen und Löschdatum im Papierkorb"

to the blog posts
- https://www.coronawarn.app/en/blog/2021-11-03-cwa-version-2-13/ and
- https://www.coronawarn.app/de/blog/2021-11-03-cwa-version-2-13/

respectively.

With this fix, the pages no longer produce a 404 error. The Cypress test suite also succeeds once again.