### PR TITLE
Update privacy objectives

### DIFF
--- a/src/data/index.json
+++ b/src/data/index.json
@@ -201,8 +201,8 @@
                         "text": "The architecture follows a decentralized approach – based on the <a href='https://github.com/DP-3T/documents' target='_blank' rel='noopener noreferrer' title=''>DP-3T</a> and <a href='https://www.lfph.io/tcn-coalition/' target='_blank' rel='noopener noreferrer' title=''>TCN</a> protocols, as well as the Privacy-Preserving Contact Tracing specifications by Apple and Google."
                     },
                     {
-                        "title": "Two objectives",
-                        "text": "Only personal data needed for the following two objectives will be processed:<br>1. Assess personal risk of infection<br>2. Learn COVID-19 test results faster."
+                        "title": "Objectives",
+                        "text": "Only personal data needed for the following objectives will be processed:<br>1. Assess personal risk of infection<br>2. Learn COVID-19 test results faster<br>3. Regarding other objectives, see the <a href='/assets/documents/cwa-privacy-notice-en.pdf' target='_blank'>privacy notice</a>"
                     },
                     {
                         "title": "Data Privacy document",

--- a/src/data/index_de.json
+++ b/src/data/index_de.json
@@ -200,8 +200,8 @@
                         "text": "Die Architektur beruht wie die Protokolle <a href='https://github.com/DP-3T/documents' target='_blank' rel='noopener noreferrer' title=''>DP-3T</a> und <a href='https://www.lfph.io/tcn-coalition/' target='_blank' rel='noopener noreferrer' title=''>TCN</a> auf einem dezentralen Ansatz und baut auf den Exposure-Notification-API-Spezifikationen von Apple und Google auf."
                     },
                     {
-                        "title": "Zwei Zwecke",
-                        "text": "Es werden nur personenbezogene Daten verarbeitet, die für die folgenden beiden Zwecke erforderlich sind: <ul class='list-unstyled'> <li> 1. zur Beurteilung des persönlichen Infektionsrisikos </li> <li> 2. zur schnelleren Übermittlung des SARS-CoV-2-Testergebnisses </li> </ul>"
+                        "title": "Zwecke",
+                        "text": "Es werden nur personenbezogene Daten verarbeitet, die für die folgenden Zwecke erforderlich sind: <ul class='list-unstyled'> <li> 1. zur Beurteilung des persönlichen Infektionsrisikos </li> <li> 2. zur schnelleren Übermittlung des SARS-CoV-2-Testergebnisses </li> 3. Bezüglich anderer Zwecke siehe die <a href='/assets/documents/cwa-privacy-notice-de.pdf' target='_blank'>Datenschutzerklärung</a><li> </ul>"
                     },
                     {
                         "title": "Datenschutzdokument",


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/2559 "Outdated personal data statement" where the statement in https://www.coronawarn.app/en/ said that only personal data for the two objectives of personal risk and test results are processed, leaving out many later additions to the functionality of the Corona-Warn-App.

The statement is now extended to refer to the [Privacy notice](https://www.coronawarn.app/assets/documents/cwa-privacy-notice-en.pdf) document, which lists other personal data processed. The [Privacy notice](https://www.coronawarn.app/assets/documents/cwa-privacy-notice-en.pdf) document is reviewed and changed if necessary with each app release, so ensuring that the statement remains valid despite any further additions to personal data processing.

EN | DE
--- | ---
![Objectives_EN](https://user-images.githubusercontent.com/66998419/163325352-af211751-d791-4fcf-9828-3e269a9fb30d.jpg) | ![Objectives_DE](https://user-images.githubusercontent.com/66998419/163325381-4f20b075-8526-4b80-b328-7b7122bd1c9a.jpg)

 Note: The source code to format the English and German sections differs. I used the existing formatting method for each language and simply added a third list item. The English section uses `<br>` for item separation whereas the German section uses `<ul class='list-unstyled'> <li>`. If there is a desire to harmonize the formatting, please let me know which method is preferred and I will change one of the languages.