### PR TITLE
/faq/results broken links updates

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2406,7 +2406,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Yes. As long as you have activated exposure logging in the app and Bluetooth (and Location Services on Android) is on, encounters are logged in the background by the Exposure Notification system integrated in iOS/Android. The app itself doesn't have to be open for this. You can minimize it or use 'swipe-to-quit' to close it.",
-                                    "To be on the safe side, open the app once a day.",
+                                    "To be on the safe side, open the app once a day. You'll find more info at <a href='../../#howto' target='_blank' >This is how the app works best</a>.",
                                     "For the risk status to be updated automatically, make sure that background updates are active. For all the info, see these FAQ:",
                                     "<ul><li><a href='#no_risk_update_ios' target='_blank' rel='noopener'>[Apple/iOS]: My risk status hasn't been updated for over a day. An internet connection was available, what's wrong?</a></li><li><a href='#no_risk_update' target='_blank' rel='noopener'>[Google/Android]: My risk status hasn't been updated for over a day. An internet connection was available, what's wrong?</a></li></ul>"
                                 ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -566,8 +566,7 @@
                                 "anchor": "test_cert_get",
                                 "active": false,
                                 "textblock": [
-                                    "You can request the certificate by registering a test in the Corona-Warn-App (CWA): To do this, tap on 'Manage Your Tests' on the Status tab ('Start Screen' before version 2.12) of your CWA (or on 'Register Test' for app versions until 2.5) and then on 'Scan QR Code'. After scanning the QR code for test registration, the window for the COVID test certificate automatically opens. There you can tap 'Request Test Certificate' or decline it if you do not want to receive one.",
-                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
+                                    "You can request the certificate by registering a test in the Corona-Warn-App (CWA): To do this, tap on 'Manage Your Tests' on the Status tab ('Start Screen' before version 2.12) of your CWA (or on 'Register Test' for app versions until 2.5) and then on 'Scan QR Code'. After scanning the QR code for test registration, the window for the COVID test certificate automatically opens. There you can tap 'Request Test Certificate' or decline it if you do not want to receive one."
                                 ]
                             },
                             {
@@ -577,8 +576,7 @@
                                 "textblock": [
                                     "You can request a certificate for both PCR and rapid tests, which are then issued in the event of a negative test.",
                                     "<b>Rapid tests</b><br>In the case of rapid tests, it may be that the respective test site does not support the digital certificate. In this case, after scanning the QR code, you will not be redirected to apply for the certificate. You will then receive the information that a test certificate cannot be requested because the test site does not support the issuance of test certificates.",
-                                    "<b>PCR tests</b><br>When requesting a test certificate for a PCR test, you must provide your date of birth. It is important that the date of birth corresponds to the one that was also indicated for the sample of the PCR test. If the dates of birth do not match, for example due to a typo, you will not receive the test result or the certificate via the app. You cannot change the date of birth that you enter in the app afterwards. Before you request the test certificate after entering the date, you should therefore briefly check whether the date is correct.",
-                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
+                                    "<b>PCR tests</b><br>When requesting a test certificate for a PCR test, you must provide your date of birth. It is important that the date of birth corresponds to the one that was also indicated for the sample of the PCR test. If the dates of birth do not match, for example due to a typo, you will not receive the test result or the certificate via the app. You cannot change the date of birth that you enter in the app afterwards. Before you request the test certificate after entering the date, you should therefore briefly check whether the date is correct."
                                 ]
                             },
                             {
@@ -586,8 +584,7 @@
                                 "anchor": "test_cert_when_and_where",
                                 "active": false,
                                 "textblock": [
-                                    "Shortly after the test result is available in the app, you will also receive your test certificate in the app - provided that you have requested it beforehand, and the respective rapid test site supports the creation of a certificate. You can then view it via the 'Certificates' tab. If you tap on the COVID test certificate, you will be shown the QR code that can be scanned for verification, and more information, such as type of test, date and time of execution and test result.",
-                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
+                                    "Shortly after the test result is available in the app, you will also receive your test certificate in the app - provided that you have requested it beforehand, and the respective rapid test site supports the creation of a certificate. You can then view it via the 'Certificates' tab. If you tap on the COVID test certificate, you will be shown the QR code that can be scanned for verification, and more information, such as type of test, date and time of execution and test result."
                                 ]
                             },
                             {
@@ -595,8 +592,7 @@
                                 "anchor": "test_cert_validity",
                                 "active": false,
                                 "textblock": [
-                                    "How long the certificate is valid depends on the regulations of the respective federal state or municipality.",
-                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
+                                    "How long the certificate is valid depends on the regulations of the respective federal state or municipality."
                                 ]
                             },
                             {
@@ -605,8 +601,7 @@
                                 "active": false,
                                 "textblock": [
                                     "To create the test certificate, the data is encrypted end-to-end and transmitted from the laboratory or the rapid test site to the Corona-Warn-App. For this purpose, the encrypted data is transmitted to the Robert Koch Institute (RKI) in order to digitally sign it and thus confirm the validity of the certificate. The data cannot be decrypted by the RKI and will be deleted after delivery of the certificate.",
-                                    "Test certificates are stored in the app for an unlimited period of time. You can delete certificates manually by going to the 'Certificates' tab, selecting the respective test certificate and then selecting 'Remove test certificate'.",
-                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
+                                    "Test certificates are stored in the app for an unlimited period of time. You can delete certificates manually by going to the 'Certificates' tab, selecting the respective test certificate and then selecting 'Remove test certificate'."
                                 ]
                             }
                         ]
