### PR TITLE
Change FAQ root detection wording

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1457,7 +1457,7 @@
                         "textblock": [
                             "This notification is a security alert: The Corona-Warn-App has found signs of administrator permissions on your device. Such permissions are also known as root permissions.",
                             "You are receiving this security notice to be made aware that these permissions may increase the risk that other applications on your smartphone could access data from the Corona-Warn-App.",
-                            "You will receive this notice whenever you restart, reinstall or update the app. These warnings can be stopped from release 2.16 until the next update of the app.",
+                            "You will receive this notice whenever you restart, reinstall or update the app. These warnings can be stopped in version 2.16 and later until the next update of the app.",
                             "We point out the possible risk that a Corona-Warn-App user could obtain a device with administrator privileges (rooted), through a third party. In such a case, the user might not be aware of using a modified device with administrator privileges. This user would only receive a security notice when the app is next updated.",
                             "See also <a href='#rooted_devices' target='_blank' >[Google/Android]: Can I also use the app on a rooted device?</a>"
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1463,7 +1463,7 @@
                         "textblock": [
                             "Es handelt sich bei dieser Benachrichtigung um einen Sicherheitshinweis: Die Corona-Warn-App hat auf Ihrem Gerät Anzeichen für Administrator-Berechtigungen gefunden. Solche Berechtigungen sind auch als Root-Berechtigungen bekannt.",
                             "Sie erhalten diesen Sicherheitshinweis, um darauf aufmerksam gemacht zu werden, dass durch diese Berechtigungen ein erhöhtes Risiko besteht, dass andere Anwendungen auf Ihrem Smartphone auf Daten der Corona-Warn-App zugreifen könnten.",
-                            "Sie werden diesen Hinweis immer dann erhalten, wenn Sie die App neu starten, neu installieren oder updaten. Diese Warnungen können ab dem Release 2.16 bis zum nächsten Update der App unterdrückt werden.",
+                            "Sie werden diesen Hinweis immer dann erhalten, wenn Sie die App neu starten, neu installieren oder updaten. Diese Warnungen können ab Version 2.16 bis zum nächsten Update der App unterdrückt werden.",
                             "Wir weisen auf das mögliche Risiko hin, dass ein Corona-Warn-App Nutzer ein Gerät mit Administrator-Berechtigung (gerooted), durch einen Dritten erhalten könnte. In so einem Fall würde der Nutzer sich möglicherweise nicht bewusst sein, ein modifiziertes Gerät mit Administrator-Berechtigungen zu benutzen. Dieser Nutzer würde erst beim nächsten Update der App einen Sicherheitshinweis erhalten.",
                             "Siehe auch <a href='#rooted_devices' target='_blank' >[Google/Android]: Kann ich die App auch auf einem gerooteten Gerät nutzen?</a>"
                         ]


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2547 "FAQ root detection android version wording" by correcting the FAQ text as follows:

---
Change the sentence in https://www.coronawarn.app/en/faq/#root_detection_android "[Google/Android]: Why do I receive a notification regarding administrator permissions (root permissions)?" to:

"These warnings can be stopped in version 2.16 and later until the next update of the app."

---
Change the sentence in https://www.coronawarn.app/de/faq/#root_detection_android "[Google/Android]: Warum erhalte ich eine Benachrichtigung bezüglich Administrator-Berechtigungen (Root-Berechtigungen)?" to:

"Diese Warnungen können ab Version 2.16 bis zum nächsten Update der App unterdrückt werden.
