### PR TITLE
Correct link to cwa-documentation branch

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2401,7 +2401,7 @@
                                 "anchor": "client_server",
                                 "active": false,
                                 "textblock": [
-                                    "You can find more information in our <a href='https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md' target='_blank' rel='noopener noreferrer'>Solution Architecture Document</a>."
+                                    "You can find more information in our <a href='https://github.com/corona-warn-app/cwa-documentation/blob/main/solution_architecture.md' target='_blank' rel='noopener noreferrer'>Solution Architecture Document</a>."
                                 ]
                             },
                             {


### PR DESCRIPTION
- This PR reapplies a missing fix from PR https://github.com/corona-warn-app/cwa-website/pull/2416 which was accidentally reverted by PR https://github.com/corona-warn-app/cwa-website/pull/2434.
- According to the (re-opened) issue https://github.com/corona-warn-app/cwa-website/issues/2384, links to https://github.com/corona-warn-app/cwa-documentation/tree/master should target https://github.com/corona-warn-app/cwa-documentation/tree/main.