@@ -2820,8 +2815,7 @@
                                 "active": false,
                                 "textblock": [
                                     "The Corona-Warn-App (CWA) can use Bluetooth Low Energy (BLE) technology to determine a risk of infection if people have had contact up to approximately 1.5 meters apart for at least 10 minutes. However, according to current knowledge, aerosols spread far beyond this distance in poorly ventilated interiors <a href='https://www.ndr.de/nachrichten/info/Synapsen-Lueften-lueften-lueften,podcastsynapsen156.html' target='_blank' rel='noopener noreferrer'>(SARS-CoV-2 transmission by aerosols)</a>. Therefore, the risk of infection in these cases is not limited to a distance of 1.5 meters. The risk of getting infected indoors is many times higher than in outdoor areas.",
-                                    "In order to be able to recognize such constellations indoors, the CWA has been extended by event registration. The app also warns people who have been in a room with a SARS-CoV-2 infected person at the same time. Persons register for an event or place by means of the CWA without providing personal data. If a participant of the event or visitor to the place later registers as positively tested via the CWA, all other persons who participated in the same event or visited the same place at the same time can be warned pseudonymously.",
-                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
+                                    "In order to be able to recognize such constellations indoors, the CWA has been extended by event registration. The app also warns people who have been in a room with a SARS-CoV-2 infected person at the same time. Persons register for an event or place by means of the CWA without providing personal data. If a participant of the event or visitor to the place later registers as positively tested via the CWA, all other persons who participated in the same event or visited the same place at the same time can be warned pseudonymously."
                                 ]
                             },
                             {
@@ -2834,8 +2828,7 @@
                                     "In summary, the proposed solution allows a host to create a venue through CWA. All necessary data about the venue is encoded in an (Event) QR code which can be presented on a mobile device or printed out, for example to be posted at the entrance of the venue. An attendee can check in to the venue by scanning the QR code. Check-Ins are stored locally on the mobile device and deleted automatically after two weeks.",
                                     "When an attendee tests positive for SARS-CoV-2, they can upload their Check-Ins along with their Diagnosis Keys to the CWA Server. The CWA Server publishes the relevant Check-Ins on CDN as warnings. Clients regularly download these warnings and match them against the local Check-Ins on the mobile device. If there is a match and the time an attendee spent at a venue overlaps with a warning for a sufficiently long time, the attendee receives a warning in CWA similar to how warnings are issued for BLE-based exposures.",
                                     "For more information on the implementation of the Check-In feature, see here: <a href='https://github.com/corona-warn-app/cwa-documentation/blob/main/event_registration.md' target='_blank' rel='noopener noreferrer'>https://github.com/corona-warn-app/cwa-documentation/blob/main/event_registration.md</a>.",
-                                    "<a href='https://raw.githubusercontent.com/corona-warn-app/cwa-documentation/main/images/evreg-tam-block.png' target='_blank' rel='noopener'><img src='/assets/img/faq/evreg-tam-block.png' alt='Check-In-functionality diagram' width='300'></a>",
-                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
+                                    "<a href='https://raw.githubusercontent.com/corona-warn-app/cwa-documentation/main/images/evreg-tam-block.png' target='_blank' rel='noopener'><img src='/assets/img/faq/evreg-tam-block.png' alt='Check-In-functionality diagram' width='300'></a>"
                                 ]
                             },
                             {
@@ -2845,8 +2838,7 @@
                                 "textblock": [
                                     "The purpose of event registration is to identify risk contacts that are currently not detected with Bluetooth-Low-Energy Technology (BLE). The scope of application is therefore primarily geared to indoor use, where there is an increased risk of infection due to the distribution of aerosols in the room, even beyond the usual contact limit of 1.5 meters. Ideally, a separate Event QR code should be created for each room where visitors are staying. Each visitor then scans the QR code for the rooms in which she/he has stayed. This ensures that only those who have been exposed to an increased risk of infection are warned.",
                                     "The QR code for an event is tied to the venue. The QR code should only be accessible to visitors of the event and should therefore not be distributed via digital media.",
-                                    "For outdoor events, the risk of infection is usually limited to a distance of 1.5 meters, which can already be detected with BLE technology, i.e. the usual use of the CWA. Basically, the event registration can be used here as well. However, it is not suitable for events in large outdoor areas, such as zoos.",
-                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
+                                    "For outdoor events, the risk of infection is usually limited to a distance of 1.5 meters, which can already be detected with BLE technology, i.e. the usual use of the CWA. Basically, the event registration can be used here as well. However, it is not suitable for events in large outdoor areas, such as zoos."
                                 ]
                             },
                             {
@@ -2855,8 +2847,7 @@
                                 "active": false,
                                 "textblock": [
                                     "A common form of misuse of the event registration can be carried out when people check in to an event or place even though they were not present. These individuals would then be warned by CWA if a person who duly checked in at the event would later be tested positive for SARS-CoV 2 and share their positive result via an app. In short, people are being warned even though there is no increased risk to them because they were not there at all. Therefore, some rules should be followed when dealing with your own Event QR codes:",
-                                    "<ul><li>Only share the QR code with your visitors</li><li>Don't share the QR code via social media or websites</li><li>If you print and display the QR code, then preferably in an area that is only accessible to your visitors</li><li>Renew the QR code regularly, ideally once a day (in the CWA, a QR code can be easily transferred)</li><li>When creating the QR code, provide a meaningful title and exact location. This is the only way to ensure that your visitors check in for the correct event.</li><li>Regularly ensure that the QR code is easy to read and not obscured (e.g., by covering or painting over it)</li></ul>",
-                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
+                                    "<ul><li>Only share the QR code with your visitors</li><li>Don't share the QR code via social media or websites</li><li>If you print and display the QR code, then preferably in an area that is only accessible to your visitors</li><li>Renew the QR code regularly, ideally once a day (in the CWA, a QR code can be easily transferred)</li><li>When creating the QR code, provide a meaningful title and exact location. This is the only way to ensure that your visitors check in for the correct event.</li><li>Regularly ensure that the QR code is easy to read and not obscured (e.g., by covering or painting over it)</li></ul>"
                                 ]
                             },
                             {
@@ -2864,8 +2855,7 @@
                                 "anchor": "check_in_prevent_false_warnings",
                                 "active": false,
                                 "textblock": [
-                                    "<ul><li>Check in only for events or places you visit. Do not scan Event QR codes distributed through digital media or websites</li><li>Check in to see if the title and location of the event (shown in the app after scanning) match the event you attended</li><li>The more accurately you specify the time of your attendance, the more accurately you can be warned or warn other participants</li><li>Already when checking in, specify as accurately as possible when you want to be checked out automatically. If your stay is shortened or extended, you can also manually correct the time after the automatic check-out has already taken place</li><li>Don't share photographed Event QR codes via social media or other channels</li></ul>",
-                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
+                                    "<ul><li>Check in only for events or places you visit. Do not scan Event QR codes distributed through digital media or websites</li><li>Check in to see if the title and location of the event (shown in the app after scanning) match the event you attended</li><li>The more accurately you specify the time of your attendance, the more accurately you can be warned or warn other participants</li><li>Already when checking in, specify as accurately as possible when you want to be checked out automatically. If your stay is shortened or extended, you can also manually correct the time after the automatic check-out has already taken place</li><li>Don't share photographed Event QR codes via social media or other channels</li></ul>"
                                 ]
                             },
                             {
@@ -2874,8 +2864,7 @@
                                 "active": false,
                                 "textblock": [
                                     "No, because the essential characteristics of the CWA - decentralization and pseudonymity - are preserved with the event registration. No personal contact details are registered, or location data is transmitted. The data is processed decentrally and pseudonymously on the smartphones.",
-                                    "The Event QR code describes an event with attributes, a detailed address is not required. The QR code is also a random ID that is not processed in the CWA.",
-                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
+                                    "The Event QR code describes an event with attributes, a detailed address is not required. The QR code is also a random ID that is not processed in the CWA."
                                 ]
                             }
                         ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -497,8 +497,7 @@
                                 "anchor": "vac_cert_multiple_scan_possible",
                                 "active": false,
                                 "textblock": [
-                                    "There is no limit to how often you can scan the QR code of vaccination certificates. By scanning the QR code of a certificate you can add and manage the vaccination certificates: <ul><li>on multiple devices, e.g. on your private and business phone </li><li>on a new device, when changing device</li><li> in several apps, e.g. the Corona-Warn-App and the CovPass-App</li><li> on a device you have reset. Certificates are not included in the backup. </li></ul>",
-                                    "<a href='#vac_cert_index' target='_self' >To the index of the vaccination certificate</a>"
+                                    "There is no limit to how often you can scan the QR code of vaccination certificates. By scanning the QR code of a certificate you can add and manage the vaccination certificates: <ul><li>on multiple devices, e.g. on your private and business phone </li><li>on a new device, when changing device</li><li> in several apps, e.g. the Corona-Warn-App and the CovPass-App</li><li> on a device you have reset. Certificates are not included in the backup. </li></ul>"
                                 ]
                             },
                             {
@@ -568,7 +567,7 @@
                                 "active": false,
                                 "textblock": [
                                     "You can request the certificate by registering a test in the Corona-Warn-App (CWA): To do this, tap on 'Manage Your Tests' on the Status tab ('Start Screen' before version 2.12) of your CWA (or on 'Register Test' for app versions until 2.5) and then on 'Scan QR Code'. After scanning the QR code for test registration, the window for the COVID test certificate automatically opens. There you can tap 'Request Test Certificate' or decline it if you do not want to receive one.",
-                                    "<a href='#test_cert_index' target='_self' >To the index of the test certificate</a>"
+                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
                                 ]
                             },
                             {
@@ -579,7 +578,7 @@
                                     "You can request a certificate for both PCR and rapid tests, which are then issued in the event of a negative test.",
                                     "<b>Rapid tests</b><br>In the case of rapid tests, it may be that the respective test site does not support the digital certificate. In this case, after scanning the QR code, you will not be redirected to apply for the certificate. You will then receive the information that a test certificate cannot be requested because the test site does not support the issuance of test certificates.",
                                     "<b>PCR tests</b><br>When requesting a test certificate for a PCR test, you must provide your date of birth. It is important that the date of birth corresponds to the one that was also indicated for the sample of the PCR test. If the dates of birth do not match, for example due to a typo, you will not receive the test result or the certificate via the app. You cannot change the date of birth that you enter in the app afterwards. Before you request the test certificate after entering the date, you should therefore briefly check whether the date is correct.",
-                                    "<a href='#test_cert_index' target='_self' >To the index of the test certificate</a>"
+                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
                                 ]
                             },
                             {
@@ -588,7 +587,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Shortly after the test result is available in the app, you will also receive your test certificate in the app - provided that you have requested it beforehand, and the respective rapid test site supports the creation of a certificate. You can then view it via the 'Certificates' tab. If you tap on the COVID test certificate, you will be shown the QR code that can be scanned for verification, and more information, such as type of test, date and time of execution and test result.",
-                                    "<a href='#test_cert_index' target='_self' >To the index of the test certificate</a>"
+                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
                                 ]
                             },
                             {
@@ -597,7 +596,7 @@
                                 "active": false,
                                 "textblock": [
                                     "How long the certificate is valid depends on the regulations of the respective federal state or municipality.",
-                                    "<a href='#test_cert_index' target='_self' >To the index of the test certificate</a>"
+                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
                                 ]
                             },
                             {
@@ -607,7 +606,7 @@
                                 "textblock": [
                                     "To create the test certificate, the data is encrypted end-to-end and transmitted from the laboratory or the rapid test site to the Corona-Warn-App. For this purpose, the encrypted data is transmitted to the Robert Koch Institute (RKI) in order to digitally sign it and thus confirm the validity of the certificate. The data cannot be decrypted by the RKI and will be deleted after delivery of the certificate.",
                                     "Test certificates are stored in the app for an unlimited period of time. You can delete certificates manually by going to the 'Certificates' tab, selecting the respective test certificate and then selecting 'Remove test certificate'.",
-                                    "<a href='#test_cert_index' target='_self' >To the index of the test certificate</a>"
+                                    "<a href='#test_cert' target='_self' >To the index of the test certificate</a>"
                                 ]
                             }
                         ]
