### PR TITLE
Fix aside scroll in FAQ's results

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -97,7 +97,7 @@ $(document).ready(function(){
         if(item && item.offset()) {
             $(menu).scrollTop(item.offset().top - item.outerHeight() - 180)
         } else if(head && head.offset()) {
-            $(menu).scrollTop(head.offset().top - 30 - 180)
+            $(menu).scrollTop($(head).offset().top - $(menu).offset().top)
         }
     }, 500);
 


### PR DESCRIPTION
due to an issue [#2693](https://github.com/corona-warn-app/cwa-website/issues/2693) I fix the aside scroll in FAQ's results
here is a video showing the problem solved: https://user-images.githubusercontent.com/57190230/161992901-9a4b820c-665c-4554-8ed2-7fbaa6ba7aaf.mp4



 