### PR TITLE
Personal Data FAQ Update

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2534,9 +2534,8 @@
                                 "anchor": "personal_data",
                                 "active": false,
                                 "textblock": [
-                                    "As mandated by the General Data Protection Regulation (GDPR), data minimization is a paramount principle in the implementation of the app. The only inputs that users can and have to provide to the app are:",
-                                    "<ul><li>Permissions for using the Exposure Notification System</li><li>TANs for test result verification</li><li>Consent to upload daily diagnosis keys</li></ul>",
-                                    "Location data is not and cannot be collected by apps using the Exposure Notification System. Diagnosis keys are only stored centrally for the epidemiologically relevant period of 14 days and removed automatically after that period."
+                                    "As mandated by the General Data Protection Regulation (GDPR), data minimization is a paramount principle in the implementation of the app.",
+                                    "Please refer to the <a href='/assets/documents/cwa-privacy-notice-en.pdf' target='_blank'>Privacy Notice</a> for details on what data is stored and why."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2543,9 +2543,8 @@
                                 "anchor": "personal_data",
                                 "active": false,
                                 "textblock": [
-                                    "Wie in der Datenschutz-Grundverordnung (DSGVO) vorgeschrieben, ist die Datenminimierung das oberste Gebot für die Umsetzung der App. Die nutzenden Personen können und müssen in Verbindung mit der App ausschließlich die folgenden Angaben machen:",
-                                    "<ul><li>Zustimmung zur Nutzung des Exposure Notification Systems</li><li>Eingabe von TANs zur Verifizierung von Testergebnissen</li><li>Zustimmung zum Upload der täglichen Diagnoseschlüssel ('Positivkennungen')</li></ul>",
-                                    "Apps können über das Exposure Notification System keine Daten zum Standort sammeln. Die Positivkennungen werden nur für den epidemiologisch relevanten Zeitraum von 14 Tagen zentral gespeichert und nach den 14 Tagen automatisch entfernt."
+                                    "Wie in der Datenschutz-Grundverordnung (DSGVO) vorgeschrieben, ist die Datenminimierung das oberste Gebot für die Umsetzung der App.",
+                                    "Einzelheiten darüber, welche Daten gespeichert werden und warum, entnehmen Sie bitte der <a href='/assets/documents/cwa-privacy-notice-de.pdf' target='_blank'>Datenschutzerklärung</a>."
                                 ]
                             },
                             {


### PR DESCRIPTION
Replaced the outdated list of data in the personal_data FAQ section with a link to the privacy policy in accordance with the details from #1729 .

Affected Sections:
DE: https://www.coronawarn.app/de/faq/#personal_data

**Before**
![image](https://user-images.githubusercontent.com/72961430/160249641-e06b9d4a-7802-441a-bf6e-7da96ce859f6.png)

**After**
![image](https://user-images.githubusercontent.com/72961430/160249607-f2788e81-92af-4bf3-a878-1577bcbc4f20.png)


EN: https://www.coronawarn.app/en/faq/#personal_data

**Before**
![image](https://user-images.githubusercontent.com/72961430/160249681-8328dd65-a825-4ad4-99a4-0603f3b96577.png)

**After**
![image](https://user-images.githubusercontent.com/72961430/160249704-f1bf7d8d-4621-4223-a8ec-8871c39cfe35.png)

---
Internal Tracking ID: [EXPOSUREAPP-12410](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12410)