@@ -673,8 +672,7 @@
                                 "anchor": "vac_booster_basics",
                                 "active": false,
                                 "textblock": [
-                                    "<div class='container'><div class='row'><div class='col-sm'><a href='/assets/img/faq/vac_booster_basics_en.png' target='_blank'><img src='/assets/img/faq/vac_booster_basics_en.png' alt='Certificate List' width='300'></a></div><div class='col-sm'><p>A booster vaccination (revaccination) is a vaccination process designed to refresh waning vaccination protection after basic immunization. In most cases, but not always, it takes place according to the recommendations of the authorities after a period of about 5-6 months after the last vaccination procedure. (Example: completion of the vaccination series for basic immunization on 08 Jul 2021, possible booster vaccination on: 08 Jan 2022)</p><p>Each booster vaccination can be attested by a digital COVID certificate, which you can scan into the Corona-Warn-App. Important: please ensure that the personal data (surname, first name and date of birth) are shown to match the existing vaccination certificates. Only then will it be possible to assign the new certificate to the booster vaccination of the basic immunization. (Example: same academic title or indication of the full double name).</p><p>Booster shots provide immediate vaccine protection.</p><p>Based on the previous vaccination series, the booster certificate will be documented '3 of 3' (in case of previous basic immunization with 2 doses) or with '2 of 2' (as vaccination optimization according to the Janssen agent from Johnson & Johnson). In the latter case, however, the CovPassCheck-App, Corona-Warn-App and CovPass-App cannot display this correctly in all cases for technical reasons.</p><p>The '1 of 1' label for a booster vaccination indicates that it is the first and only vaccination after a COVID-19 disease recovery. Vaccinations with Johnson & Johnson are an exception.</p><p> See also: <a href='#vac_booster_jj' target='blank'>Why does a 14-day wait for full vaccine protection after a booster vaccination appear in the Corona-Warn-App?</a></p></div></div></div>",
-                                    "<p><a href='#vac_cert_booster' target='_self' >To the index of the booster vaccination</a></p>"
+                                    "<div class='container'><div class='row'><div class='col-sm'><a href='/assets/img/faq/vac_booster_basics_en.png' target='_blank'><img src='/assets/img/faq/vac_booster_basics_en.png' alt='Certificate List' width='300'></a></div><div class='col-sm'><p>A booster vaccination (revaccination) is a vaccination process designed to refresh waning vaccination protection after basic immunization. In most cases, but not always, it takes place according to the recommendations of the authorities after a period of about 5-6 months after the last vaccination procedure. (Example: completion of the vaccination series for basic immunization on 08 Jul 2021, possible booster vaccination on: 08 Jan 2022)</p><p>Each booster vaccination can be attested by a digital COVID certificate, which you can scan into the Corona-Warn-App. Important: please ensure that the personal data (surname, first name and date of birth) are shown to match the existing vaccination certificates. Only then will it be possible to assign the new certificate to the booster vaccination of the basic immunization. (Example: same academic title or indication of the full double name).</p><p>Booster shots provide immediate vaccine protection.</p><p>Based on the previous vaccination series, the booster certificate will be documented '3 of 3' (in case of previous basic immunization with 2 doses) or with '2 of 2' (as vaccination optimization according to the Janssen agent from Johnson & Johnson). In the latter case, however, the CovPassCheck-App, Corona-Warn-App and CovPass-App cannot display this correctly in all cases for technical reasons.</p><p>The '1 of 1' label for a booster vaccination indicates that it is the first and only vaccination after a COVID-19 disease recovery. Vaccinations with Johnson & Johnson are an exception.</p><p> See also: <a href='#vac_booster_jj' target='blank'>Why does a 14-day wait for full vaccine protection after a booster vaccination appear in the Corona-Warn-App?</a></p></div></div></div>"
                                 ]
                             },
                             {
@@ -684,8 +682,7 @@
                                 "textblock": [
                                     "The Conference of Health Ministers has now passed a regulation on COVID-19 booster vaccinations. An additional booster vaccination is designed to help raise neutralizing antibody titers again, which may decline over time after basic immunization. This becomes particularly important if a weak/muted vaccine response is assumed or recognized after basic immunization in certain groups of vulnerable people.",
                                     "The Corona-Warn-App (CWA) will notify the user to consider a booster vaccination if certain conditions are met. These conditions are based on the recommendations of the Paul Ehrlich Institute and the Permanent Vaccination Commission (STIKO) of the Robert Koch Institute (RKI).",
-                                    "How long someone is effectively protected by a COVID-19 vaccination (basic immunization) depends on several factors and can therefore not be answered in general terms according to current knowledge.",
-                                    "<a href='#vac_cert_booster' target='_self' >To the index of the booster vaccination</a>"
+                                    "How long someone is effectively protected by a COVID-19 vaccination (basic immunization) depends on several factors and can therefore not be answered in general terms according to current knowledge."
                                 ]
                             },
                             {
@@ -695,8 +692,7 @@
                                 "textblock": [
                                     "Since version 2.9, the Corona-Warn-App will allow importing certificates documenting a booster vaccination. (see blog article: <a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank' >Corona-Warn-App version 2.9: Organizers can use the check-in function to warn guests on behalf of the health department</a>)",
                                     "Since version 2.10, users receive a notification to consider a booster vaccination if necessary. The notification is based on national rules that have been implemented in collaboration and alignment with the Robert Koch Institute (RKI). These rules are continuously reviewed and adapted according to developments and new findings. (see blog article: <a href='../../blog/2021-09-22-cwa-version-2-10/' target='_blank' >Blog article Corona-Warn-App version 2.10</a>)",
-                                    "Please note: The booster vaccination certificate is only valid if you can also prove the required basic immunization by the corresponding last certificate of the vaccination series. Please do not delete the other vaccination certificates from the CWA! Since no uniform EU-standards have yet been defined on this topic, you should also carry the basic immunization certificates with you, especially when traveling abroad, whether in the CWA, as a PDF, or as a paper printout. We therefore recommend keeping all vaccination certificates in the app, even if they are no longer up to date.",
-                                    "<a href='#vac_cert_booster' target='_self' >To the index of the booster vaccination</a>"
+                                    "Please note: The booster vaccination certificate is only valid if you can also prove the required basic immunization by the corresponding last certificate of the vaccination series. Please do not delete the other vaccination certificates from the CWA! Since no uniform EU-standards have yet been defined on this topic, you should also carry the basic immunization certificates with you, especially when traveling abroad, whether in the CWA, as a PDF, or as a paper printout. We therefore recommend keeping all vaccination certificates in the app, even if they are no longer up to date."
                                 ]
                             },
                             {
@@ -2188,7 +2184,7 @@
                                     "<ul><li>Google Play Services are outdated.</li><li>The app is not available with Google Play for your country. See <a href='#international' target='_blank' >In which international app stores is the app available?</a> for the supported country versions.</li><li>You haven’t installed Corona-Warn-App via the official Google Play Store.</li><li>Your device has been modified (e.g. by rooting).</li><li>You have multiple user accounts on your device and the user that you use Corona-Warn-App with doesn’t have administrator rights.</li><li>The manufacturer of your device hasn’t made Google Play Services and Google Play Store available for your device. This affects some models by Huawei und Xiaomi, for example.</li><li>Google Mobile Services are outdated.</li></ul>",
                                     "<b>Troubleshooting</b>",
                                     "Many affected users were able to get rid of this error through the following steps:",
-                                    "<ol><li>Update your Google Play Services to the latest version. See: <a href='https://play.google.com/store/apps/details?id=com.google.android.gms&hl=en' target='_blank' rel='noopener noreferrer'>Google Play Services</a>. In the device settings under 'Apps & notifications' > 'Google Play Services' > 'Advanced', you can check your version at the bottom. Please also see the note on Google Mobile Services at the bottom of this answer.</li><li>Clear the cache of the Google Play Services in the device settings under 'Apps & notifications' > 'Google Play Services' > 'Storage' > 'Clear cache'.</li><li>Change your Google Play country to Germany as described here: <a href='https://support.google.com/googleplay/answer/7431675?hl=de' target='_blank' rel='noopener noreferrer'>Change your Google Play country</a>.</li><li>Check if your device generally supports exposure logging in Germany. In the device settings under 'Google' > 'COVID-19 Exposure Notifications', Corona-Warn-App should be listed.</li><li>Make sure that the user account that you’re using on your device has administrator rights. In the device settings, go to 'System' > 'Advanced' > 'Multiple users'.</li><li>Before you install Corona-Warn-App make sure that you’re connected to the internet and that you have activated Bluetooth and Location (see also <a href='/en/faq/#android_location' target='_blank' >[Google/Android]: When activating exposure logging or Bluetooth I'm asked to activate my location. Do I have to do this?</a>).</li><li>Restart your device.</li><li>If nothing else worked, because doing so could remove the already collected random IDs (see <a href='#delete_random_ids' target='_blank' rel='noopener'>Are the exposure logs/random IDs removed from my phone when I uninstall the app?</a>): Uninstall the Corona-Warn-App and reinstall it from the Google Play Store (<a href='https://play.google.com/store/apps/details?id=de.rki.coronawarnapp&hl=en&showAllReviews=true' target='_blank' rel='noopener noreferrer'>Corona-Warn-App</a>).</li></ol>",
+                                    "<ol><li>Update your Google Play Services to the latest version. See: <a href='https://play.google.com/store/apps/details?id=com.google.android.gms&hl=en' target='_blank' rel='noopener noreferrer'>Google Play Services</a>. In the device settings under 'Apps & notifications' > 'Google Play Services' > 'Advanced', you can check your version at the bottom. Please also see the note on Google Mobile Services at the bottom of this answer.</li><li>Clear the cache of the Google Play Services in the device settings under 'Apps & notifications' > 'Google Play Services' > 'Storage' > 'Clear cache'.</li><li>Change your Google Play country to Germany as described here: <a href='https://support.google.com/googleplay/answer/7431675?hl=de' target='_blank' rel='noopener noreferrer'>Change your Google Play country</a>.</li><li>Check if your device generally supports exposure logging in Germany. In the device settings under 'Google' > 'COVID-19 Exposure Notifications', Corona-Warn-App should be listed.</li><li>Make sure that the user account that you’re using on your device has administrator rights. In the device settings, go to 'System' > 'Advanced' > 'Multiple users'.</li><li>Before you install Corona-Warn-App make sure that you’re connected to the internet and that you have activated Bluetooth and Location (see also <a href='#android_location' target='_blank' >[Google/Android]: When activating exposure logging or Bluetooth I'm asked to activate my location. Do I have to do this?</a>).</li><li>Restart your device.</li><li>If nothing else worked, because doing so could remove the already collected random IDs (see <a href='#delete_random_ids' target='_blank' rel='noopener'>Are the exposure logs/random IDs removed from my phone when I uninstall the app?</a>): Uninstall the Corona-Warn-App and reinstall it from the Google Play Store (<a href='https://play.google.com/store/apps/details?id=de.rki.coronawarnapp&hl=en&showAllReviews=true' target='_blank' rel='noopener noreferrer'>Corona-Warn-App</a>).</li></ol>",
                                     "If the error persists even though you went through all steps listed above, Possibly a short wait is necessary for your device to activate Exposure Logging. Please close Corona-Warn-App and wait for two hours before trying again.",
                                     "Note on Google Mobile Services: For Corona-Warn-App to work, Google Mobile Services has to be automatically updated on the device by Google. You cannot manually trigger this update. If you have already updated the Google Play Services as described above, you have to wait for the automatic update of Google Mobile Services. Try using the app again the next day.",
                                     "We’re constantly improving the app and will try to remove possible app-related causes of this error."
@@ -2410,7 +2406,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Yes. As long as you have activated exposure logging in the app and Bluetooth (and Location Services on Android) is on, encounters are logged in the background by the Exposure Notification system integrated in iOS/Android. The app itself doesn't have to be open for this. You can minimize it or use 'swipe-to-quit' to close it.",
-                                    "To be on the safe side, open the app once a day. You'll find more info at <a href='../#howto' target='_blank' >This is how the app works best</a>.",
+                                    "To be on the safe side, open the app once a day.",
                                     "For the risk status to be updated automatically, make sure that background updates are active. For all the info, see these FAQ:",
                                     "<ul><li><a href='#no_risk_update_ios' target='_blank' rel='noopener'>[Apple/iOS]: My risk status hasn't been updated for over a day. An internet connection was available, what's wrong?</a></li><li><a href='#no_risk_update' target='_blank' rel='noopener'>[Google/Android]: My risk status hasn't been updated for over a day. An internet connection was available, what's wrong?</a></li></ul>"
                                 ]
