### PR TITLE
Remove links to deleted verification service FAQs in 2.15 blog

### DIFF
--- a/blog/2021-12-20-cwa-2-15/index.md
+++ b/blog/2021-12-20-cwa-2-15/index.md
@@ -102,8 +102,6 @@ In addition, with version 2.15, the project team has adapted the guidelines unde
 Version 2.15 - like previous versions - will be delivered in a staged rollout and is made available for users in waves. While users can manually trigger an update in Apple’s App Store, this option is not available in the Google Play Store. There, the delivery of the Corona-Warn-App’s new version can take up to 48 hours.
 
 <hr/>
-See also the following FAQ-articles:
+See also the following FAQ-article:
 
 - [Questions and answers about certificate verification during ticketing.](/en/faq/#val_service_basics)
-- [Why do I get the message that there is no suitable certificate?](/en/faq/#val_service_no_valid_dcc)
-- [Why is my certificate not verifiable or not recognized?](/en/faq/#val_service_result)

--- a/blog/2021-12-20-cwa-2-15/index_de.md
+++ b/blog/2021-12-20-cwa-2-15/index_de.md
@@ -100,8 +100,6 @@ Des Weiteren hat das Projektteam mit Version 2.15 die **Handlungsempfehlungen un
 Version 2.15 wird, wie vorherige Versionen auch, schrittweise über 48 Stunden an alle Nutzer\*innen ausgerollt. iOS-Nutzer\*innen können sich die aktuelle App-Version ab sofort aus dem Store von Apple manuell herunterladen. Der Google Play Store bietet keine Möglichkeit, ein manuelles Update anzustoßen. Hier steht Nutzer*innen die neue Version der Corona-Warn-App innerhalb der nächsten 48 Stunden zur Verfügung.
 
 <hr/>
-Siehe auch folgende FAQ-Artikel:
+Siehe auch folgenden FAQ-Artikel:
 
 - [Fragen und Antworten zur Zertifikatsprüfung bei Ticketbuchungen](/de/faq/#val_service_basics)
-- [Warum erhalte ich die Meldung, dass kein geeignetes Zertifikat vorhanden ist?](/de/faq/#val_service_no_valid_dcc)
-- [Warum ist mein Zertifikat nicht prüfbar oder wird nicht anerkannt?](/de/faq/#val_service_result)


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2745 "Verification Service blog (2.15) has links to deleted FAQs". It removes the references to deleted and (at least temporarily) obsolete FAQ articles in the following blog articles covering the Verification Service, which is on hold with no defined future plan:

- https://www.coronawarn.app/en/blog/2021-12-20-cwa-2-15/ "Corona-Warn-App simplifies certificate checks when booking tickets", remove links to deleted articles:
    - https://www.coronawarn.app/en/faq/#val_service_no_valid_dcc "Why do I get the message that there is no suitable certificate?"
    - https://www.coronawarn.app/en/faq/#val_service_result "Why is my certificate not verifiable or not recognized?"

- https://www.coronawarn.app/de/blog/2021-12-20-cwa-2-15/ "Corona-Warn-App vereinfacht die Zertifikatsprüfungen bei der Ticketbuchung", remove links to deleted articles:
    - https://www.coronawarn.app/de/faq/#val_service_no_valid_dcc "Warum erhalte ich die Meldung, dass kein geeignetes Zertifikat vorhanden ist?"
    - https://www.coronawarn.app/de/faq/#val_service_result "Warum ist mein Zertifikat nicht prüfbar oder wird nicht anerkannt?"