### PR TITLE
use current topic in on-click event listener for section headers

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -618,7 +618,8 @@ $(document).ready(function(){
                         handleResultFoundTextVisibility(glossaryList)
                     } else {
                         $("#faq-container").removeClass('d-none');
-                        updateResults(search, topic, faq);
+                        let currentTopic = $(this).attr("class").split(/\s+/)[1];
+                        updateResults(search, currentTopic, faq);
                         $("#glossary_container").addClass('d-none');
                         $(".bread-section").addClass('d-none');
                         $("#bread_separator").addClass('d-none');


### PR DESCRIPTION
Fix for Issue #2652

The on-click listener of the section headers use the URL parameter **topic** for updating the results, but if you click on a section-header the URL parameter doesn't changes to the clicked topic. So if somebody search in **All** topics and then click on a section header the result counter is calculated wrong.

So i pass the clicked topic the the **updateResult()** funtion.