### PR TITLE
Correct Science Blog DE abbreviations

### DIFF
--- a/science/2021-06-15-science-blog-1/index_de.md
+++ b/science/2021-06-15-science-blog-1/index_de.md
@@ -87,7 +87,7 @@ Testergebnis ohne Verzögerung erhalten,
 
 Personen, die ein positives Testergebnis erhalten haben, sollen andere
 Personen, die sich in ihrer unmittelbaren Nähe aufgehalten haben,
-darüber informieren bzw. warnen, dass für sie (d.h. für die anderen
+darüber informieren bzw. warnen, dass für sie (d.&nbsp;h. für die anderen
 Personen) ein erhöhtes Infektionsrisiko bestanden hat,
 
 **Zweck 3 – Risikoermittlung**
@@ -303,7 +303,7 @@ Daten aus zentralen und dezentralen Komponenten der
 Corona-Warn-App-Infrastruktur sowie auf externe Quellen bezogen.
 
 Für die Evaluation im Hinblick auf Zweckmäßigkeit, Wirksamkeit,
-Akzeptanz und Nutzen ist u.a. die Erhebung und Auswertung folgender
+Akzeptanz und Nutzen ist u.&nbsp;a. die Erhebung und Auswertung folgender
 Kennzahlen (kumulativ und im Zeitverlauf) vorgesehen:
 
 -   Kennzahlen aus Nutzenden-Erhebung (EDUS und PPA)  
@@ -369,7 +369,7 @@ werden seit Anfang März 2021 erhoben.
 Konkret können mit Hilfe der Datenspende folgende Aspekte untersucht
 werden:
 
--   welche Ereignisse (z.B. Anzeige eines erhöhten Risikos,
+-   welche Ereignisse (z.&nbsp;B. Anzeige eines erhöhten Risikos,
     Registrierung eines Tests, Anzeige eines Testergebnisses,
     Schlüsseleinreichung zum Warnen Anderer) in der App mit welcher
     Häufigkeit auftreten,
@@ -381,7 +381,7 @@ werden:
 
 -   wo und wann Nutzende Prozesse innerhalb der App abbrechen,
 
--   mit welchen demografischen Daten (z.B. Altersgruppe, Landkreis) dies
+-   mit welchen demografischen Daten (z.&nbsp;B. Altersgruppe, Landkreis) dies
     assoziiert ist.
 
 
@@ -397,7 +397,7 @@ CWA-Infrastruktur.
 
 Dem RKI stehen weitere Kennzahlen aus ergänzenden Quellen zur Verfügung,
 die indirekte Belege für den Nutzen der Corona-Warn-App liefern können.
-Hierzu zählen u.a. Daten aus dem Apple App Store sowie Google Play
+Hierzu zählen u.&nbsp;a. Daten aus dem Apple App Store sowie Google Play
 Store. Zudem lassen sich externe (Befragungs-)Studien mit
 unterschiedlichen Studienzeiträumen und thematischen Schwerpunkten
 heranziehen. Externe Studien weisen zwar verschiedene methodische und

--- a/science/2021-07-08-science-blog-2/index_de.md
+++ b/science/2021-07-08-science-blog-2/index_de.md
@@ -810,7 +810,7 @@ Für den Vergleich mit SARS-CoV-2-Neuinfektionen müssen die dreistelligen Postl
 
 ### 5.2 Unterschiede zwischen urbanen und ländlichen Landkreisen
 
-Die folgende Abbildung zeigt den Zusammenhang zwischen der Bevölkerungsdichte und der „Inzidenz” der Teilnehmenden, d.h. der Anzahl der Teilnehmenden pro 100.000 Einwohner. Die Größe eines Landkreises ist dabei proportional zur Einwohnerzahl.
+Die folgende Abbildung zeigt den Zusammenhang zwischen der Bevölkerungsdichte und der „Inzidenz” der Teilnehmenden, d.&nbsp;h. der Anzahl der Teilnehmenden pro 100.000 Einwohner. Die Größe eines Landkreises ist dabei proportional zur Einwohnerzahl.
 
 <div class="figure" alt="EDUS Teilnehmende nach Bevölkerungsdichte in städtischen und ländlichen des Landkreisen.">
 <div id="htmlwidget-plotly-ab98e7e8f5de4f99ed67" style="width:80%;height:80%;" class="plotly html-widget"></div>
@@ -912,7 +912,7 @@ Mosaik-Plots sind ein graphisches Verfahren zur Visualisierung von Datensätzen 
 -   Die Größe der einzelnen Rechtecke ist proportional zur Häufigkeit der jeweiligen Merkmalskombination.
 -   Die Färbung der einzelnen Rechtecke gibt Informationen über die standardisierte Abweichung der beobachteten und erwarteten Häufigkeiten, die sogenannten Pearson-Residuen.
 
-Jedes Rechteck innerhalb des Mosaik-Plots steht für eine Merkmalskombination. Die Farbe der Rechtecke hängt von den Pearson-Residuen ab. Sind diese signifikant, wird das jeweilige Rechteck eingefärbt. Ist die Abweichung sehr groß, ist der Farbton des betroffenen Rechtecks intensiver. Die Farbe Violett steht für eine signifikante Abweichung nach oben, die Farbe Grün steht für eine signifikante Abweichung nach unten. Sind die Rechtecke weiß, liegt keine signifikante Abweichung vor, d.h., die beobachteten und erwarteten Häufigkeiten liegen nah beieinander.
+Jedes Rechteck innerhalb des Mosaik-Plots steht für eine Merkmalskombination. Die Farbe der Rechtecke hängt von den Pearson-Residuen ab. Sind diese signifikant, wird das jeweilige Rechteck eingefärbt. Ist die Abweichung sehr groß, ist der Farbton des betroffenen Rechtecks intensiver. Die Farbe Violett steht für eine signifikante Abweichung nach oben, die Farbe Grün steht für eine signifikante Abweichung nach unten. Sind die Rechtecke weiß, liegt keine signifikante Abweichung vor, d.&nbsp;h., die beobachteten und erwarteten Häufigkeiten liegen nah beieinander.
 
 Auf der rechten Seite des Mosaik-Plots befindet sich eine Legende, die zwei Informationen beinhaltet:
 

--- a/science/2021-08-02-science-blog-3/index_de.md
+++ b/science/2021-08-02-science-blog-3/index_de.md
@@ -35,7 +35,7 @@ In zweiten Teil der Analyse der ereignisbezogenen Online-Befragung (Event-Driven
 
 ## 1 Das Wichtigste in Kürze: Zahlen, Daten, Fakten
 
-Der zweite Teil der ereignisbezogenen Befragung (EDUS) hat u.a. ergeben, dass
+Der zweite Teil der ereignisbezogenen Befragung (EDUS) hat u.&nbsp;a. ergeben, dass
 
 <ul><li>ein signifikanter Anteil der Befragten (72,5%) von der <q>roten Warnung</q> überrascht war,</li>
 <li>die Befragten ihre Testergebnisse meistens innerhalb von 24 Stunden über die App erhielten,</li>
@@ -2419,7 +2419,7 @@ Die Daten geben keine Hinweise auf statistisch signifikante Verhaltensunterschie
 
 ### 4.4 Übersicht zum Gesamttestprozess
 
-Die folgende interaktive Grafik (Sankey-Diagramm) verdeutlich die Aufteilung der Antworten auf Fragen zur Testung über die Basis- und Folgebefragung. Sankey-Diagramme sind eine spezifische Art Flussdiagramm. Flussmengen werden durch mengenproportionale Pfeile dargestellt, deren Dicke die maßstabsgerechte Menge repräsentiert. Die Flüsse verlaufen zwischen zwei Knoten, die als Zwischenstufen fungieren und u.a. Auskunft über die Struktur des beschriebenen Systems geben.
+Die folgende interaktive Grafik (Sankey-Diagramm) verdeutlich die Aufteilung der Antworten auf Fragen zur Testung über die Basis- und Folgebefragung. Sankey-Diagramme sind eine spezifische Art Flussdiagramm. Flussmengen werden durch mengenproportionale Pfeile dargestellt, deren Dicke die maßstabsgerechte Menge repräsentiert. Die Flüsse verlaufen zwischen zwei Knoten, die als Zwischenstufen fungieren und u.&nbsp;a. Auskunft über die Struktur des beschriebenen Systems geben.
 
 <div class="figure" alt="EDUS – CWA Testprozess, von Testvorhaben über Testart, tatsächlich durchgeführtem Test, Testergebnis, Testerhalt via CWA bis Teilung.">
 <div id="htmlwidget-networkD3-27894f19b2bee56740ed" style="width:100%;height:700px;" class="sankeyNetwork html-widget"></div>
@@ -3003,5 +3003,3 @@ Wir bedanken uns an dieser Stelle noch einmal ganz herzlich bei allen Nutzenden,
 ## 7 So geht es weiter
 
 In den kommenden Wochen werden wir uns hier im Science Blog mit dem Thema <q>Datenspende</q> der Corona-Warn-App beschäftigen. Wir wollen analysieren, inwieweit das freiwillige, datenschutzkonforme Bereitstellen von Nutzenden-Daten Erkenntnisse über das Nutzungsverhalten möglich macht. Außerdem werden wir zeigen, wie die Datenspende bei der Weiterentwicklung der Corona-Warn-App geholfen hat.
-
-

--- a/science/2021-10-15-science-blog-4/index_de.md
+++ b/science/2021-10-15-science-blog-4/index_de.md
@@ -75,7 +75,7 @@ Die CWA-Datenspende hilft zu verstehen,
 2.	wann diese Ereignisse auftreten und wie bzw. mit welchem zeitlichen Abstand (Verzug) sie aufeinander folgen,
 3.	welche Auswahlen die Nutzenden in der App daraufhin treffen,
 4.	wo und wann es zu Abbrüchen kommt,
-5.	und ob all dies mit technischen Eigenschaften der Geräte oder demografischen Eigenschaften (z.B. Altersgruppe, Wohnregion) der Nutzenden zusammenhängt.
+5.	und ob all dies mit technischen Eigenschaften der Geräte oder demografischen Eigenschaften (z.&nbsp;B. Altersgruppe, Wohnregion) der Nutzenden zusammenhängt.
 
 Mit diesem Verständnis können:
 

--- a/science/2022-03-03-science-blog-5/index_de.md
+++ b/science/2022-03-03-science-blog-5/index_de.md
@@ -259,7 +259,7 @@ Freiwillige Datenspende (Privacy-Preserving-Analytics (PPA))
 1.14
 </td>
 <td style="text-align:left;width: 11cm; ">
-Erweiterung des Kontakt-Tagebuchs (u.a. Pop-Up-Menü), Erweiterung der freiwilligen Datenspende (neue Datenpunkte)
+Erweiterung des Kontakt-Tagebuchs (u.&nbsp;a. Pop-Up-Menü), Erweiterung der freiwilligen Datenspende (neue Datenpunkte)
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2725 "German abbreviations non-conformant to DIN 5008 in blogs" in https://www.coronawarn.app/de/science/, the German language Science Blog.

It changes the following abbreviations:

- `u.a.` => `u.&nbsp;a.`
- `d.h.` => `d.&nbsp;h.`
- `z.B.` => `z.&nbsp;B.`

in the following Science Blog articles:

- https://www.coronawarn.app/de/science/2021-06-15-science-blog-1/
- https://www.coronawarn.app/de/science/2021-07-08-science-blog-2/
- https://www.coronawarn.app/de/science/2021-08-02-science-blog-3/
- https://www.coronawarn.app/de/science/2021-10-15-science-blog-4/
- https://www.coronawarn.app/de/science/2022-03-03-science-blog-5/