@@ -2825,7 +2821,7 @@
                                 "textblock": [
                                     "The Corona-Warn-App (CWA) can use Bluetooth Low Energy (BLE) technology to determine a risk of infection if people have had contact up to approximately 1.5 meters apart for at least 10 minutes. However, according to current knowledge, aerosols spread far beyond this distance in poorly ventilated interiors <a href='https://www.ndr.de/nachrichten/info/Synapsen-Lueften-lueften-lueften,podcastsynapsen156.html' target='_blank' rel='noopener noreferrer'>(SARS-CoV-2 transmission by aerosols)</a>. Therefore, the risk of infection in these cases is not limited to a distance of 1.5 meters. The risk of getting infected indoors is many times higher than in outdoor areas.",
                                     "In order to be able to recognize such constellations indoors, the CWA has been extended by event registration. The app also warns people who have been in a room with a SARS-CoV-2 infected person at the same time. Persons register for an event or place by means of the CWA without providing personal data. If a participant of the event or visitor to the place later registers as positively tested via the CWA, all other persons who participated in the same event or visited the same place at the same time can be warned pseudonymously.",
-                                    "<a href='#check_in_index' target='_self' >To the index of the event registration</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
                                 ]
                             },
                             {
@@ -2839,7 +2835,7 @@
                                     "When an attendee tests positive for SARS-CoV-2, they can upload their Check-Ins along with their Diagnosis Keys to the CWA Server. The CWA Server publishes the relevant Check-Ins on CDN as warnings. Clients regularly download these warnings and match them against the local Check-Ins on the mobile device. If there is a match and the time an attendee spent at a venue overlaps with a warning for a sufficiently long time, the attendee receives a warning in CWA similar to how warnings are issued for BLE-based exposures.",
                                     "For more information on the implementation of the Check-In feature, see here: <a href='https://github.com/corona-warn-app/cwa-documentation/blob/main/event_registration.md' target='_blank' rel='noopener noreferrer'>https://github.com/corona-warn-app/cwa-documentation/blob/main/event_registration.md</a>.",
                                     "<a href='https://raw.githubusercontent.com/corona-warn-app/cwa-documentation/main/images/evreg-tam-block.png' target='_blank' rel='noopener'><img src='/assets/img/faq/evreg-tam-block.png' alt='Check-In-functionality diagram' width='300'></a>",
-                                    "<a href='#check_in_index' target='_self' >To the index of the event registration</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
                                 ]
                             },
                             {
@@ -2850,7 +2846,7 @@
                                     "The purpose of event registration is to identify risk contacts that are currently not detected with Bluetooth-Low-Energy Technology (BLE). The scope of application is therefore primarily geared to indoor use, where there is an increased risk of infection due to the distribution of aerosols in the room, even beyond the usual contact limit of 1.5 meters. Ideally, a separate Event QR code should be created for each room where visitors are staying. Each visitor then scans the QR code for the rooms in which she/he has stayed. This ensures that only those who have been exposed to an increased risk of infection are warned.",
                                     "The QR code for an event is tied to the venue. The QR code should only be accessible to visitors of the event and should therefore not be distributed via digital media.",
                                     "For outdoor events, the risk of infection is usually limited to a distance of 1.5 meters, which can already be detected with BLE technology, i.e. the usual use of the CWA. Basically, the event registration can be used here as well. However, it is not suitable for events in large outdoor areas, such as zoos.",
-                                    "<a href='#check_in_index' target='_self' >To the index of the event registration</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
                                 ]
                             },
                             {
@@ -2860,7 +2856,7 @@
                                 "textblock": [
                                     "A common form of misuse of the event registration can be carried out when people check in to an event or place even though they were not present. These individuals would then be warned by CWA if a person who duly checked in at the event would later be tested positive for SARS-CoV 2 and share their positive result via an app. In short, people are being warned even though there is no increased risk to them because they were not there at all. Therefore, some rules should be followed when dealing with your own Event QR codes:",
                                     "<ul><li>Only share the QR code with your visitors</li><li>Don't share the QR code via social media or websites</li><li>If you print and display the QR code, then preferably in an area that is only accessible to your visitors</li><li>Renew the QR code regularly, ideally once a day (in the CWA, a QR code can be easily transferred)</li><li>When creating the QR code, provide a meaningful title and exact location. This is the only way to ensure that your visitors check in for the correct event.</li><li>Regularly ensure that the QR code is easy to read and not obscured (e.g., by covering or painting over it)</li></ul>",
-                                    "<a href='#check_in_index' target='_self' >To the index of the event registration</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
                                 ]
                             },
                             {
@@ -2869,7 +2865,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<ul><li>Check in only for events or places you visit. Do not scan Event QR codes distributed through digital media or websites</li><li>Check in to see if the title and location of the event (shown in the app after scanning) match the event you attended</li><li>The more accurately you specify the time of your attendance, the more accurately you can be warned or warn other participants</li><li>Already when checking in, specify as accurately as possible when you want to be checked out automatically. If your stay is shortened or extended, you can also manually correct the time after the automatic check-out has already taken place</li><li>Don't share photographed Event QR codes via social media or other channels</li></ul>",
-                                    "<a href='#check_in_index' target='_self' >To the index of the event registration</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
                                 ]
                             },
                             {
@@ -2879,7 +2875,7 @@
                                 "textblock": [
                                     "No, because the essential characteristics of the CWA - decentralization and pseudonymity - are preserved with the event registration. No personal contact details are registered, or location data is transmitted. The data is processed decentrally and pseudonymously on the smartphones.",
                                     "The Event QR code describes an event with attributes, a detailed address is not required. The QR code is also a random ID that is not processed in the CWA.",
-                                    "<a href='#check_in_index' target='_self' >To the index of the event registration</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >To the index of the event registration</a>"
                                 ]
                             }
                         ]
@@ -3143,7 +3139,7 @@
                 {
                     "term": "Exposure Notification Express (ENE)",
                     "anchor": "ene",
-                    "description": "See FAQ: <a href='/en/faq/#ene' target='_blank' >Exposure Notification Express (ENE)</a>"
+                    "description": "See FAQ: <a href='#ene' target='_blank' >Exposure Notification Express (ENE)</a>"
                 },
                 {
                     "term": "Exposure Notification Framework (ENF)",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -566,8 +566,7 @@
                                 "anchor": "test_cert_get",
                                 "active": false,
                                 "textblock": [
-                                    "Das Zertifikat können Sie anfordern, indem Sie einen Test in der Corona-Warn-App (CWA) registrieren: Dazu können Sie unter Status (vor Version 2.12 'Startseite') in Ihrer CWA auf 'Sie lassen sich testen?' tippen (bzw. auf 'Test registrieren' in App-Versionen bis 2.5 tippen) und dann auf 'QR-Code scannen'. Nachdem Sie den QR-Code zur Test-Registrierung gescannt haben, öffnet sich automatisch das Fenster zum COVID-Testzertifikat. Dort können Sie das 'Testzertifikat anfordern' oder ablehnen, falls Sie keins erhalten möchten.",
-                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "Das Zertifikat können Sie anfordern, indem Sie einen Test in der Corona-Warn-App (CWA) registrieren: Dazu können Sie unter Status (vor Version 2.12 'Startseite') in Ihrer CWA auf 'Sie lassen sich testen?' tippen (bzw. auf 'Test registrieren' in App-Versionen bis 2.5 tippen) und dann auf 'QR-Code scannen'. Nachdem Sie den QR-Code zur Test-Registrierung gescannt haben, öffnet sich automatisch das Fenster zum COVID-Testzertifikat. Dort können Sie das 'Testzertifikat anfordern' oder ablehnen, falls Sie keins erhalten möchten."
                                 ]
                             },
                             {
@@ -577,8 +576,7 @@
                                 "textblock": [
                                     "Sie können sowohl für PCR- als auch für Schnelltests ein Zertifikat anfordern, das dann bei einem negativen Test ausgestellt wird.",
                                     "<b>Schnelltests</b><br>Bei Schnelltests kann es sein, dass die jeweilige Teststelle das digitale Zertifikat nicht unterstützt. In diesem Fall werden Sie nach dem Scannen des QR-Codes nicht zum Beantragen des Zertifikats weitergeleitet. Sie erhalten im Anschluss die Information, dass ein Testzertifikat nicht angefordert werden kann, da die Teststelle die Ausstellung von Testzertifikaten nicht unterstützt.",
-                                    "<b>PCR-Tests</b><br>Bei der Anforderung eines Testzertifikats für einen PCR-Test müssen Sie Ihr Geburtsdatum angeben. Dabei ist wichtig, dass das Geburtsdatum mit dem übereinstimmt, das auch beim Abstrich für den PCR-Test angegeben wurde. Sollten die Geburtsdaten nicht übereinstimmen, beispielsweise aufgrund eines Tippfehlers, bekommen Sie weder das Testergebnis noch das Zertifikat über die App. Sie können das Geburtsdatum, das Sie in der App eintragen, nachträglich nicht mehr ändern. Bevor Sie das Testzertifikat nach der Eingabe des Datums anfordern, sollten Sie deshalb kurz überprüfen, ob das Datum auch wirklich korrekt ist.",
-                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "<b>PCR-Tests</b><br>Bei der Anforderung eines Testzertifikats für einen PCR-Test müssen Sie Ihr Geburtsdatum angeben. Dabei ist wichtig, dass das Geburtsdatum mit dem übereinstimmt, das auch beim Abstrich für den PCR-Test angegeben wurde. Sollten die Geburtsdaten nicht übereinstimmen, beispielsweise aufgrund eines Tippfehlers, bekommen Sie weder das Testergebnis noch das Zertifikat über die App. Sie können das Geburtsdatum, das Sie in der App eintragen, nachträglich nicht mehr ändern. Bevor Sie das Testzertifikat nach der Eingabe des Datums anfordern, sollten Sie deshalb kurz überprüfen, ob das Datum auch wirklich korrekt ist."
                                 ]
                             },
                             {
@@ -586,8 +584,7 @@
                                 "anchor": "test_cert_when_and_where",
                                 "active": false,
                                 "textblock": [
-                                    "Kurz nachdem das Testergebnis in der App vorliegt, erhalten Sie auch Ihr Testzertifikat in der App - vorausgesetzt, Sie haben es vorher angefordert und die jeweilige Schnellteststelle unterstützt die Erstellung eines Zertifikats. Sie können es dann über den Reiter 'Zertifikate' in Ihrer Registerkarte einsehen. Tippen Sie auf das COVID-Testzertifikat, wird Ihnen der QR-Code angezeigt, der zur Überprüfung gescannt werden kann, und weitere Informationen, wie Art des Tests, Datum und Uhrzeit der Durchführung und Testergebnis.",
-                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "Kurz nachdem das Testergebnis in der App vorliegt, erhalten Sie auch Ihr Testzertifikat in der App - vorausgesetzt, Sie haben es vorher angefordert und die jeweilige Schnellteststelle unterstützt die Erstellung eines Zertifikats. Sie können es dann über den Reiter 'Zertifikate' in Ihrer Registerkarte einsehen. Tippen Sie auf das COVID-Testzertifikat, wird Ihnen der QR-Code angezeigt, der zur Überprüfung gescannt werden kann, und weitere Informationen, wie Art des Tests, Datum und Uhrzeit der Durchführung und Testergebnis."
                                 ]
                             },
                             {
@@ -595,8 +592,7 @@
                                 "anchor": "test_cert_validity",
                                 "active": false,
                                 "textblock": [
-                                    "Wie lange das Zertifikat gültig ist, hängt von den Bestimmungen des jeweiligen Bundeslandes oder der Kommune ab.",
-                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "Wie lange das Zertifikat gültig ist, hängt von den Bestimmungen des jeweiligen Bundeslandes oder der Kommune ab."
                                 ]
                             },
                             {
@@ -605,8 +601,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Zur Erstellung des Testzertifikats werden die Daten Ende-zu-Ende verschlüsselt und vom Labor, beziehungsweise der Schnellteststelle an die Corona-Warn-App übermittelt. Dafür werden die verschlüsselten Daten an das Robert Koch-Institut (RKI) übermittelt, um sie digital zu signieren und so die Gültigkeit des Zertifikats zu bestätigen. Die Daten können vom RKI nicht entschlüsselt werden und werden nach Zustellung des Zertifikats gelöscht.",
-                                    "Testzertifikate werden unbefristet in der App gespeichert. Sie können Zertifikate manuell löschen, indem Sie auf den Reiter 'Zertifikate' gehen, das jeweilige Testzertifikat auswählen und dann 'Testzertifikat entfernen' auswählen.",
-                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "Testzertifikate werden unbefristet in der App gespeichert. Sie können Zertifikate manuell löschen, indem Sie auf den Reiter 'Zertifikate' gehen, das jeweilige Testzertifikat auswählen und dann 'Testzertifikat entfernen' auswählen."
                                 ]
                             }
                         ]
