### PR TITLE
Correct grammar for DE accessibility statement

### DIFF
--- a/src/data/accessibility_de.json
+++ b/src/data/accessibility_de.json
@@ -1,18 +1,18 @@
 {
     "meta": {
-        "title": "Barrierefreiheitserklärung des Robert Koch-Instituts und Bundesministerium für Gesundheit",
+        "title": "Barrierefreiheitserklärung des Robert Koch-Instituts und des Bundesministeriums für Gesundheit",
         "description": ""
     },
-    "title": "Barrierefreiheitserklärung des Robert Koch-Instituts und Bundesministerium für Gesundheit",
+    "title": "Barrierefreiheitserklärung des Robert Koch-Instituts und des Bundesministeriums für Gesundheit",
     "section-android-main": {
         "textblock": [
-            "Diese Erklärung zur Barrierefreiheit gilt für Version 2.17 der <b>Corona-Warn-App (Android)</b> des Robert Koch-Instituts und Bundesministerium für Gesundheit.",
+            "Diese Erklärung zur Barrierefreiheit gilt für Version 2.17 der <b>Corona-Warn-App (Android)</b> des Robert Koch-Instituts und des Bundesministeriums für Gesundheit.",
             "Als öffentliche Stelle im Sinne der Richtlinie (EU) 2016/2102 sind wir bemüht, unsere Websites und mobilen Anwendungen im Einklang mit den Bestimmungen des Behindertengleichstellungsgesetzes des Bundes (BGG) sowie der Barrierefreien-Informationstechnik-Verordnung (BITV 2.0) zur Umsetzung der Richtlinie (EU) 2016/2102 barrierefrei zugänglich zu machen."
         ]
     },
     "section-ios-main": {
         "textblock": [
-            "Diese Erklärung zur Barrierefreiheit gilt für Version 2.17 der <b>Corona-Warn-App (iOS)</b> des Robert Koch-Instituts und Bundesministerium für Gesundheit.",
+            "Diese Erklärung zur Barrierefreiheit gilt für Version 2.17 der <b>Corona-Warn-App (iOS)</b> des Robert Koch-Instituts und des Bundesministeriums für Gesundheit.",
             "Als öffentliche Stelle im Sinne der Richtlinie (EU) 2016/2102 sind wir bemüht, unsere Websites und mobilen Anwendungen im Einklang mit den Bestimmungen des Behindertengleichstellungsgesetzes des Bundes (BGG) sowie der Barrierefreien-Informationstechnik-Verordnung (BITV 2.0) zur Umsetzung der Richtlinie (EU) 2016/2102 barrierefrei zugänglich zu machen."
         ]
     },


### PR DESCRIPTION
This PR changes the "Bundesministerium" into genitive case in marked up in green in the following screenshot:

![image](https://user-images.githubusercontent.com/66998419/158984951-54b393e4-53fc-4caa-8f97-1f456945ad15.png)

This affects:
- https://www.coronawarn.app/de/accessibility/
- https://www.coronawarn.app/de/accessibility/#android
- https://www.coronawarn.app/de/accessibility/#ios
 