### PR TITLE
Remove FAQ entries `val_service_no_valid_dcc` & `val_service_result`, add redirect to `val_service_basics` & add update to `val_service_basics`

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -800,71 +800,11 @@
                                 "anchor": "val_service_basics",
                                 "active": false,
                                 "textblock": [
+                                    "<b>UPDATE January 10, 2022</b><br/> The Europe-wide requirements for online verification services have already been in place since October 2021. In Germany, <b>no provider of an online verification service has been approved yet</b>. Tests are currently being carried out, the results of which are being awaited for the time being. Online verification services will not be available in practice until these tests have been evaluated and the Federal Commissioner for Data Protection and Freedom of Information (BfDI) has provided advice. With version 2.15, however, the CWA is ready to support corresponding verification services as soon as providers of such a service are approved.<hr/>",
                                     "<b>What is a DCC validation service? </b>",
                                     "Companies must comply with legal requirements to protect the health of employees and customers. In the pandemic, they therefore need reliable access management for business premises, factory halls, aircraft, trams, hotels and restaurants or events for instance. They need to be able to verify the authenticity of Digital COVID Certificates (DCCs) quickly and easily. This is served by a Validation Service.  The Federal Ministry of Health (Bundesministerium für Gesundheit, BMG) has decided to enable several validation services after appropriate verification.",
                                     "<b>When does a DCC validation service bring advantages over the certificate check with the CovPassCheck-App, for example?</b>",
-                                    "The advantage can be seen, for example, in the purchase of an event ticket. If the buyer requires a valid certificate for the event visit, they can carry out the certificate check immediately upon purchase. The certificate check at the event location is omitted. This saves waiting times, avoids long queues at the entrance control and ultimately contributes to reducing the risk of infection. If the service is accessed directly from the Corona-Warn-App or, in the future, from the CovPass-App, it makes it possible to validate the DCC without having to upload it to the ticket provider. Thus, the service contributes to the most data-saving use of the DCCs.",
-                                    "<b>How does a DCC validation service work?</b>",
-                                    "Via an interface and a secure connection, the Corona-Warn-App and in the future also the CovPass-App use encrypted communication with a validation service. This checks the certificate for validity and only transmits the result of the check (not the certificate itself) back to the buyer and the event organizer. The latter authorizes the purchase of the ticket after successful verification. This allows the customer to successfully complete the purchase.",
-                                    "The check is technically similar to the procedure of the CovPassCheck-App. Only that the check does not run on the check app, but on a validation server. The DCC validation service deletes the personal data for a validation process effectively and immediately after each verification process completes.",
-                                    "If the check fails, the validation service informs the buyer of the reason. The event organizer does not receive this information. However, they are informed that the examination was not successful.",
-                                    "<b>Where does the validation process take place?</b>",
-                                    "On a validation server operated by a strictly ISO 27001 certified organization.",
-                                    "<b>Does the DCC validation server store personal data?</b>",
-                                    "No. The check itself takes place on-the-fly in the memory of the validation service server. The memory areas involved are automatically cleaned up. Also the log files involved do not store any personal data or information about the certificates. For billing purposes, the technology only documents that a check has been carried out for the ticket provider. Again, no personal data is processed. The only remaining storage location of a certificate is the user's smartphone.",
-                                    "<b>Is the documentation of the validation service publicly available? </b>",
-                                    "For validation services to be interoperable throughout Europe, the EU has published the document <a href='https://ec.europa.eu/health/sites/health/files/ehealth/docs/covid-certificate_traveller-onlinebooking_en.pdf' target='_blank' rel='noopener noreferrer'>Guidelines on the use of Digital Covid Certificates in traveller and online booking scenarios</a> which specifies the software architecture and the requirements.",
-                                    "<b>Is the validation service open source?</b>",
-                                    "The EU has commissioned a reference implementation. This can be used by institutions and companies that want to operate a validation service themselves. The source code is publicly available on <a href='https://github.com/eu-digital-green-certificates/dgca-validation-service' target='_blank' rel='noopener noreferrer'>GitHub: EU Digital COVID Certificate Validation Service</a>.",
-                                    "<b>What does data protection look like for the DCC validation service?</b>",
-                                    "The providers of validation services must comply with the provisions of the General Data Protection Regulation (GDPR).",
-                                    "<b>Is the DCC validation service a new feature of the Corona-Warn-App?</b>",
-                                    "The DCC validation service is not a new app feature. With CWA version 2.15, only the technical possibility was created to access a validation service for checking DCCs as part of booking processes.",
-                                    "<b>Is the use of a DCC validation service voluntary?</b>",
-                                    "Yes. In the Corona-Warn-App and in future also in the CovPass-App, a user explicitly declares their consent before calling up the validation service. Just as with the access check, for example when entering a restaurant, the user decides for themself whether they want to prove a certificate for verification purposes or not.",
-                                    "<b>Is there an approval process for DCC validation service providers?</b>",
-                                    "Interested companies can go through a test procedure at the BMG. The procedure is open to all providers.",
-                                    "<b>Which companies already offer a DCC validation service?</b>",
-                                    "The first provider is T-Systems. The model is deliberately designed to be open to the market and allows several providers. The verification of certificates makes an important contribution to the fight against the pandemic. With competition, we want to support the fastest possible dissemination of validation services.",
-                                    "Currently, access to the T-Systems validation service from the Corona-Warn-App is being actively tested in preparation for productive use for customers of the validation service (e.g., event organizers, companies).",
-                                    "<b>Which customers are already using a DCC validation service?</b>",
-                                    "Customers or providers will publish this information themselves, independently.",
-                                    "<hr/>",
-                                    "See also the following FAQ-articles:",
-                                    "<ul>",
-                                    "<li><a href='#val_service_no_valid_dcc' target='_blank'>Why do I get the message that there is no suitable certificate?</a></li>",
-                                    "<li><a href='#val_service_result' target='_blank'>Why is my certificate not verifiable or not recognized?</a></li>",
-                                    "</ul>"
-
-                                ]
-                            },
-                            {
-                                "title": "Why do I get the message that there is no suitable certificate?",
-                                "anchor": "val_service_no_valid_dcc",
-                                "active": false,
-                                "textblock": [
-                                    "The app checks whether your certificates meet the requirements of the booking system. Various parameters are checked. First, the type of your certificate must meet the requirements of the booking system. To do this, find out about the accepted certificates from your ticket provider, add the appropriate certificates in the app if you have not already done so, and make sure that your certificates are valid.",
-                                    "<b>What should you be aware of?</b>",
-                                    "You should make sure that the name shown in the certificate you want to use for verification corresponds exactly to the name you have specified in the booking system. If this is not the case, it is not possible to select the corresponding certificate in the Corona-Warn-App. For example, if both your first and middle names are shown in your certificate, you should also specify both names when booking the ticket. If you only enter one name, the Corona-Warn-App cannot recognize that it is the same person. If your certificate is no longer valid or contains spelling errors or a wrong date of birth, contact the issuer of the certificate to obtain a new certificate. If you have any other questions, please contact the ticket provider."
-                                ]
-                            },
-                            {
-                                "title": "Why is my certificate not verifiable or not recognized?",
-                                "anchor": "val_service_result",
-                                "active": false,
-                                "textblock": [
-                                    "<b>Not recognized</b>",
-                                    "If you receive the message 'Certificate not recognized' as the result of the validation check, then the certificate is technically valid but does not meet the requirements of the provider.",
-                                    "This can be due to several reasons. Possible reasons are, for example:",
-                                    "<ul>",
-                                    "<li>An antigen test is older than 48 hours and has therefore lost its validity</li>",
-                                    "<li>The certificate was not issued by a certified test center</li>",
-                                    "</ul>",
-                                    "<b>Certificate not verifiable</b>",
-                                    "If you receive the message 'Certificate not verifiable' as the result of the validation check, this may be for technical reasons. In this case, your certificate may be technically outdated or there may be a lack of data within the certificate that is needed for verification.",
-                                    "In this case you can contact the issuer of your certificate to obtain a new certificate.",
-                                    "<b>Successful exam</b>",
-                                    "The certificate has been successfully verified and meets the requirements of the provider."
+                                    "The advantage can be seen, for example, in the purchase of an event ticket. If the buyer requires a valid certificate for the event visit, they can carry out the certificate check immediately upon purchase. The certificate check at the event location is omitted. This saves waiting times, avoids long queues at the entrance control and ultimately contributes to reducing the risk of infection. If the service is accessed directly from the Corona-Warn-App or, in the future, from the CovPass-App, it makes it possible to validate the DCC without having to upload it to the ticket provider. Thus, the service contributes to the most data-saving use of the DCCs."
                                 ]
                             }
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -800,71 +800,11 @@
                                 "anchor": "val_service_basics",
                                 "active": false,
                                 "textblock": [
+                                    "<b>AKTUELL 10. Januar 2022</b><br/>Bereits seit Oktober 2021 liegen die europaweit gültigen Anforderungen an Onlineverifikationsdienste vor. In Deutschland ist momentan <b>noch kein Anbieter eines Onlineverifikationsdienstes zugelassen</b> worden. Derzeit erfolgen Tests, deren Ergebnisse zunächst abgewartet werden. Erst nach einer Auswertung dieser Tests und nach erfolgter Beratung durch den Bundesbeauftragten für den Datenschutz und die Informationsfreiheit (BfDI), werden Onlineverifikationsdienste in der Praxis verfügbar sein. Mit Version 2.15 ist die CWA aber bereit, entsprechende Verifikationsdienste zu unterstützen, sobald Anbieter eines solchen Dienstes zugelassen sind.<hr/>",
                                     "<b>Was ist ein DCC-Validierungsservice?</b>",
                                     "Unternehmen müssen gesetzliche Vorgaben zum Schutz der Gesundheit von Belegschaft und Kund*innen einhalten. Sie benötigen daher in der Pandemie ein verlässliches Zutrittsmanagement für beispielsweise Geschäftsräume, Werkshallen, Flugzeuge, Straßenbahnen, Hotels und Restaurants oder Veranstaltungen. Sie müssen schnell und unkompliziert die Echtheit von Digitalen COVID-Zertifikaten (DCCs) überprüfen können. Dem dient ein Corona Validation Service. Das Bundesministerium für Gesundheit (BMG) hat entschieden, mehrere Validation Services nach entsprechender Prüfung zu ermöglichen.",
                                     "<b>Wann bringt ein DCC-Validierungsservice Vorteile etwa gegenüber dem Zertifikatcheck mit der CovPassCheck-App?</b>",
-                                    "Der Vorteil zeigt sich zum Beispiel beim Kauf eines Event-Tickets. Braucht der Käufer für den Event-Besuch ein gültiges Zertifikat, kann er den Zertifikat-Check sofort beim Kauf durchführen. Die Zertifikatsprüfung vor der Event-Location entfällt. Das spart Wartezeiten, vermeidet lange Schlangen bei der Einlasskontrolle und trägt so letztlich auch zur Senkung des Infektionsrisikos bei. Wenn der Service direkt aus der Corona-Warn-App oder zukünftig aus der CovPass-App heraus aufgerufen wird, ermöglicht er es, das DCC zu validieren, ohne dass es dabei zu dem Ticketanbieter hochgeladen werden muss. Somit trägt der Service zu einer möglichst datensparsamen Verwendung der DCCs bei.",
-                                    "<b>Wie funktioniert ein DCC-Validierungsservice?</b>",
-                                    "Über eine Schnittstelle und eine gesicherte Verbindung kommuniziert die Corona-Warn-App und in Zukunft auch die CovPass-App verschlüsselt mit einem Validierungsservice. Dieser prüft das Zertifikat auf Gültigkeit und übermittelt nur das Prüfergebnis (nicht das Zertifikat selbst) zurück an den Käufer sowie an den Eventveranstalter. Letzterer autorisiert nach erfolgreicher Prüfung den Erwerb des Tickets. So kann der Kunde den Kauf erfolgreich abschließen.",
-                                    "Die Prüfung gleicht technisch dem Verfahren der CovPassCheck-App. Nur dass die Prüfung nicht auf der Check-App, sondern einem Validierungsserver läuft. Der DCC-Validierungsservice löscht die personenbezogenen Daten zu einem Validierungsvorgang effektiv und unverzüglich nach einem Prüfvorgang.",
-                                    "Schlägt die Prüfung fehl, informiert der Validierungsservice den Käufer über den Grund. Der Eventveranstalter erhält diese Information nicht. Er wird aber darüber informiert, dass die Prüfung nicht erfolgreich war.",
-                                    "<b>Wo findet der Validierungsprozess statt?</b>",
-                                    "Auf einem Validierungsserver, der von einer streng nach ISO 27001-zertifizierten Organisation betrieben wird.",
-                                    "<b>Speichert der DCC-Validierungsserver personenbezogene Daten?</b>",
-                                    "Nein. Die Prüfung selbst findet on-the-fly im Arbeitsspeicher des Servers des Validierungsservices statt. Die beteiligten Speicherbereiche werden automatisiert bereinigt. Auch beteiligte Logfiles speichern keine personenbezogenen Daten oder Informationen zu den Zertifikaten. Zu Abrechnungszwecken dokumentiert die Technik nur, dass eine Prüfung für den Ticketanbieter durchgeführt wurde. Auch hierbei werden keine personenbezogenen Daten verarbeitet. Einzig verbleibender Speicherort eines Zertifikats ist das Smartphone des Nutzers.",
-                                    "<b>Ist die Dokumentation des Validierungs-Dienstes öffentlich zugänglich? </b>",
-                                    "Damit Validierungs-Dienste europaweit interoperabel sind, wurde eine Spezifikation zur Softwarearchitektur und zu den erfüllenden Anforderungen in Form einer EU-Guideline erstellt. Diese ist unter dem englischen Titel: <a href='https://ec.europa.eu/health/sites/health/files/ehealth/docs/covid-certificate_traveller-onlinebooking_en.pdf' target='_blank' rel='noopener noreferrer'>Guidelines on the use of Digital Covid Certificates in traveller and online booking scenarios</a> abrufbar.",
-                                    "<b>Ist der Validierungsservice Open-Source?</b>",
-                                    "Die EU hat eine Referenzimplementierung in Auftrag gegeben. Diese kann von Institutionen und Unternehmen verwendet werden, die selbst einen Validierungsservice betreiben möchten. Der Quellcode ist öffentlich auf GitHub unter dem Titel <a href='https://github.com/eu-digital-green-certificates/dgca-validation-service' target='_blank' rel='noopener noreferrer'>EU Digital COVID Certificate Validation Service</a> einsehbar.",
-                                    "<b>Wie sieht der Datenschutz beim DCC-Validierungsservice aus?</b>",
-                                    "Die Anbieter von Validierungsdiensten müssen sich nach den Regelungen der Datenschutzgrundverordnung (DSGVO) richten.",
-                                    "<b>Ist der DCC-Validierungsservice ein neues Feature der Corona-Warn-App?</b>",
-                                    "Der DCC-Validierungsservice ist kein neues App-Feature. Mit der CWA Version 2.15 wurde lediglich die technische Möglichkeit geschaffen, im Rahmen von Buchungsprozessen auf einen Validierungsservice zur Prüfung von DCCs zuzugreifen.",
-                                    "<b>Ist die Nutzung eines DCC-Validierungsservices freiwillig?</b>",
-                                    "Ja. In der Corona-Warn-App und in Zukunft auch in der CovPass-App erklärt ein Nutzer explizit seine Einwilligung, bevor er den Validierungsvorgang startet. Ebenso wie bei der Zutrittskontrolle etwa beim Betreten eines Restaurants entscheidet der Nutzer selbst, ob er ein Zertifikat zu Prüfzwecken nachweisen möchte oder nicht.",
-                                    "<b>Gibt es ein Zulassungsverfahren für Anbieter eines DCC-Validierungsservices?</b>",
-                                    "Interessierte Unternehmen können ein Prüfverfahren beim BMG durchlaufen. Das Verfahren ist für alle Anbieter offen.",
-                                    "<b>Welche Unternehmen bieten bereits einen DCC-Validierungsservice an?</b>",
-                                    "Erster Anbieter ist T-Systems. Das Modell ist bewusst marktoffen gestaltet und lässt mehrere verschiedene Anbieter zu. Die Überprüfung von Zertifikaten leistet einen wichtigen Beitrag im Kampf gegen die Pandemie. Mit Wettbewerb wollen wir eine möglichst schnelle Verbreitung von Validierungs-Diensten unterstützen.",
-                                    "Derzeit wird der Zugriff aus der Corona-Warn-App heraus auf diesen Validierungsservice der T-Systems als Vorbereitung für den produktiven Einsatz bei Kunden des Validierungsservice (z.&nbsp;B. Veranstalter*innen, Unternehmen) aktiv getestet.",
-                                    "<b>Welche Kunden nutzen bereits einen DCC-Validierungsservice?</b>",
-                                    "Dies werden Kunden bzw. Anbieter in eigener Verantwortung veröffentlichen.",
-                                    "<hr/>",
-                                    "Siehe auch folgende FAQ-Artikel:",
-                                    "<ul>",
-                                    "<li><a href='#val_service_no_valid_dcc' target='_blank'>Warum erhalte ich die Meldung, dass kein geeignetes Zertifikat vorhanden ist?</a></li>",
-                                    "<li><a href='#val_service_result' target='_blank'>Warum ist mein Zertifikat nicht prüfbar oder wird nicht anerkannt?</a></li>",
-                                    "</ul>"
-
-                                ]
-                            },
-                            {
-                                "title": "Warum erhalte ich die Meldung, dass kein geeignetes Zertifikat vorhanden ist?",
-                                "anchor": "val_service_no_valid_dcc",
-                                "active": false,
-                                "textblock": [
-                                    "Die App überprüft, ob Ihre Zertifikate den Anforderungen des Buchungssystems entsprechen. Dabei werden verschiedene Parameter geprüft. Zunächst muss der Typ Ihres Zertifikats den Anforderungen des Buchungssystems entsprechen. Informieren Sie sich hierzu über die akzeptierten Zertifikate bei Ihrem Ticketanbieter, fügen Sie die entsprechenden Zertifikate in der App hinzu, sofern noch nicht geschehen und stellen Sie sicher, dass Ihre Zertifikate gültig sind.",
-                                    "<b>Was sollten Sie beachten?</b>",
-                                    "Sie sollten unbedingt darauf achten, dass der Name, der im Zertifikat, das Sie zur Überprüfung benutzen wollen, hinterlegt ist, exakt dem Namen entspricht, den Sie im Buchungssystem angegeben haben. Ist das nicht der Fall, können Sie das entsprechende Zertifikat in der Corona-Warn-App nicht auswählen. Haben Sie Ihrem Zertifikat beispielsweise Ihren ersten und zweiten Vornamen hinterlegt, sollten Sie beide Namen auch bei der Ticketbuchung angeben. Geben Sie nur einen Namen an, kann die Corona-Warn-App nicht erkennen, dass es sich um ein und dieselbe Person handelt.",
-                                    "Wenn Ihr Zertifikat nicht mehr gültig ist oder Rechtschreibfehler/Zahlendreher enthält, wenden Sie sich an den Aussteller des Zertifikats, um ein neues Zertifikat zu erhalten. Bei anderweitigen Rückfragen wenden Sie sich an den Ticketanbieter."
-                                ]
-                            },
-                            {
-                                "title": "Warum ist mein Zertifikat nicht prüfbar oder wird nicht anerkannt?",
-                                "anchor": "val_service_result",
-                                "active": false,
-                                "textblock": [
-                                    "<b>Nicht anerkannt</b>",
-                                    "Wenn Sie als Ergebnis der Gültigkeitsprüfung die Meldung „Zertifikat nicht anerkannt“ erhalten, dann ist das Zertifikat technisch gültig aber entspricht nicht den Anforderungen des Anbieters.",
-                                    "<ul>",
-                                    "<li>Ein Antigentest ist älter als 48 Stunden und hat somit seine Gültigkeit verloren</li>",
-                                    "<li>Das Zertifikat wurde nicht von einem zertifizierten Testzentrum ausgestellt</li>",
-                                    "</ul>",
-                                    "<b>Zertifikat nicht prüfbar</b>",
-                                    "Wenn Sie als Ergebnis der Gültigkeitsprüfung die Meldung „Zertifikat nicht prüfbar“ erhalten, kann dies technische Gründe haben. Ihr Zertifikat ist in diesem Fall möglicherweise technisch veraltet oder es fehlen Daten innerhalb des Zertifikats, die zur Überprüfung benötigt werden.",
-                                    "Hier können Sie sich an den Aussteller Ihres Zertifikats wenden, um ein neues Zertifikat zu erhalten und den Ticketanbieter kontaktieren, wenn das Problem weiterhin bestehen sollte.",
-                                    "<b>Erfolgreiche Prüfung</b>",
-                                    "Das Zertifikat wurde erfolgreich überprüft und entspricht den Anforderungen des Anbieters."
+                                    "Der Vorteil zeigt sich zum Beispiel beim Kauf eines Event-Tickets. Braucht der Käufer für den Event-Besuch ein gültiges Zertifikat, kann er den Zertifikat-Check sofort beim Kauf durchführen. Die Zertifikatsprüfung vor der Event-Location entfällt. Das spart Wartezeiten, vermeidet lange Schlangen bei der Einlasskontrolle und trägt so letztlich auch zur Senkung des Infektionsrisikos bei. Wenn der Service direkt aus der Corona-Warn-App oder zukünftig aus der CovPass-App heraus aufgerufen wird, ermöglicht er es, das DCC zu validieren, ohne dass es dabei zu dem Ticketanbieter hochgeladen werden muss. Somit trägt der Service zu einer möglichst datensparsamen Verwendung der DCCs bei."
                                 ]
                             }
                         ]

