### PR TITLE
Rename  FAQ entry `val_service_basics`

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -796,7 +796,7 @@
                         "indexed": false,
                         "accordion": [
                             {
-                                "title": "Questions and answers about certificate verification during ticketing",
+                                "title": "Information on certificate verification during ticketing",
                                 "anchor": "val_service_basics",
                                 "active": false,
                                 "textblock": [

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -796,7 +796,7 @@
                         "indexed": false,
                         "accordion": [
                             {
-                                "title": "Fragen und Antworten zur Zertifikatsprüfung bei Ticketbuchungen",
+                                "title": "Informationen zur Zertifikatsprüfung bei Ticketbuchungen",
                                 "anchor": "val_service_basics",
                                 "active": false,
                                 "textblock": [


### PR DESCRIPTION
## Description

This PR renames the FAQ entry `val_service_basics`, to reflect that there is only one question answered, and not multiple questions.

## What was changed

- The title of the German FAQ entry https://www.coronawarn.app/de/faq/results/#val_service_basics was changed from "Fragen und Antworten zur Zertifikatsprüfung bei Ticketbuchungen" to "Informationen zur Zertifikatsprüfung bei Ticketbuchungen"
- The title of the English FAQ entry https://www.coronawarn.app/en/faq/results/#val_service_basics was changed from "Questions and answers about certificate verification during ticketing" to "Information on certificate verification during ticketing"

## Screenshots

| German | English |
|---|---|
| <img width="1070" alt="German" src="https://user-images.githubusercontent.com/67682506/163427940-dc9ea789-a9f2-49f8-8b46-5c9b9d9ac5e6.png"> | <img width="1068" alt="English" src="https://user-images.githubusercontent.com/67682506/163427927-ccd944ff-94aa-4fb7-9be3-a1b42f872e6a.png"> |
