### PR TITLE
Bump current iOS & Android app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -491,10 +491,10 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html", PATHS.dist + "/**/*.json"])
     .pipe(replace('[ios.latest-os-version]', '15.4'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.20.2'))
+    .pipe(replace('[ios.current-app-version]', '2.20.3'))
     .pipe(replace('[android.latest-os-version]', '12'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.20.1'))
+    .pipe(replace('[android.current-app-version]', '2.20.3'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
This commit PR the current iOS & Android app version to 2.20.3.

---

GitHub releases:
- iOS: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v2.20.3
- Android: https://github.com/corona-warn-app/cwa-app-android/releases/tag/v2.20.3