@@ -2829,8 +2824,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Die Corona-Warn-App (CWA) kann über die Bluetooth-Low-Energy-Technologie (BLE) ein Infektionsrisiko ermitteln, wenn Personen für die Dauer von mindestens 10 Minuten einen Kontakt im Abstand von bis zu ca. 1,5 Meter hatten. Nach heutigem Wissensstand breiten sich Aerosole <a href='https://www.ndr.de/nachrichten/info/Synapsen-Lueften-lueften-lueften,podcastsynapsen156.html' target='_blank' rel='noopener noreferrer'>(SARS-CoV-2 Übertragung durch Aerosole)</a> jedoch in schlecht gelüfteten Innenräumen weit über diese Distanz hinaus aus. Daher ist das Infektionsrisiko in diesen Fällen nicht auf einen Abstand von 1,5 Metern begrenzt. Das Risiko, sich in Innenräumen anzustecken, ist um ein Vielfaches höher als in Außenbereichen.",
-                                    "Um auch solche Konstellationen in Innenräumen erkennen zu können, wurde die CWA um die Event-Registrierung erweitert. Damit warnt die App auch Personen, die sich zur gleichen Zeit in einem Raum mit einer SARS-CoV-2-infizierten Person aufgehalten haben. Personen registrieren sich mittels der CWA - ohne Angabe persönlicher Daten - zu einem Event oder einem Ort. Meldet sich ein Teilnehmer des Events oder Besucher des Ortes später als positiv getestet über die CWA, können alle anderen Personen pseudonym gewarnt werden, die zur gleichen Zeit am gleichen Event teilgenommen haben oder den gleichen Ort besucht haben.",
-                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "Um auch solche Konstellationen in Innenräumen erkennen zu können, wurde die CWA um die Event-Registrierung erweitert. Damit warnt die App auch Personen, die sich zur gleichen Zeit in einem Raum mit einer SARS-CoV-2-infizierten Person aufgehalten haben. Personen registrieren sich mittels der CWA - ohne Angabe persönlicher Daten - zu einem Event oder einem Ort. Meldet sich ein Teilnehmer des Events oder Besucher des Ortes später als positiv getestet über die CWA, können alle anderen Personen pseudonym gewarnt werden, die zur gleichen Zeit am gleichen Event teilgenommen haben oder den gleichen Ort besucht haben."
                                 ]
                             },
                             {
@@ -2843,8 +2837,7 @@
                                     "Zusammenfassend lässt sich sagen: Die vorgeschlagene Lösung ermöglicht es einer Gastgeberin, einem Gastgeber, einen Veranstaltungsort über die CWA zu erstellen. Alle notwendigen Daten über den Veranstaltungsort sind in einem (Event-)QR-Code eingebettet, der entweder auf einem mobilen Gerät präsentiert oder aber auch ausgedruckt werden kann, beispielsweise am Eingang des Veranstaltungsortes. Veranstaltungsteilnehmende können am Veranstaltungsort einchecken, indem sie den QR-Code scannen. Check-ins werden lokal auf dem mobilen Gerät gespeichert und nach zwei Wochen automatisch gelöscht.",
                                     "Wenn Teilnehmende positiv auf SARS-CoV-2 getestet wurden, können sie ihre Check-ins zusammen mit den Diagnoseschlüsseln auf den CWA-Server hochladen. Der CWA-Server veröffentlicht die entsprechenden Check-ins auf dem Content Delivery Network (CDN) als Warnungen. Smartphones der Besucherinnen und Besucher laden diese Warnungen regelmäßig herunter und stimmen sie mit den bereits vorhandenen lokalen Check-ins auf dem mobilen Gerät ab. Wenn eine Übereinstimmung vorliegt und sich die Zeit, die eine Teilnehmerin oder ein Teilnehmer an einem Veranstaltungsort verbracht hat, mit einer Warnung für eine ausreichend lange Zeit überschneidet, erhält die Teilnehmerin oder der Teilnehmer eine Warnung in der CWA - ähnlich wie Warnungen für BLE-basierte Risikopositionen ausgegeben werden.",
                                     "Weitere Informationen, wie die Check-in-Funktion technisch umgesetzt wird, finden sich hier: <a href='https://github.com/corona-warn-app/cwa-documentation/blob/main/event_registration.md' target='_blank' rel='noopener noreferrer'>https://github.com/corona-warn-app/cwa-documentation/blob/main/event_registration.md</a>.",
-                                    "<a href='https://raw.githubusercontent.com/corona-warn-app/cwa-documentation/main/images/evreg-tam-block.png' target='_blank' rel='noopener'><img src='/assets/img/faq/evreg-tam-block.png' alt='Check-In-Funktionalität Diagramm' width='300'></a>",
-                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<a href='https://raw.githubusercontent.com/corona-warn-app/cwa-documentation/main/images/evreg-tam-block.png' target='_blank' rel='noopener'><img src='/assets/img/faq/evreg-tam-block.png' alt='Check-In-Funktionalität Diagramm' width='300'></a>"
                                 ]
                             },
                             {
@@ -2854,8 +2847,7 @@
                                 "textblock": [
                                     "Zweck der Eventregistrierung ist es, Risikokontakte zu ermitteln, die bislang mit der Bluetooth-Low-Energy Technologie (BLE) nicht erfasst werden. Der Einsatzbereich ist daher vor allem auf die Anwendung in Innenräumen ausgerichtet, in denen es aufgrund der Verteilung der Aerosole im Raum auch über die sonst übliche Kontaktgrenze von 1,5 Metern hinaus, zu einem erhöhten Infektionsrisiko kommt. Dabei sollte idealerweise für jeden Raum, in dem sich Besucher aufhalten, ein eigener Event-QR-Code erstellt werden. Jede Besucherin und jeder Besucher scannt dann den QR-Code für die Räume, in denen sie/er sich aufgehalten hat. So kann sichergestellt werden, dass nur die Personen gewarnt werden, die auch tatsächlich einem erhöhten Infektionsrisiko ausgesetzt waren.",
                                     "Der QR-Code für eine Veranstaltung ist gebunden an den Veranstaltungsort. Der QR-Code sollte nur Besuchern der Veranstaltung zugänglich sein und daher keinesfalls über digitale Medien verteilt werden.",
-                                    "Bei Veranstaltungen im Freien begrenzt sich das Infektionsrisiko in aller Regel auf den Abstand von 1,5 Metern, der bereits mit der BLE-Technologie – also der üblichen Nutzung der CWA - erkannt werden kann. Grundsätzlich kann die Event-Registrierung zwar auch hier verwendet werden,. für Veranstaltungen auf weiträumigen Gebieten im Außenbereich, wie beispielsweise Zoos, eignet sie sich jedoch nicht.",
-                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "Bei Veranstaltungen im Freien begrenzt sich das Infektionsrisiko in aller Regel auf den Abstand von 1,5 Metern, der bereits mit der BLE-Technologie – also der üblichen Nutzung der CWA - erkannt werden kann. Grundsätzlich kann die Event-Registrierung zwar auch hier verwendet werden,. für Veranstaltungen auf weiträumigen Gebieten im Außenbereich, wie beispielsweise Zoos, eignet sie sich jedoch nicht."
                                 ]
                             },
                             {
@@ -2864,8 +2856,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Eine weit verbreitete Form des Missbrauchs der Event-Registrierung kann betrieben werden, wenn sich Personen zu einem Event oder einem Ort einchecken, obwohl sie dort gar nicht anwesend waren. Diese Personen würden dann per CWA gewarnt werden, wenn eine Person, die sich ordnungsgemäß vor Ort im Event eingecheckt hat, später positiv auf SARS-CoV-2 getestet würde und per App ihr positives Ergebnis teilt. Kurz gesagt: Es erhalten Personen eine Warnung, obwohl es kein erhöhtes Risiko für sie gibt, weil sie überhaupt nicht vor Ort waren. Daher sollten Sie einige Regeln bei der Verteilung Ihrer eigenen Event-QR-Codes beachten:",
-                                    "<ul><li>Teilen Sie den QR-Code nur mit Ihren Besuchern</li><li>Teilen Sie den QR-Code nicht über soziale Medien oder Webseiten</li><li>Wenn Sie den QR-Code ausdrucken und aufhängen, dann möglichst in einem Bereich, der nur für Ihre Besucher zugänglich ist</li><li>Erneuern Sie den QR-Code regelmäßig, idealerweise einmal täglich (In der CWA kann ein QR-Code hierzu einfach übernommen werden)</li><li>Geben Sie beim Anlegen des QR-Codes einen aussagekräftigen Titel und genauen Ort an. Nur so können Ihre Besucher sicherstellen, dass sie zu der korrekten Veranstaltung einchecken</li><li>Stellen Sie regelmäßig sicher, dass der QR-Code gut lesbar ist und nicht verdeckt wird (z.&nbsp;B. durch Überkleben oder Übermalen)</li></ul>",
-                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<ul><li>Teilen Sie den QR-Code nur mit Ihren Besuchern</li><li>Teilen Sie den QR-Code nicht über soziale Medien oder Webseiten</li><li>Wenn Sie den QR-Code ausdrucken und aufhängen, dann möglichst in einem Bereich, der nur für Ihre Besucher zugänglich ist</li><li>Erneuern Sie den QR-Code regelmäßig, idealerweise einmal täglich (In der CWA kann ein QR-Code hierzu einfach übernommen werden)</li><li>Geben Sie beim Anlegen des QR-Codes einen aussagekräftigen Titel und genauen Ort an. Nur so können Ihre Besucher sicherstellen, dass sie zu der korrekten Veranstaltung einchecken</li><li>Stellen Sie regelmäßig sicher, dass der QR-Code gut lesbar ist und nicht verdeckt wird (z.&nbsp;B. durch Überkleben oder Übermalen)</li></ul>"
                                 ]
                             },
                             {
@@ -2873,8 +2864,7 @@
                                 "anchor": "check_in_prevent_false_warnings",
                                 "active": false,
                                 "textblock": [
-                                    "<ul><li>Checken Sie nur zu Veranstaltungen oder Orten ein, die Sie auch tatsächlich besuchen. Scannen Sie keine Event-QR-Codes, die über digitale Medien oder Webseiten verteilt werden</li><li> Überprüfen Sie beim Check-in, ob Titel und Ort der Veranstaltung (wird nach dem Scannen in der App angezeigt) mit der besuchten Veranstaltung übereinstimmen</li><li> Je genauer Sie die Zeitangabe für Ihre Teilnahme angeben, umso präziser können Sie gewarnt werden oder andere Teilnehmer warnen</li><li> Geben Sie bereits beim Check-in möglichst genau an, wann Sie automatisch ausgecheckt werden wollen. Falls sich Ihr Aufenthalt verkürzt oder verlängert, können Sie die Zeit auch nach dem bereits erfolgten automatischen Check-out manuell korrigieren</li><li> Teilen Sie keine fotografierten Event-QR-Codes über soziale Medien oder anderweitige Kanäle</li></ul>",
-                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<ul><li>Checken Sie nur zu Veranstaltungen oder Orten ein, die Sie auch tatsächlich besuchen. Scannen Sie keine Event-QR-Codes, die über digitale Medien oder Webseiten verteilt werden</li><li> Überprüfen Sie beim Check-in, ob Titel und Ort der Veranstaltung (wird nach dem Scannen in der App angezeigt) mit der besuchten Veranstaltung übereinstimmen</li><li> Je genauer Sie die Zeitangabe für Ihre Teilnahme angeben, umso präziser können Sie gewarnt werden oder andere Teilnehmer warnen</li><li> Geben Sie bereits beim Check-in möglichst genau an, wann Sie automatisch ausgecheckt werden wollen. Falls sich Ihr Aufenthalt verkürzt oder verlängert, können Sie die Zeit auch nach dem bereits erfolgten automatischen Check-out manuell korrigieren</li><li> Teilen Sie keine fotografierten Event-QR-Codes über soziale Medien oder anderweitige Kanäle</li></ul>"
                                 ]
                             },
                             {
@@ -2883,8 +2873,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Nein, denn die wesentlichen Merkmale der CWA - Dezentralität und Pseudonymität – bleiben mit der Event-Registrierung gewahrt. Es werden keine persönlichen Kontaktdaten registriert oder Ortsdaten übermittelt. Die Daten werden dezentral und pseudonym auf den Smartphones verarbeitet.",
-                                    "Der Event-QR-Code beschreibt ein Event mit Attributen, eine detaillierte Adresse ist nicht erforderlich. Der QR-Code ist zudem eine Zufalls-ID, die in der CWA nicht weiterverarbeitet wird.",
-                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "Der Event-QR-Code beschreibt ein Event mit Attributen, eine detaillierte Adresse ist nicht erforderlich. Der QR-Code ist zudem eine Zufalls-ID, die in der CWA nicht weiterverarbeitet wird."
                                 ]
                             }
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2415,7 +2415,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Ja. Solange Sie in der App die Risiko-Ermittlung aktiviert und Bluetooth (und bei Android die Standort-Dienste) eingeschalten haben, werden Begegnungen vom Exposure Notification Framework von iOS/Android aufgezeichnet. Die App selbst muss dafür nicht geöffnet bleiben. Sie können die App schließen, sowohl durch Minimieren als auch durch 'Swipe-to-quit'.",
-                                    "Sicherheitshalber können Sie die App einmal täglich öffnen.",
+                                    "Sicherheitshalber können Sie die App einmal täglich öffnen. Weitere Hinweise finden Sie unter <a href='../../#howto' target='_blank' >So funktioniert die App am besten</a>.",
                                     "Damit der Risikostatus automatisch aktualisiert werden kann, muss die Hintergrundaktualisierung aktiviert sein. Alle Infos dazu finden Sie in diesen FAQs:",
                                     "<ul><li><a href='#no_risk_update_ios' target='_blank' rel='noopener'>[Apple/iOS]: Mein Risikostatus wurde seit über einem Tag nicht mehr aktualisiert. Internet war aber verfügbar, was läuft hier falsch?</a></li><li><a href='#no_risk_update' target='_blank' rel='noopener'>[Google/Android]: Mein Risikostatus wurde seit über einem Tag nicht mehr aktualisiert. Internet war aber verfügbar, was läuft hier falsch?</a></li></ul>"
                                 ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -497,8 +497,7 @@
                                 "anchor": "vac_cert_multiple_scan_possible",
                                 "active": false,
                                 "textblock": [
-                                    "Es gibt keine Begrenzung, wie oft Sie den QR-Code eines Impfzertifikats scannen können. Indem Sie den QR-Code scannen, können Sie Impfzertifikate hinzufügen und verwalten: <ul><li>auf mehreren Geräten, </li><li>auf einem neuen Gerät, wenn Sie das Gerät wechseln</li><li>in mehreren Apps, z.&nbsp;B. in der Corona-Warn-App und der CovPass-App</li><li>auf einem zurückgesetzten Gerät. Zertifikate sind nicht in der Sicherung (Backup) enthalten.</li></ul>",
-                                    "<a href='#vac_cert_index' target='_self' >Zum Inhaltsverzeichnis des Impfzertifikats</a>"
+                                    "Es gibt keine Begrenzung, wie oft Sie den QR-Code eines Impfzertifikats scannen können. Indem Sie den QR-Code scannen, können Sie Impfzertifikate hinzufügen und verwalten: <ul><li>auf mehreren Geräten, </li><li>auf einem neuen Gerät, wenn Sie das Gerät wechseln</li><li>in mehreren Apps, z.&nbsp;B. in der Corona-Warn-App und der CovPass-App</li><li>auf einem zurückgesetzten Gerät. Zertifikate sind nicht in der Sicherung (Backup) enthalten.</li></ul>"
                                 ]
                             },
                             {
@@ -568,7 +567,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Das Zertifikat können Sie anfordern, indem Sie einen Test in der Corona-Warn-App (CWA) registrieren: Dazu können Sie unter Status (vor Version 2.12 'Startseite') in Ihrer CWA auf 'Sie lassen sich testen?' tippen (bzw. auf 'Test registrieren' in App-Versionen bis 2.5 tippen) und dann auf 'QR-Code scannen'. Nachdem Sie den QR-Code zur Test-Registrierung gescannt haben, öffnet sich automatisch das Fenster zum COVID-Testzertifikat. Dort können Sie das 'Testzertifikat anfordern' oder ablehnen, falls Sie keins erhalten möchten.",
-                                    "<a href='#test_cert_index' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
                                 ]
                             },
                             {
@@ -579,7 +578,7 @@
                                     "Sie können sowohl für PCR- als auch für Schnelltests ein Zertifikat anfordern, das dann bei einem negativen Test ausgestellt wird.",
                                     "<b>Schnelltests</b><br>Bei Schnelltests kann es sein, dass die jeweilige Teststelle das digitale Zertifikat nicht unterstützt. In diesem Fall werden Sie nach dem Scannen des QR-Codes nicht zum Beantragen des Zertifikats weitergeleitet. Sie erhalten im Anschluss die Information, dass ein Testzertifikat nicht angefordert werden kann, da die Teststelle die Ausstellung von Testzertifikaten nicht unterstützt.",
                                     "<b>PCR-Tests</b><br>Bei der Anforderung eines Testzertifikats für einen PCR-Test müssen Sie Ihr Geburtsdatum angeben. Dabei ist wichtig, dass das Geburtsdatum mit dem übereinstimmt, das auch beim Abstrich für den PCR-Test angegeben wurde. Sollten die Geburtsdaten nicht übereinstimmen, beispielsweise aufgrund eines Tippfehlers, bekommen Sie weder das Testergebnis noch das Zertifikat über die App. Sie können das Geburtsdatum, das Sie in der App eintragen, nachträglich nicht mehr ändern. Bevor Sie das Testzertifikat nach der Eingabe des Datums anfordern, sollten Sie deshalb kurz überprüfen, ob das Datum auch wirklich korrekt ist.",
-                                    "<a href='#test_cert_index' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
                                 ]
                             },
                             {
@@ -588,7 +587,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Kurz nachdem das Testergebnis in der App vorliegt, erhalten Sie auch Ihr Testzertifikat in der App - vorausgesetzt, Sie haben es vorher angefordert und die jeweilige Schnellteststelle unterstützt die Erstellung eines Zertifikats. Sie können es dann über den Reiter 'Zertifikate' in Ihrer Registerkarte einsehen. Tippen Sie auf das COVID-Testzertifikat, wird Ihnen der QR-Code angezeigt, der zur Überprüfung gescannt werden kann, und weitere Informationen, wie Art des Tests, Datum und Uhrzeit der Durchführung und Testergebnis.",
-                                    "<a href='#test_cert_index' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
                                 ]
                             },
                             {
@@ -597,7 +596,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Wie lange das Zertifikat gültig ist, hängt von den Bestimmungen des jeweiligen Bundeslandes oder der Kommune ab.",
-                                    "<a href='#test_cert_index' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
                                 ]
                             },
                             {
@@ -607,7 +606,7 @@
                                 "textblock": [
                                     "Zur Erstellung des Testzertifikats werden die Daten Ende-zu-Ende verschlüsselt und vom Labor, beziehungsweise der Schnellteststelle an die Corona-Warn-App übermittelt. Dafür werden die verschlüsselten Daten an das Robert Koch-Institut (RKI) übermittelt, um sie digital zu signieren und so die Gültigkeit des Zertifikats zu bestätigen. Die Daten können vom RKI nicht entschlüsselt werden und werden nach Zustellung des Zertifikats gelöscht.",
                                     "Testzertifikate werden unbefristet in der App gespeichert. Sie können Zertifikate manuell löschen, indem Sie auf den Reiter 'Zertifikate' gehen, das jeweilige Testzertifikat auswählen und dann 'Testzertifikat entfernen' auswählen.",
-                                    "<a href='#test_cert_index' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
+                                    "<a href='#test_cert' target='_self' >Zum Inhaltsverzeichnis des Testzertifikats</a>"
                                 ]
                             }
                         ]
