### PR TITLE
Make nav-aside bigger

### DIFF
--- a/src/assets/scss/_nav.scss
+++ b/src/assets/scss/_nav.scss
@@ -24,7 +24,7 @@
   padding-left: 0;
   margin-bottom: 0;
   list-style: none;
-  max-height: calc(100vh - 120px);
+  max-height: calc(100vh - 50px);
   overflow-y: auto;
   display: block;
 }


### PR DESCRIPTION
Due to the issue: #2690 I made nav-aside more bigger.

- Before:

![Open-Source-Project-Corona-Warn-App-–-FAQ](https://user-images.githubusercontent.com/56647466/161966089-3c79bbce-d204-4b98-b652-b582b9d5dd2a.png)

- After: 

![Open-Source-Project-Corona-Warn-App-–-FAQ (1)](https://user-images.githubusercontent.com/56647466/161967117-a2523483-8a73-43d3-9686-0487dacf3d95.png)


 