### PR TITLE
Restore screenshot version text

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1632,7 +1632,7 @@
                                 "anchor": "dcc_ri_429",
                                 "active": false,
                                 "textblock": [
-                                    "Die Fehlermeldung mit dem Kode „DCC_RI_429“ tritt auf, wenn Sie mehr als drei Mal versuchen, ein Zertifikat neu auszustellen. Das könnte z.B. geschehen, wenn Sie sich auf mehreren Geräten das Zertifikat neu ausstellen lassen möchten. In diesem Fall können Sie den QR-Code des Zertifikates von einem anderen Gerät scannen, wenn Sie dort schon das neue, ausgetauschte Zertifikat erhalten haben.",
+                                    "Die Fehlermeldung mit dem Kode „DCC_RI_429“ tritt auf, wenn Sie mehr als drei Mal versuchen, ein Zertifikat neu auszustellen. Das könnte z.&nbsp;B. geschehen, wenn Sie sich auf mehreren Geräten das Zertifikat neu ausstellen lassen möchten. In diesem Fall können Sie den QR-Code des Zertifikates von einem anderen Gerät scannen, wenn Sie dort schon das neue, ausgetauschte Zertifikat erhalten haben.",
                                     "Wir empfehlen Ihnen wegen dieser Beschränkung das neu ausgestellte Zertifikat als PDF-Datei zu exportieren und auszudrucken, damit Sie bei Bedarf den QR-Code des Zertifikats erneut einscannen können (siehe <a href='#eu_dcc_export' target='_blank' >\"Wie erstelle ich einen Ausdruck meines Digitalen COVID Zertifikates der EU?\"</a>).",
                                     "Siehe auch: <a href='#dcc_replacement' target='_blank' >\"Können Zertifikate über die App aktualisiert werden?\"</a>"
                                 ]

--- a/src/partials/text-component.html
+++ b/src/partials/text-component.html
@@ -11,6 +11,8 @@
 {{#if textblock}}
 {{#each textblock}}
 <p>{{{.}}}</p>
+<h4 class="headline">{{head}}</h4>
+{{{block}}}
 {{/each}}
 {{/if}}
 {{#if textcaption}}

--- a/src/partials/text-component.html
+++ b/src/partials/text-component.html
@@ -11,8 +11,6 @@
 {{#if textblock}}
 {{#each textblock}}
 <p>{{{.}}}</p>
-<h4 class="headline">{{head}}</h4>
-{{{block}}}
 {{/each}}
 {{/if}}
 {{#if textcaption}}

--- a/src/partials/text-component.html
+++ b/src/partials/text-component.html
@@ -10,8 +10,7 @@
 {{/if}}
 {{#if textblock}}
 {{#each textblock}}
-    <h4 class="headline">{{head}}</h4>
-    {{{block}}}
+<p>{{{.}}}</p>
 {{/each}}
 {{/if}}
 {{#if textcaption}}


### PR DESCRIPTION
One change of #2449 caused the text describing the versions changes on the screenshots page to disappear. This PR reverts that change to restore the text.

In addition, I have corrected an abbreviation in the recently published FAQ "dcc_ri_429", so that it matches [DIN 5008](https://de.wikipedia.org/wiki/DIN_5008#Abk%C3%BCrzungen_(Abschnitt_4.5)) @MikeMcC399 https://github.com/corona-warn-app/cwa-website/pull/2720#issuecomment-1094584913