### PR TITLE
Make "encounter_deletition" general for low and increased risk encounters

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1909,11 +1909,11 @@
                         ]
                     },
                     {
-                        "title": "I received the message that I had a low risk encounter. The next day it was gone again. Shouldn't this be deleted after 14 days?",
+                        "title": "I received the message that I had a risk encounter. The next day it was gone again. Shouldn't this be deleted after 14 days?",
                         "anchor": "encounter_deletion",
                         "active": false,
                         "textblock": [
-                            "As soon as the app downloads the current diagnosis keys (positive IDs) from the server, a check of the contact log is performed. For each of the last 14 days for which diagnosis keys are available, a separate contact log check is performed. This means that the app compares the encounters of the last 14 days with the positive IDs to check whether there has been a contact with a person who tested positive. If the message about a low-risk encounter disappears after one day, this means that the corresponding encounter was more than 14 days ago in this case."
+                            "As soon as the app downloads the current diagnosis keys (positive IDs) from the server, a check of the contact log is performed. For each of the last 14 days for which diagnosis keys are available, a separate contact log check is performed. This means that the app compares the encounters of the last 14 days with the positive IDs to check whether there has been a contact with a person who tested positive. If the message about a risk encounter disappears after one day, this means that the corresponding encounter was more than 14 days ago in this case."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1916,11 +1916,11 @@
                         ]
                     },
                     {
-                        "title": "Ich habe die Meldung bekommen, dass ich eine niedrige Risiko-Begegnung hatte. Am nächsten Tag war sie wieder weg. Sollte das nicht erst nach 14 Tagen gelöscht werden?",
+                        "title": "Ich habe die Meldung bekommen, dass ich eine Risiko-Begegnung hatte. Am nächsten Tag war sie wieder weg. Sollte das nicht erst nach 14 Tagen gelöscht werden?",
                         "anchor": "encounter_deletion",
                         "active": false,
                         "textblock": [
-                            "Sobald die App die aktuellen Diagnoseschlüssel (Positivkennungen) vom Server lädt, wird eine Überprüfung des Kontaktprotokolls durchgeführt. Dabei wird für jeden der letzten 14 Tage, für den Diagnoseschlüssel vorhanden sind, eine separate Überprüfung des Kontaktprotokolls durchgeführt. Das bedeutet also, die App gleicht die Begegnungen der letzten 14 Tage mit den Positivkennungen ab, um zu überprüfen, ob es zu einem Kontakt mit einer positiv getesteten Person gekommen ist. Ist die Meldung über eine Begegnung mit niedrigem Risiko nach einem Tag verschwunden, bedeutet das, dass die entsprechende Begegnung in diesem Fall länger als 14 Tage zurückliegt."
+                            "Sobald die App die aktuellen Diagnoseschlüssel (Positivkennungen) vom Server lädt, wird eine Überprüfung des Kontaktprotokolls durchgeführt. Dabei wird für jeden der letzten 14 Tage, für den Diagnoseschlüssel vorhanden sind, eine separate Überprüfung des Kontaktprotokolls durchgeführt. Das bedeutet also, die App gleicht die Begegnungen der letzten 14 Tage mit den Positivkennungen ab, um zu überprüfen, ob es zu einem Kontakt mit einer positiv getesteten Person gekommen ist. Ist die Meldung über eine Risiko-Begegnung nach einem Tag verschwunden, bedeutet das, dass die entsprechende Begegnung in diesem Fall länger als 14 Tage zurückliegt."
                         ]
                     },
                     {


### PR DESCRIPTION
This PR updates the text of the FAQ entry `encounter_deletion`. It makes the text general, so that the FAQ is not specific to low risk encounters anymore.

<details>
<summary>Preview of the change</summary>

| German | English | 
|---|---|
|![DE](https://user-images.githubusercontent.com/67682506/151957181-8aeee869-5072-498e-afb8-4b51b76b20fb.png)| ![EN](https://user-images.githubusercontent.com/67682506/151957187-4571f8d8-dcbd-432f-9093-7d1deeb3e3f4.png)|



</details>