### PR TITLE
Add FAQ Q&A index redirects

### DIFF
--- a/src/data/faq_redirects.json
+++ b/src/data/faq_redirects.json
@@ -8,5 +8,9 @@
     "vac_booster": "vac_cert_booster",
     "vac_cert_invalid_211111": "vac_cert_invalid_21_1",
     "vac_cert_verification": "eu_dcc_check",
-    "in_short": "in_a_nutshell"
+    "in_short": "in_a_nutshell",
+    "vac_cert_index":  "vac_cert",
+    "vac_cert_booster": "vac_cert",
+    "test_cert_index": "test_cert",
+    "check_in_index": "check_in"
 }


### PR DESCRIPTION
- This PR implements the suggestion from https://github.com/corona-warn-app/cwa-website/issues/2661#issuecomment-1087690698

The following FAQ redirects are added
From anchor | To anchor
--- | ---
#vac_cert_index |  #vac_cert
#vac_cert_booster | #vac_cert
#test_cert_index | #test_cert
#check_in_index | #check_in

This means that for instance a bookmark https://www.coronawarn.app/en/faq/#vac_cert_index from the old FAQ format will redirect to https://www.coronawarn.app/en/faq/results/#vac_cert.

The original anchors were not carried over from the old FAQ format to the new FAQ format, because the corresponding content was deleted, so this ensures that any external bookmarks using these links will continue to direct the user to the most appropriate content.