### PR TITLE
Added alt text to external image

### DIFF
--- a/src/data/analyse_de.json
+++ b/src/data/analyse_de.json
@@ -286,32 +286,38 @@
     	{
     		"title": "RKI: COVID-19-Dashboard (DE)",
             "desc": "Tagesaktuelle Informationen zum Infektionsgeschehen in Deutschland nach Landkreisen und Bundesländern.",
-    		"link": "https://experience.arcgis.com/experience/478220a4c454480e823b17327b2bf1d4"
+    		"link": "https://experience.arcgis.com/experience/478220a4c454480e823b17327b2bf1d4",
+            "alt": "externer Link"
     	},
     	{
     		"title": "RKI: Covid-19-Trends (DE)",
             "desc": "Trend-Übersicht zur Entwicklung des Infektionsgeschehens in Deutschland.",
-    		"link": "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Situationsberichte/COVID-19-Trends/COVID-19-Trends.html?__blob=publicationFile#/home"
+    		"link": "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Situationsberichte/COVID-19-Trends/COVID-19-Trends.html?__blob=publicationFile#/home",
+            "alt": "externer Link"
     	},
     	{
     		"title": "BMG: Impfdashboard (DE)",
             "desc": "Arbeitstägliche Informationen über den Impfstatus und Impffortschritt in Deutschland von der Website ‘Zusammen gegen Corona‘ des Bundesministeriums für Gesundheit (BMG).",
-    		"link": "https://impfdashboard.de/"
+    		"link": "https://impfdashboard.de/",
+            "alt": "externer Link"
     	},
     	{
     		"title": "WHO: COVID-19-Dashboard (EN)",
             "desc": "Tagesaktuelle Informationen zum weltweiten Infektionsgeschehen von der World Health Organisation (WHO).",
-    		"link": "https://covid19.who.int/"
+    		"link": "https://covid19.who.int/",
+            "alt": "externer Link"
     	},
     	{
     		"title": "CSSE (JHU): COVID-19-Dashboard (EN)",
             "desc": "Tagesaktuelle Informationen zum weltweiten Infektionsgeschehen vom Center for Systems Science and Engineering (CSSE) der Johns Hopkins University (JHU) Baltimore (Maryland, USA).",
-    		"link": "https://gisanddata.maps.arcgis.com/apps/dashboards/bda7594740fd40299423467b48e9ecf6"
+    		"link": "https://gisanddata.maps.arcgis.com/apps/dashboards/bda7594740fd40299423467b48e9ecf6",
+            "alt": "externer Link"
     	},
         {
     		"title": "OWID: COVID-19 (EN)",
             "desc": "Tagesaktuelle Informationen zum weltweiten Infektionsgeschehen in der Online-Publikation Our World in Data (OWID).",
-    		"link": "https://ourworldindata.org/coronavirus"
+    		"link": "https://ourworldindata.org/coronavirus",
+            "alt": "externer Link"
     	}
     ]
 }

--- a/src/data/analyse_en.json
+++ b/src/data/analyse_en.json
@@ -286,32 +286,38 @@
     	{
     		"title": "RKI: COVID-19 Dashboard (GER)",
             "desc": "Daily updated information on the incidence of infections in Germany by county and federal state.",
-    		"link": "https://experience.arcgis.com/experience/478220a4c454480e823b17327b2bf1d4"
+    		"link": "https://experience.arcgis.com/experience/478220a4c454480e823b17327b2bf1d4",
+            "alt": "external link"
     	},
     	{
     		"title": "RKI: Covid-19 Trends (GER)",
             "desc": "Overview of the trends of the epidemic situation in Germany.",
-    		"link": "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Situationsberichte/COVID-19-Trends/COVID-19-Trends.html?__blob=publicationFile#/home"
+    		"link": "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Situationsberichte/COVID-19-Trends/COVID-19-Trends.html?__blob=publicationFile#/home",
+            "alt": "external link"
     	},
     	{
     		"title": "BMG: Impfdashboard (EN)",
             "desc": "Daily updated information on vaccination status and progress in Germany, from the website 'together against corona' from the German Federal Ministry of Health (BMG).",
-    		"link": "https://impfdashboard.de/en/"
+    		"link": "https://impfdashboard.de/en/",
+            "alt": "external link"
     	},
     	{
     		"title": "WHO: COVID-19 Dashboard (EN)",
             "desc": "Daily updated information on the worldwide pandemic situation, from the World Health Organisation (WHO).",
-    		"link": "https://covid19.who.int/"
+    		"link": "https://covid19.who.int/",
+            "alt": "external link"
     	},
     	{
     		"title": "CSSE (JHU): COVID-19 Dashboard (EN)",
             "desc": "Daily updated information on the worldwide pandemic situation, from the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University (JHU) Baltimore (Maryland, USA).",
-    		"link": "https://gisanddata.maps.arcgis.com/apps/dashboards/bda7594740fd40299423467b48e9ecf6"
+    		"link": "https://gisanddata.maps.arcgis.com/apps/dashboards/bda7594740fd40299423467b48e9ecf6",
+            "alt": "external link"
     	},
         {
     		"title": "OWID: COVID-19 (EN)",
             "desc": "Daily updated information on the worldwide incidence of infections from the online publication Our World in Data (OWID).",
-    		"link": "https://ourworldindata.org/coronavirus"
+    		"link": "https://ourworldindata.org/coronavirus",
+            "alt": "external link"
     	}
     ]
 }

--- a/src/partials/page-analyse.html
+++ b/src/partials/page-analyse.html
@@ -260,7 +260,7 @@
 		
 		<div class="analyseMore">
 			{{#each page-contents.moreLinks}}
-				<a href="{{link}}" title="{{desc}}" target="_blank">{{title}}<img src="{{../root}}assets/img/icons/external.svg"></a>
+				<a href="{{link}}" title="{{desc}}" target="_blank">{{title}}<img src="{{../root}}assets/img/icons/external.svg" alt="{{alt}}"></a>
 			{{/each}}
 		</div>
 	{{/if}}


### PR DESCRIPTION
### Added an alt text for external images, so they are clearly identifiable

**Example:**
![externalalt](https://user-images.githubusercontent.com/84206644/154453329-f5d62cf2-b00a-416c-b27d-80bf8a9a52c9.PNG)

