### PR TITLE
Correct simple language FAQ definition

### DIFF
--- a/src/data/simple-language_de.json
+++ b/src/data/simple-language_de.json
@@ -78,7 +78,7 @@
                 "<hr/><picture><source media='(orientation: landscape)' srcset='../../assets/img/simple-language/header-faq.png'><source media='(orientation: portrait)' srcset='../../assets/img/simple-language/header-faq_mobile.png'><img src='../../assets/img/simple-language/header-faq.png' alt='FAQ' class='img-fluid'></picture>",
                 "Klicken Sie auf: <b>FAQ</b>",
                 "Es öffnet sich eine neue Internet-Seite.",
-                "Auf der Internet-Seite gibt es Informationen zu den Kennzahlen der Corona-Warn-App.",
+                "Auf der Internet-Seite gibt es Antworten zu den häufig gestellten Fragen der Corona-Warn-App.",
                 "<hr/><picture><source media='(orientation: landscape)' srcset='../../assets/img/simple-language/header-sign-language.png'><source media='(orientation: portrait)' srcset='../../assets/img/simple-language/header-sign-language_mobile.png'><img src='../../assets/img/simple-language/header-sign-language.png' alt='Gebärdensprachen-Symbol' class='img-fluid'></picture>",
                 "Klicken Sie auf das <b>Gebärdensprachen-Symbol.</b>",
                 "Es öffnet sich eine neue Internet-Seite.",


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2571 "Wrong text for FAQ simple language".

It corrects the definition for FAQ on https://www.coronawarn.app/de/simple-language/#usage as shown in the following screenshot:

![image](https://user-images.githubusercontent.com/66998419/161816158-54472913-c282-4de5-9caf-367e8521abf0.png)

The text is:

"Auf der Internet-Seite gibt es Antworten zu den häufig gestellten Fragen der Corona-Warn-App."
