### PR TITLE
Reapply checklinks exception for wiley.com

### DIFF
--- a/cypress/integration/check_links.js
+++ b/cypress/integration/check_links.js
@@ -33,7 +33,8 @@ context("Check for broken links", () => {
                   '/en/sign-language/'
                 ]
     const allowlist = [
-      'https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999'
+      'https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999',
+      'https://onlinelibrary.wiley.com/doi/abs/10.2307/3315826.n1'
     ]
 
   it('Check if txt results exist',() => {
@@ -69,7 +70,8 @@ context("Check for broken links on entries", () => {
   const subpages = ['/de/blog/','/en/blog/','/de/science/', '/en/science/']
   const pagesToAvoid = ['/de/blog/', '/en/blog/', '/de/science/', '/en/science/', '/de/blog/archiv', '/en/blog/archive']
   const allowlist = [
-    'https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999'
+    'https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999',
+    'https://onlinelibrary.wiley.com/doi/abs/10.2307/3315826.n1'
   ]
   subpages.forEach(sub => {
     it(`"${sub}" entries - Check for broken links`, () => {


### PR DESCRIPTION
- This PR resolves the regression in PR https://github.com/corona-warn-app/cwa-website/pull/2434 which reverted the fix from PR #2554.
- The re-opened issue https://github.com/corona-warn-app/cwa-website/issues/2490 is resolved by this PR.

After applying this PR the Cypress test `check_links.js` no longer fails with

```
[RESPONSE 503] https://onlinelibrary.wiley.com/doi/abs/10.2307/3315826.n1 on 'http://localhost:8000/de/blog/2021-08-05-statistictiles' 
[RESPONSE 503] https://onlinelibrary.wiley.com/doi/abs/10.2307/3315826.n1 on 'http://localhost:8000/en/blog/2021-08-05-statistictiles'
```

in `broken_links_result.txt`. Instead all tests pass.

## Verification

```
npm run test:prepare
npm run test:open
```
select `check_links.js` in Cypress console

Ensure that all tests pass and that there are no failures i.e. -- next to red X.

![image](https://user-images.githubusercontent.com/66998419/160098327-d0d2df91-1d79-4eaf-bb1c-94d2b032efb0.png)
