### PR TITLE
Fix format topic selector's option in FAQ page

### DIFF
--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -9,7 +9,7 @@
           <select class="form-select mr-3 w-25" id="faq-topic" name="topic">
             <option value="all" selected>{{page-contents.section-main.texts.all-topics}}</option>
             {{#each page-contents.section-main.topics}}
-              <option value="{{id}}">{{title}}</option>
+              <option value="{{id}}">{{{title}}}</option>
             {{/each}}
             <option value="glossary">{{page-contents.section-main.texts.glossary}}</option>
           </select>


### PR DESCRIPTION
This PR is to solve a format issue about topic selector in FAQ homepage.

**Before**
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/44208107/160368567-a9c432a5-cfd5-4878-9370-17ec5f9dea72.png)

**After**
![Screenshot 2022-03-28 at 11 26 38](https://user-images.githubusercontent.com/44208107/160368997-8a7db196-3234-49f2-a932-450f092233d4.png)