@@ -673,8 +672,7 @@
                                 "anchor": "vac_booster_basics",
                                 "active": false,
                                 "textblock": [
-                                    "<div class='container'><div class='row'><div class='col-sm'><a href='/assets/img/faq/vac_booster_basics_de.png' target='_blank'><img src='/assets/img/faq/vac_booster_basics_de.png' alt='Zertifikatenliste' width='300'></a></div><div class='col-sm'><p>Die Auffrischimpfung (Boosterimpfung) ist ein Impfvorgang, der nach der Grundimmunisierung den nachlassenden Impfschutz auffrischen soll. In den meisten Fällen, aber nicht immer, findet Sie gemäß den Empfehlungen der Behörden nach einer Zeit von etwa 5-6 Monaten nach dem letzten Impfvorgang statt. Typisches Beispiel: Erfolgte der Abschluss der Impfreihe zur Grundimmunisierung am 08.07.2021, dann könnte eine Auffrischimpfung am 08.01.2022 erfolgen.</p><p>Jede Auffrischimpfung kann durch ein digitales COVID-Zertifikat dokumentiert werden, das Sie in die Corona-Warn-App einlesen können. <b>*Wichtig*</b>: Bitte achten Sie schon direkt beim Ausstellen des Zertifikats darauf, dass die persönlichen Daten (Titel, Name, Vornamen, und Geburtsdatum) passend zu den bereits existierenden Impfzertifikaten ausgewiesen werden. Nur so kann die Corona-Warn-App das neue Zertifikat der Auffrischimpfung der Grundimmunisierung zuordnen (Beispiel: gleicher akademischer Titel oder Angabe des vollständigen Doppelnamens). Alle Zertifikate einer Person sollten in der Corona-Warn-App gruppiert angezeigt werden, siehe Abbildung.</p><p>Auffrischimpfungen bieten einen sofortigen Impfschutz.</p><p>Basierend auf den bisherigen Impfvorgängen, wird das erste Zertifikat einer Auffrischimpfung mit '3 von 3' (bei vorheriger Grundimmunisierung mit 2 Dosen) oder mit '2 von 2' (als Impfoptimierung nach dem Impfstoff Janssen von Johnson & Johnson) ausgestellt. Im letzteren Fall können die CovPassCheck-App, Corona-Warn-App und CovPass-App dies aber aus technischen Gründen nicht in allen Fällen korrekt anzeigen.</p><p>Die Kennzeichnung '1 von 1' im Zertifikat einer Auffrischimpfung zeigt an, dass es sich um den ersten und einzigen Impfvorgang nach einer Genesung handelt. Eine Ausnahme bilden Impfungen mit Johnson & Johnson.</p><p>Siehe FAQ-Artikel: <a href='#vac_booster_jj' target='blank'>Warum erscheint in der Corona-Warn-App eine 14-tägige Wartezeit bis zum vollen Impfschutz nach einer Auffrischimpfung?</a></p></div></div></div>",
-                                    "<p><a href='#vac_cert_booster' target='_self' >Zum Inhaltsverzeichnis der Auffrischimpfung</a></p>"
+                                    "<div class='container'><div class='row'><div class='col-sm'><a href='/assets/img/faq/vac_booster_basics_de.png' target='_blank'><img src='/assets/img/faq/vac_booster_basics_de.png' alt='Zertifikatenliste' width='300'></a></div><div class='col-sm'><p>Die Auffrischimpfung (Boosterimpfung) ist ein Impfvorgang, der nach der Grundimmunisierung den nachlassenden Impfschutz auffrischen soll. In den meisten Fällen, aber nicht immer, findet Sie gemäß den Empfehlungen der Behörden nach einer Zeit von etwa 5-6 Monaten nach dem letzten Impfvorgang statt. Typisches Beispiel: Erfolgte der Abschluss der Impfreihe zur Grundimmunisierung am 08.07.2021, dann könnte eine Auffrischimpfung am 08.01.2022 erfolgen.</p><p>Jede Auffrischimpfung kann durch ein digitales COVID-Zertifikat dokumentiert werden, das Sie in die Corona-Warn-App einlesen können. <b>*Wichtig*</b>: Bitte achten Sie schon direkt beim Ausstellen des Zertifikats darauf, dass die persönlichen Daten (Titel, Name, Vornamen, und Geburtsdatum) passend zu den bereits existierenden Impfzertifikaten ausgewiesen werden. Nur so kann die Corona-Warn-App das neue Zertifikat der Auffrischimpfung der Grundimmunisierung zuordnen (Beispiel: gleicher akademischer Titel oder Angabe des vollständigen Doppelnamens). Alle Zertifikate einer Person sollten in der Corona-Warn-App gruppiert angezeigt werden, siehe Abbildung.</p><p>Auffrischimpfungen bieten einen sofortigen Impfschutz.</p><p>Basierend auf den bisherigen Impfvorgängen, wird das erste Zertifikat einer Auffrischimpfung mit '3 von 3' (bei vorheriger Grundimmunisierung mit 2 Dosen) oder mit '2 von 2' (als Impfoptimierung nach dem Impfstoff Janssen von Johnson & Johnson) ausgestellt. Im letzteren Fall können die CovPassCheck-App, Corona-Warn-App und CovPass-App dies aber aus technischen Gründen nicht in allen Fällen korrekt anzeigen.</p><p>Die Kennzeichnung '1 von 1' im Zertifikat einer Auffrischimpfung zeigt an, dass es sich um den ersten und einzigen Impfvorgang nach einer Genesung handelt. Eine Ausnahme bilden Impfungen mit Johnson & Johnson.</p><p>Siehe FAQ-Artikel: <a href='#vac_booster_jj' target='blank'>Warum erscheint in der Corona-Warn-App eine 14-tägige Wartezeit bis zum vollen Impfschutz nach einer Auffrischimpfung?</a></p></div></div></div>"
                                 ]
                             },
                             {
@@ -684,8 +682,7 @@
                                 "textblock": [
                                     "Durch die Gesundheitsminister-Konferenz wurde inzwischen die Regelung zu COVID-19-Auffrischimpfungen beschlossen. Eine zusätzliche Auffrischimpfung soll helfen, die neutralisierenden Antikörpertiter wieder zu erhöhen, die nach der Grundimmunisierung mit der Zeit absinken können. Das gilt insbesondere bei den Personengruppen, bei denen nach einer Grundimmunisierung eine gedämpfte Impfantwort vermutet oder erkannt wird.",
                                     "Die Corona-Warn-App wird darauf hinweisen, eine Auffrischimpfung in Betracht zu ziehen, falls bestimmte Bedingungen erfüllt sind. Diese Bedingungen basieren auf den Empfehlungen der Paul-Ehrlich-Instituts sowie der Ständigen Impfkommission (STIKO) des Robert Koch-Instituts (RKI).",
-                                    "Wie lange jemand durch eine COVID-19-Impfung (Grundimmunisierung) tatsächlich geschützt ist, hängt von verschiedenen Faktoren ab und lässt sich daher nach heutigem Kenntnisstand nicht pauschal beantworten.",
-                                    "<a href='#vac_cert_booster' target='_self' >Zum Inhaltsverzeichnis der Auffrischimpfung</a>"
+                                    "Wie lange jemand durch eine COVID-19-Impfung (Grundimmunisierung) tatsächlich geschützt ist, hängt von verschiedenen Faktoren ab und lässt sich daher nach heutigem Kenntnisstand nicht pauschal beantworten."
                                 ]
                             },
                             {
@@ -695,8 +692,7 @@
                                 "textblock": [
                                     "Seit Version 2.9 unterstützt die Corona-Warn-App auch den Import von Zertifikaten, die eine Auffrischimpfung dokumentieren. (siehe Blog Artikel: <a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank' >Corona-Warn-App Version 2.9: Veranstalter*innen können Gäste im Auftrag des Gesundheitsamtes über die Check-in-Funktion warnen</a>)",
                                     "Seit Version 2.10 erhalten Anwender einen Hinweis, ggf. eine Auffrischimpfung in Betracht zu ziehen. Der Hinweis basiert auf nationalen Regeln, die in Absprache mit dem Robert Koch-Institut (RKI) implementiert wurden. Diese Regeln werden fortlaufend geprüft und entsprechend den Entwicklungen und neuen Erkenntnissen angepasst. (siehe Blog Artikel: <a href='../../blog/2021-09-22-cwa-version-2-10/' target='_blank' >Mit Version 2.10 ist die Corona-Warn-App bereit, schnell über Auffrischimpfungen zu informieren.</a>)",
-                                    "Bitte beachten Sie: Das Zertifikat zur Auffrischimpfung ist nur gültig, wenn Sie auch die nötige Grundimmunisierung durch das entsprechende letzte Zertifikat der Impfreihe nachweisen können. Löschen Sie bitte die anderen Impfzertifikate nicht aus der CWA! Da bisher noch keine einheitlichen EU-Standards zu diesem Thema festgelegt wurden, sollte man insbesondere bei Reisen ins Ausland auch die Zertifikate der Grundimmunisierung mit sich führen, sei es in der CWA, als PDF, oder als Papierausdruck. Wir empfehlen daher alle Impfzertifikate in der App zu behalten, auch wenn diese nicht mehr aktuell sind.",
-                                    "<a href='#vac_cert_booster' target='_self' >Zum Inhaltsverzeichnis der Auffrischimpfung</a>"
+                                    "Bitte beachten Sie: Das Zertifikat zur Auffrischimpfung ist nur gültig, wenn Sie auch die nötige Grundimmunisierung durch das entsprechende letzte Zertifikat der Impfreihe nachweisen können. Löschen Sie bitte die anderen Impfzertifikate nicht aus der CWA! Da bisher noch keine einheitlichen EU-Standards zu diesem Thema festgelegt wurden, sollte man insbesondere bei Reisen ins Ausland auch die Zertifikate der Grundimmunisierung mit sich führen, sei es in der CWA, als PDF, oder als Papierausdruck. Wir empfehlen daher alle Impfzertifikate in der App zu behalten, auch wenn diese nicht mehr aktuell sind."
                                 ]
                             },
                             {
@@ -2419,7 +2415,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Ja. Solange Sie in der App die Risiko-Ermittlung aktiviert und Bluetooth (und bei Android die Standort-Dienste) eingeschalten haben, werden Begegnungen vom Exposure Notification Framework von iOS/Android aufgezeichnet. Die App selbst muss dafür nicht geöffnet bleiben. Sie können die App schließen, sowohl durch Minimieren als auch durch 'Swipe-to-quit'.",
-                                    "Sicherheitshalber können Sie die App einmal täglich öffnen. Weitere Hinweise finden Sie unter <a href='../#howto' target='_blank' >So funktioniert die App am besten</a>.",
+                                    "Sicherheitshalber können Sie die App einmal täglich öffnen.",
                                     "Damit der Risikostatus automatisch aktualisiert werden kann, muss die Hintergrundaktualisierung aktiviert sein. Alle Infos dazu finden Sie in diesen FAQs:",
                                     "<ul><li><a href='#no_risk_update_ios' target='_blank' rel='noopener'>[Apple/iOS]: Mein Risikostatus wurde seit über einem Tag nicht mehr aktualisiert. Internet war aber verfügbar, was läuft hier falsch?</a></li><li><a href='#no_risk_update' target='_blank' rel='noopener'>[Google/Android]: Mein Risikostatus wurde seit über einem Tag nicht mehr aktualisiert. Internet war aber verfügbar, was läuft hier falsch?</a></li></ul>"
                                 ]
