### PR TITLE
Bump current iOS version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -489,7 +489,7 @@ function createFaqRedirects() {
 function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html", PATHS.dist + "/**/*.json"])
-    .pipe(replace('[ios.latest-os-version]', '15.4'))
+    .pipe(replace('[ios.latest-os-version]', '15.4.1'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.20.2'))
     .pipe(replace('[android.latest-os-version]', '12'))


### PR DESCRIPTION
This PR bumps the current iOS version from 15.4 to 15.4.1.

---

Apple release: https://developer.apple.com/news/releases/?id=03312022d