### PR TITLE
Bump current iOS version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -432,7 +432,7 @@ function createFaqRedirects() {
 function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html"])
-    .pipe(replace('[ios.latest-os-version]', '15.3'))
+    .pipe(replace('[ios.latest-os-version]', '15.3.1'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.17.1'))
     .pipe(replace('[android.latest-os-version]', '12'))


### PR DESCRIPTION
This PR bumps the current iOS version from 15.3 to 15.3.1.

--- 

Apple release: https://developer.apple.com/news/releases/?id=02102022c