### PR TITLE
Bump current iOS app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -434,7 +434,7 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html"])
     .pipe(replace('[ios.latest-os-version]', '15.4'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.19.0'))
+    .pipe(replace('[ios.current-app-version]', '2.19.1'))
     .pipe(replace('[android.latest-os-version]', '12'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '2.19.2'))


### PR DESCRIPTION
This PR bumps the current iOS app version from 2.19.0 to 2.19.1

---

GitHub release: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v2.19.1