--- a/src/data/faq_redirects.json
+++ b/src/data/faq_redirects.json
@@ -14,5 +14,7 @@
     "vac_cert_booster": "vac_cert",
     "test_cert_index": "test_cert",
     "check_in_index": "check_in",
-    "dissimilar_indication_of_risk_status": "risk_encounter_different_devices"
+    "dissimilar_indication_of_risk_status": "risk_encounter_different_devices",
+    "val_service_no_valid_dcc": "val_service_basics",
+    "val_service_result": "val_service_basics"
 }


### PR DESCRIPTION
## Description

This PR removes the FAQ entries `val_service_no_valid_dcc` & `val_service_result`, adds a redirect from these entries to `val_service_basics`.
It also removes multiple paragraphs from `val_service_basics` and adds an update to this FAQ entry.

## What was changed

- https://www.coronawarn.app/de/faq/results/#val_service_no_valid_dcc was deleted
- https://www.coronawarn.app/en/faq/results/#val_service_no_valid_dcc was delted
- https://www.coronawarn.app/de/faq/results/#val_service_result was deleted
- https://www.coronawarn.app/en/faq/results/#val_service_result was deleted
- FAQ redirects from https://www.coronawarn.app/en/faq/results/#val_service_no_valid_dcc & https://www.coronawarn.app/en/faq/results/#val_service_result to https://www.coronawarn.app/en/faq/results/#val_service_basics were added
-  FAQ redirects from https://www.coronawarn.app/de/faq/results/#val_service_no_valid_dcc & https://www.coronawarn.app/de/faq/results/#val_service_result to https://www.coronawarn.app/de/faq/results/#val_service_basics were added
- https://www.coronawarn.app/de/faq/results/#val_service_basics was updated to include information on the current status of this feature
- https://www.coronawarn.app/de/faq/results/#val_service_basics was updated to include information on the current status of this feature

## Screenshots

| English | German |
|---|---|
| <img width="791" alt="English" src="https://user-images.githubusercontent.com/67682506/162766999-2160cb31-fb2f-49bf-8128-6c5acff89bc4.png"> | <img width="791" alt="German" src="https://user-images.githubusercontent.com/67682506/162767010-0a8ba0f8-4834-4b60-8309-5b786a4333e0.png"> |

## Important information
This PR is currently in draft status as I want to get another text for the update, which better reflects the current situation.

---

**Fixes #2624**