### PR TITLE
Add more details to "recovered" FAQ entry (Addresses #2492)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1797,7 +1797,8 @@
                         "anchor": "recovered",
                         "active": false,
                         "textblock": [
-                            "Since version 1.13, you have the option to reactivate the app after recovering from a SARS-CoV-2 infection and to restart the risk assessment after sharing your own random IDs. This means that you can now decide if and when to turn risk assessment back on once having shared your encrypted random IDs after a positive test result, thus warning others. Previously, this was only possible via a reset of the app."
+                            "Since version 1.13, you have the option to reactivate the app after recovering from a SARS-CoV-2 infection and to restart the risk assessment after sharing your own random IDs. This means that you can now decide if and when to turn risk assessment back on once having shared your encrypted random IDs after a positive test result, thus warning others. Previously, this was only possible via a reset of the app.",
+                            "In order for the app to show you the 'Risk of Infection' tile again, you need to <b>delete the positive test result from the app</b>. To do this, please tap on the tile that shows the positive test result and tap 'Delete Test' there. After these steps, the test result will be moved to the recycle bin for 30 days and the 'Risk of Infection' tile will be displayed again."
                         ]
                     },
                     {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1804,7 +1804,8 @@
                         "anchor": "recovered",
                         "active": false,
                         "textblock": [
-                            "Seit der Version 1.13 haben Sie die Möglichkeit nach einer überstanden SARS-CoV-2 Infektion, die App wieder zu aktivieren und die Fortführung der Risiko-Ermittlung nach Teilung der eigenen Zufalls-IDs erneut zu starten. Dies bedeutet, dass Sie nun entscheiden können, ob und wann Sie die Risiko-Ermittlung wieder einschalten, nachdem Sie Ihre verschlüsselten Zufalls-IDs nach einem Positivtest geteilt und andere damit gewarnt haben. Bisher war dies nur über ein Reset der App möglich."
+                            "Seit der Version 1.13 haben Sie die Möglichkeit nach einer überstanden SARS-CoV-2 Infektion, die App wieder zu aktivieren und die Fortführung der Risiko-Ermittlung nach Teilung der eigenen Zufalls-IDs erneut zu starten. Dies bedeutet, dass Sie nun entscheiden können, ob und wann Sie die Risiko-Ermittlung wieder einschalten, nachdem Sie Ihre verschlüsselten Zufalls-IDs nach einem Positivtest geteilt und andere damit gewarnt haben. Bisher war dies nur über ein Reset der App möglich.",
+                            "Damit die App Ihnen die 'Infektionsrisiko'-Kachel wieder anzeigt, müssen Sie das <b>positive Testergebnis aus der App löschen</b>. Um dies zu tun tippen Sie bitte auf die Kachel, die das positve Testergebnis anzeigt und tippen dort auf 'Test löschen'. Anschließend wird das Testergebnis für 30 Tage in den Papierkorb verschoben und die 'Infektionsrisiko'-Kachel wird wieder angezeigt."
                         ]
                     },
                     {


### PR DESCRIPTION
## Description

This PR adds more details to the "recovered" FAQ entry.

## What was changed?

I added more information to the FAQ entry https://www.coronawarn.app/de/faq/#recovered / https://www.coronawarn.app/en/faq/#recovered. The text added states that it is necessary to remove the test in order to see the "Risk of Infection" tile again.

## Screenshots

| English | German |
|---|---|
| <img width="1035" alt="English" src="https://user-images.githubusercontent.com/67682506/155974080-b4e69a44-e187-4247-ae1a-1c82501297b0.png"> | <img width="1035" alt="German" src="https://user-images.githubusercontent.com/67682506/155974089-86c2fba7-19cc-41a5-bd22-16eb3354ca74.png"> |


**Closes #2492**
