### PR TITLE
added missing double quote

### DIFF
--- a/src/partials/page-analyse.html
+++ b/src/partials/page-analyse.html
@@ -249,7 +249,7 @@
 	<div class="analyseModalInfo" rel="{{page-contents.updateNoticeIcon.title}}">
 		<h2 class="headline analyseModal-title">
 			<button class="btn analyseModalInfo-close">
-				<img src="{{root}}assets/img/icons/Close.svg" alt="" aria-label="{{close}}>
+				<img src="{{root}}assets/img/icons/Close.svg" alt="" aria-label="{{close}}">
 			</button>
 			{{page-contents.updateNoticeIcon.title}}
 		</h2>


### PR DESCRIPTION
Initial Issue #2458

The Pop-up layout on the dashboard page is broken again since PR WCAG fixes #2644 was merged. I have added the missing double quotes again.

<img width="1552" alt="pop-up-layout-broken" src="https://user-images.githubusercontent.com/25111875/161383068-f2618423-af79-40e6-82c2-70546f54d944.png">