### PR TITLE
Add soft hyphens to long DE FAQ  titles

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -732,7 +732,7 @@
                         ]
                     },
                     {
-                        "title": "Statusnachweis",
+                        "title": "Status&shy;nachweis",
                         "id": "status_proof",
                         "indexed": true,
                         "accordion": [
@@ -1181,7 +1181,7 @@
                         ]
                     },
                     {
-                        "title": "Impfempfehlung",
+                        "title": "Impfemp&shy;fehlung",
                         "id": "vaccination_recommendation",
                         "indexed": true,
                         "accordion": [
@@ -1318,7 +1318,7 @@
                         ]
                     },
                     {
-                        "title": "Verfügbarkeit",
+                        "title": "Verfüg&shy;barkeit",
                         "id": "availability",
                         "indexed": true,
                         "accordion": [
@@ -2284,7 +2284,7 @@
                 ]
             },
             {
-                "title": "Technische Zusammenhänge",
+                "title": "Technische Zusammen&shy;hänge",
                 "id": "technical_context",
                 "icon": "/assets/img/icons/improvement.svg",
                 "sections": [


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2742 "Overlapping text on FAQ overview (DE)" by inserting soft hyphens into long titles using Duden rules for hyphenation of German words.

After this change, the text from one column does not run into the next, and each of the 5 columns stays at the same width compared to other columns as the width of the browser window is changed.

The narrowest view of https://www.coronawarn.app/de/faq/ which still shows columns across the page now looks like this:

![image](https://user-images.githubusercontent.com/66998419/163004489-b8a69b91-fe17-4bf6-8186-6950ff0544b7.png)

The wide view, before any hyphenation due to narrowing of the browser window takes place, looks like this:

![image](https://user-images.githubusercontent.com/66998419/163005141-b629dd00-61cc-426b-8253-642fd471d7a4.png)

