### PR TITLE
Update check_anchor_links.js for new FAQ

### DIFF
--- a/cypress/integration/check_anchor_links.js
+++ b/cypress/integration/check_anchor_links.js
@@ -26,7 +26,9 @@ context("Check for broken anchor links", () => {
                   '/de/screenshots/',
                   '/en/screenshots/',
                   '/de/faq/',
+                  '/de/faq/results/',
                   '/en/faq/',
+                  '/en/faq/results/',
                   '/de/rat-partner/',
                   '/en/rat-partner/',
                   '/de/privacy/',
@@ -51,7 +53,7 @@ context("Check for broken anchor links", () => {
     it(`"${page}" - Check for broken anchor links`, () => {
       cy.visit({log: false, url: page} )
       cy.get("a[href*='#']").each(url => {
-        if (url.prop('href') && url.prop('href').includes("localhost") && url.prop('href').split("#")[1] !== "top") {    
+        if (url.prop('href') && url.prop('href').includes("localhost") && url.prop('href').split("#")[1] !== "top" && url.prop('href').split("#")[1] !== "") {    
           if(url.prop('href').split(":8000") !== page) cy.visit({log: false, url: url.prop('href')} )
           cy.get("body").then($body => {
             if ($body.find(`#${url.prop('href').split("#")[1]}`).length > 0) {   


### PR DESCRIPTION
Updated check_anchor_links.js to allow for testing of "/en/faq/results/" and "/de/faq/results/".
See https://github.com/corona-warn-app/cwa-website/issues/2613#issuecomment-1085418447

![image](https://user-images.githubusercontent.com/72961430/161205428-dc06977e-b7c1-4d06-a816-0c2f25944f23.png)
