### PR TITLE
Create new FAQ #news

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1044,6 +1044,15 @@
                         "indexed": false,
                         "accordion": [
                             {
+                                "title": "Where can I find news on the Corona-Warn-App?",
+                                "anchor": "news",
+                                "active": false,
+                                "textblock": [
+                                    "The availability and details of new Corona-Warn-App versions are published in the <a href='../../blog/' target='_blank'>Blog</a> as soon as an update is released into the stores. (See also <a href='#where_to_get' target='_blank'>Where can I get the app?</a>.) Occasionally, information on various other topics is published in the Blog as well, such as recommendations on how to behave in the event of a red tile.",
+                                    "Additionally, news about the Corona-Warn-App is published on <a href='https://twitter.com/coronawarnapp' target='_blank' rel='noopener noreferrer'>Twitter</a> where users can also ask questions and get replies from the helpful community there. The announcements and conversations in the Twitter channel are in German generally."
+                                ]
+                            },
+                            {
                                 "title": "In-App statistics starting with release 1.11",
                                 "anchor": "further_details",
                                 "active": false,

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1044,6 +1044,15 @@
                         "indexed": false,
                         "accordion": [
                             {
+                                "title": "Wo kann ich Neuigkeiten über die Corona-Warn-App finden?",
+                                "anchor": "news",
+                                "active": false,
+                                "textblock": [
+                                    "Die Verfügbarkeit und Details zu neuen Versionen der Corona-Warn-App werden im <a href='../../blog/' target='_blank'>Blog</a> veröffentlicht, sobald die Updates in den Stores veröffentlicht wurden. (Siehe auch <a href='#where_to_get' target='_blank'>Wo bekomme ich die App?</a>.) Zusätzlich erscheinen bei Bedarf Informationen zu verschiedenen Themen, wie beispielsweise zu Verhaltensempfehlungen bei einer roten Kachel.",
+                                    "Des Weiteren werden Neuigkeiten über die Corona-Warn-App auf <a href='https://twitter.com/coronawarnapp' target='_blank' rel='noopener noreferrer'>Twitter</a> veröffentlicht. Insbesondere dort hat man als Nutzer die Möglichkeit, themenbezogene Fragen zu stellen und wird mit Hilfe der Community auf eine Antwort stoßen."
+                                ]
+                            },
+                            {
                                 "title": "In-App Statistiken ab Release 1.11",
                                 "anchor": "further_details",
                                 "active": false,


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2671 "FAQ #news backwards compatibility" by creating a new FAQ entry with `#news` as anchor. It also guides the user to where to find news about the app in:

1. the Blog https://www.coronawarn.app/en/blog/ (EN/DE) and
2. in the Twitter channel https://twitter.com/coronawarnapp (predominantly DE)

with an additional link to [#where_to_get](https://www.coronawarn.app/en/faq/results/#where_to_get) containing links to the App Store and Google Play Store.

The FAQ article is placed at the top of the list App Features > [Other features](https://www.coronawarn.app/en/faq/results/#other_features).

---
EN

![news_en](https://user-images.githubusercontent.com/66998419/161693245-8fda0031-a403-4497-adfd-80a2152487b4.jpg)

---
DE

![news_de](https://user-images.githubusercontent.com/66998419/161693280-abc266c6-e72f-4647-b355-f674e6893753.jpg)