### PR TITLE
added redirect for #notification anchor

### DIFF
--- a/src/data/faq_redirects.json
+++ b/src/data/faq_redirects.json
@@ -8,5 +8,6 @@
     "vac_booster": "vac_cert_booster",
     "vac_cert_invalid_211111": "vac_cert_invalid_21_1",
     "vac_cert_verification": "eu_dcc_check",
-    "in_short": "in_a_nutshell"
+    "in_short": "in_a_nutshell",
+    "notification": "support_general"
 }


### PR DESCRIPTION
Added redirect for anchor 'notification' to fix Issue 'FAQ notification backwards compatibility #2672'