@@ -2834,7 +2830,7 @@
                                 "textblock": [
                                     "Die Corona-Warn-App (CWA) kann über die Bluetooth-Low-Energy-Technologie (BLE) ein Infektionsrisiko ermitteln, wenn Personen für die Dauer von mindestens 10 Minuten einen Kontakt im Abstand von bis zu ca. 1,5 Meter hatten. Nach heutigem Wissensstand breiten sich Aerosole <a href='https://www.ndr.de/nachrichten/info/Synapsen-Lueften-lueften-lueften,podcastsynapsen156.html' target='_blank' rel='noopener noreferrer'>(SARS-CoV-2 Übertragung durch Aerosole)</a> jedoch in schlecht gelüfteten Innenräumen weit über diese Distanz hinaus aus. Daher ist das Infektionsrisiko in diesen Fällen nicht auf einen Abstand von 1,5 Metern begrenzt. Das Risiko, sich in Innenräumen anzustecken, ist um ein Vielfaches höher als in Außenbereichen.",
                                     "Um auch solche Konstellationen in Innenräumen erkennen zu können, wurde die CWA um die Event-Registrierung erweitert. Damit warnt die App auch Personen, die sich zur gleichen Zeit in einem Raum mit einer SARS-CoV-2-infizierten Person aufgehalten haben. Personen registrieren sich mittels der CWA - ohne Angabe persönlicher Daten - zu einem Event oder einem Ort. Meldet sich ein Teilnehmer des Events oder Besucher des Ortes später als positiv getestet über die CWA, können alle anderen Personen pseudonym gewarnt werden, die zur gleichen Zeit am gleichen Event teilgenommen haben oder den gleichen Ort besucht haben.",
-                                    "<a href='#check_in_index' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
                                 ]
                             },
                             {
@@ -2848,7 +2844,7 @@
                                     "Wenn Teilnehmende positiv auf SARS-CoV-2 getestet wurden, können sie ihre Check-ins zusammen mit den Diagnoseschlüsseln auf den CWA-Server hochladen. Der CWA-Server veröffentlicht die entsprechenden Check-ins auf dem Content Delivery Network (CDN) als Warnungen. Smartphones der Besucherinnen und Besucher laden diese Warnungen regelmäßig herunter und stimmen sie mit den bereits vorhandenen lokalen Check-ins auf dem mobilen Gerät ab. Wenn eine Übereinstimmung vorliegt und sich die Zeit, die eine Teilnehmerin oder ein Teilnehmer an einem Veranstaltungsort verbracht hat, mit einer Warnung für eine ausreichend lange Zeit überschneidet, erhält die Teilnehmerin oder der Teilnehmer eine Warnung in der CWA - ähnlich wie Warnungen für BLE-basierte Risikopositionen ausgegeben werden.",
                                     "Weitere Informationen, wie die Check-in-Funktion technisch umgesetzt wird, finden sich hier: <a href='https://github.com/corona-warn-app/cwa-documentation/blob/main/event_registration.md' target='_blank' rel='noopener noreferrer'>https://github.com/corona-warn-app/cwa-documentation/blob/main/event_registration.md</a>.",
                                     "<a href='https://raw.githubusercontent.com/corona-warn-app/cwa-documentation/main/images/evreg-tam-block.png' target='_blank' rel='noopener'><img src='/assets/img/faq/evreg-tam-block.png' alt='Check-In-Funktionalität Diagramm' width='300'></a>",
-                                    "<a href='#check_in_index' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
                                 ]
                             },
                             {
@@ -2859,7 +2855,7 @@
                                     "Zweck der Eventregistrierung ist es, Risikokontakte zu ermitteln, die bislang mit der Bluetooth-Low-Energy Technologie (BLE) nicht erfasst werden. Der Einsatzbereich ist daher vor allem auf die Anwendung in Innenräumen ausgerichtet, in denen es aufgrund der Verteilung der Aerosole im Raum auch über die sonst übliche Kontaktgrenze von 1,5 Metern hinaus, zu einem erhöhten Infektionsrisiko kommt. Dabei sollte idealerweise für jeden Raum, in dem sich Besucher aufhalten, ein eigener Event-QR-Code erstellt werden. Jede Besucherin und jeder Besucher scannt dann den QR-Code für die Räume, in denen sie/er sich aufgehalten hat. So kann sichergestellt werden, dass nur die Personen gewarnt werden, die auch tatsächlich einem erhöhten Infektionsrisiko ausgesetzt waren.",
                                     "Der QR-Code für eine Veranstaltung ist gebunden an den Veranstaltungsort. Der QR-Code sollte nur Besuchern der Veranstaltung zugänglich sein und daher keinesfalls über digitale Medien verteilt werden.",
                                     "Bei Veranstaltungen im Freien begrenzt sich das Infektionsrisiko in aller Regel auf den Abstand von 1,5 Metern, der bereits mit der BLE-Technologie – also der üblichen Nutzung der CWA - erkannt werden kann. Grundsätzlich kann die Event-Registrierung zwar auch hier verwendet werden,. für Veranstaltungen auf weiträumigen Gebieten im Außenbereich, wie beispielsweise Zoos, eignet sie sich jedoch nicht.",
-                                    "<a href='#check_in_index' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
                                 ]
                             },
                             {
@@ -2869,7 +2865,7 @@
                                 "textblock": [
                                     "Eine weit verbreitete Form des Missbrauchs der Event-Registrierung kann betrieben werden, wenn sich Personen zu einem Event oder einem Ort einchecken, obwohl sie dort gar nicht anwesend waren. Diese Personen würden dann per CWA gewarnt werden, wenn eine Person, die sich ordnungsgemäß vor Ort im Event eingecheckt hat, später positiv auf SARS-CoV-2 getestet würde und per App ihr positives Ergebnis teilt. Kurz gesagt: Es erhalten Personen eine Warnung, obwohl es kein erhöhtes Risiko für sie gibt, weil sie überhaupt nicht vor Ort waren. Daher sollten Sie einige Regeln bei der Verteilung Ihrer eigenen Event-QR-Codes beachten:",
                                     "<ul><li>Teilen Sie den QR-Code nur mit Ihren Besuchern</li><li>Teilen Sie den QR-Code nicht über soziale Medien oder Webseiten</li><li>Wenn Sie den QR-Code ausdrucken und aufhängen, dann möglichst in einem Bereich, der nur für Ihre Besucher zugänglich ist</li><li>Erneuern Sie den QR-Code regelmäßig, idealerweise einmal täglich (In der CWA kann ein QR-Code hierzu einfach übernommen werden)</li><li>Geben Sie beim Anlegen des QR-Codes einen aussagekräftigen Titel und genauen Ort an. Nur so können Ihre Besucher sicherstellen, dass sie zu der korrekten Veranstaltung einchecken</li><li>Stellen Sie regelmäßig sicher, dass der QR-Code gut lesbar ist und nicht verdeckt wird (z.&nbsp;B. durch Überkleben oder Übermalen)</li></ul>",
-                                    "<a href='#check_in_index' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
                                 ]
                             },
                             {
@@ -2878,7 +2874,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<ul><li>Checken Sie nur zu Veranstaltungen oder Orten ein, die Sie auch tatsächlich besuchen. Scannen Sie keine Event-QR-Codes, die über digitale Medien oder Webseiten verteilt werden</li><li> Überprüfen Sie beim Check-in, ob Titel und Ort der Veranstaltung (wird nach dem Scannen in der App angezeigt) mit der besuchten Veranstaltung übereinstimmen</li><li> Je genauer Sie die Zeitangabe für Ihre Teilnahme angeben, umso präziser können Sie gewarnt werden oder andere Teilnehmer warnen</li><li> Geben Sie bereits beim Check-in möglichst genau an, wann Sie automatisch ausgecheckt werden wollen. Falls sich Ihr Aufenthalt verkürzt oder verlängert, können Sie die Zeit auch nach dem bereits erfolgten automatischen Check-out manuell korrigieren</li><li> Teilen Sie keine fotografierten Event-QR-Codes über soziale Medien oder anderweitige Kanäle</li></ul>",
-                                    "<a href='#check_in_index' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
                                 ]
                             },
                             {
@@ -2888,7 +2884,7 @@
                                 "textblock": [
                                     "Nein, denn die wesentlichen Merkmale der CWA - Dezentralität und Pseudonymität – bleiben mit der Event-Registrierung gewahrt. Es werden keine persönlichen Kontaktdaten registriert oder Ortsdaten übermittelt. Die Daten werden dezentral und pseudonym auf den Smartphones verarbeitet.",
                                     "Der Event-QR-Code beschreibt ein Event mit Attributen, eine detaillierte Adresse ist nicht erforderlich. Der QR-Code ist zudem eine Zufalls-ID, die in der CWA nicht weiterverarbeitet wird.",
-                                    "<a href='#check_in_index' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
+                                    "<a href='#technical_correlations_check_in' target='_self' >Zum Inhaltsverzeichnis der Event-Registrierung</a>"
                                 ]
                             }
                         ]
@@ -3131,7 +3127,7 @@
                 {
                     "term": "Exposure Notification Express (ENE)",
                     "anchor": "ene",
-                    "description": "Siehe FAQ: <a href='/de/faq/#ene' target='_blank' >Exposure Notification Express (ENE)</a>"
+                    "description": "Siehe FAQ: <a href='#ene' target='_blank' >Exposure Notification Express (ENE)</a>"
                 },
                 {
                     "term": "Exposure Notification Framework (ENF)",


### PR DESCRIPTION
As part of PR https://github.com/corona-warn-app/cwa-website/pull/2656#issue-1189294825 I was able to run the check_anchor_links.js Cypress test for /faq/results/ and found a number of broken links.

Creating this PR to update these broken links to the corresponding new link.

Before:
![image](https://user-images.githubusercontent.com/72961430/161207745-a70e66d0-ffdc-4939-9f23-987959faaeb5.png)

After:
![image](https://user-images.githubusercontent.com/72961430/161207780-217d4897-8d98-449a-a07c-09a24919aece.png)
