### PR TITLE
Correct #keys_matches: GAEN still keeps 14 day's keys

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -114,7 +114,7 @@
                                 "textblock": [
                                     "The exposure check logs show how many keys that report a positive test result are downloaded from the server, and how many of them are matching the keys that your phone has collected. For info about the app flow, see <a href='#risk_info' target='_blank' >How do you get information about a risk of infection?</a> for details.",
                                     "<b>Exposure checks</b>",
-                                    "This is where the checks of up to 15 days are logged (today plus the last 14  (10 days since version 2.20)). There may be multiple checks made per day. Selecting an entry leads to a detailed view with the corresponding time stamps and the number of matched keys.",
+                                    "This is where the checks of up to 15 days are logged (today plus the last 14 days). There may be multiple checks made per day. Selecting an entry leads to a detailed view with the corresponding time stamps and the number of matched keys.",
                                     "<b>Provided Key Count</b> (iOS) | <b>Number of keys</b> (Android)",
                                     "This is the number of keys related to a positive test result, so called diagnosis keys, that your phone downloaded from the server.",
                                     "<b>Matched Key Count</b> (iOS) | <b>Number of matches</b> (Android)",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -114,7 +114,7 @@
                                 "textblock": [
                                     "Die COVID-19-Begegnungsüberprüfung zeigt an, wie viele Schlüssel, die einem gemeldeten positiven Testergebnis zuzuordnen sind, vom Server heruntergeladen wurden, und wie viele davon mit Schlüsseln, die Ihr Smartphone eingesammelt hat, übereinstimmen. Mehr zum Ablauf finden Sie unter <a href='#risk_info' target='_blank' >Wie werde ich über ein Infektionsrisiko informiert?</a>",
                                     "<b>Begegnungsüberprüfungen</b> (iOS) | <b>Überprüfungen auf mögliche Begegnungen</b> (Android)",
-                                    "Hier sind die Überprüfungen von bis zu 15 Tagen protokolliert (heute plus die letzten 14 Tage (10 Tage ab Version 2.20)). Es können auch jeden Tag mehrere Überprüfungen durchgeführt worden sein. Das Auswählen eines Eintrages führt zur Detailansicht mit den entsprechenden Zeitstempeln und der Anzahl der abgeglichenen Schlüssel.",
+                                    "Hier sind die Überprüfungen von bis zu 15 Tagen protokolliert (heute plus die letzten 14 Tage). Es können auch jeden Tag mehrere Überprüfungen durchgeführt worden sein. Das Auswählen eines Eintrages führt zur Detailansicht mit den entsprechenden Zeitstempeln und der Anzahl der abgeglichenen Schlüssel.",
                                     "<b>Bereitgestellte Schlüssel</b> (iOS) | <b>Anzahl der Schlüssel</b> (Android)",
                                     "Das ist die Anzahl der Schlüssel, welche zu einem gemeldeten, positiven Testergebnis gehören, sogenannte Positivkennungen, die Ihr Smartphone vom Server heruntergeladen hat.",
                                     "<b>Übereinstimmende Schlüssel</b> (iOS) | <b>Anzahl der Treffer</b> (Android)",


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2678 "Google controlled history not reduced to 10 days". It 

- removes the added text "(10 days since version 2.20)" from https://www.coronawarn.app/en/faq/results/#keys_matches "What do the exposure check logs show?" and

- removes the added text "(10 Tage ab Version 2.20)" from https://www.coronawarn.app/de/faq/results/#keys_matches "Was bedeutet die Überprüfung auf mögliche Begegnungen?"

Effectively this reverts the changes made to the above FAQ articles by:

- PR https://github.com/corona-warn-app/cwa-website/pull/2540