### PR TITLE
Correct links to "Explanatory video"

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1161,7 +1161,7 @@
                                     "<h3>Explanatory video</h3>",
                                     "<hr>",
                                     "In the following explanatory video you can find out how the contact tracing of the Corona-Warn-App works and what it can do.",
-                                    "<video src='../../assets/video/erklaerfilm_en.mp4' class='w-100' controls='' alt='Corona-Warn-App - explanatory film'></video>"
+                                    "<video src='/assets/video/erklaerfilm_en.mp4' class='w-100' controls='' alt='Corona-Warn-App - explanatory film'></video>"
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1159,7 +1159,7 @@
                             "<h3>Erklärvideo</h3>",
                             "<hr>",
                             "Im folgenden Erklärvideo erfahren Sie wie die Kontaktverfolgung der Corona-Warn-App funktioniert und was sie kann.",
-                            "<video src='../../assets/video/erklaerfilm_de.mp4' class='w-100' controls='' alt='Corona-Warn-App - Erklärvideo'></video>"
+                            "<video src='/assets/video/erklaerfilm_de.mp4' class='w-100' controls='' alt='Corona-Warn-App - Erklärvideo'></video>"
                                 ]
                             },
                             {


### PR DESCRIPTION
This PR corrects issue https://github.com/corona-warn-app/cwa-website/issues/2588 "Bad link to explanatory video".

The non-working video link
`<video src='../../assets/video/erklaerfilm_en.mp4'`
is replaced by
`<video src='/assets/video/erklaerfilm_en.mp4'` (EN)

Correspondingly for the German-language link

## Verification

### EN

1. Open https://www.coronawarn.app/en/faq/results/#in_a_nutshell in web browser
2. Scroll down to "Explanatory video"
3. Confirm that video shows the CWA logo and can be played

### DE

1. Open https://www.coronawarn.app/de/faq/results/#in_a_nutshell in web browser
2. Scroll down to "Erklärvideo"
3. Confirm that video shows the CWA logo and can be played