### PR TITLE
Add FAQ redirect from `check_in_qr_warning` to `check_in`

### DIFF
--- a/src/data/faq_redirects.json
+++ b/src/data/faq_redirects.json
@@ -16,5 +16,6 @@
     "check_in_index": "check_in",
     "dissimilar_indication_of_risk_status": "risk_encounter_different_devices",
     "val_service_no_valid_dcc": "val_service_basics",
-    "val_service_result": "val_service_basics"
+    "val_service_result": "val_service_basics",
+    "check_in_qr_warning": "check_in"
 }


### PR DESCRIPTION
## Description

This PR adds a new FAQ redirect  from `check_in_qr_warning` to `check_in`, as the FAQ entry `check_in_qr_warning` has been deleted.

## What was changed
- A FAQ Redirect was added
