### PR TITLE
More precise information reg. check in warning in FAQ entries `check_in_qr_warning_procedure` & `check_in_qr_warning_how` (Addresses #1651) 

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -907,7 +907,7 @@
                                 "anchor": "check_in_qr_warning_procedure",
                                 "active": false,
                                 "textblock": [
-                                    "The procedure is based on the existing CWA warning process: If an event participant or a visitor of a location has tested positive, he/she should share this result via the CWA. As a result, all other participants who were checked in at the same time will receive an immediate warning without having to burden the health authorities. Depending on the epidemiological situation, the warning is displayed in one of two versions: 'low risk' (green tile) or 'high risk' (red tile)."
+                                    "The procedure is based on the existing CWA warning process: If an event participant or a visitor of a location has tested positive, they should share the result via the CWA. As a result, all other participants who were checked in at the same time, or up to 30 minutes after the positive tested person checked out, will receive an immediate warning without having to burden the health authorities. Depending on the epidemiological situation, the warning is displayed in one of two versions: 'low risk' (green tile) or 'high risk' (red tile)."
                                 ]
                             },
                             {
@@ -915,7 +915,7 @@
                                 "anchor": "check_in_qr_warning_how",
                                 "active": false,
                                 "textblock": [
-                                    "The calculation of the risk depends on whether and for how long a user's attendance overlaps with the attendance of a person who later tested positive for COVID-19. If the attendance overlaps by less than 10 minutes, users receive a warning for a low-risk encounter (green tile). If a user's attendance overlaps by 10 minutes or more with that of a person who later tested positive for COVID-19, users will receive a warning about an encounter with increased risk (red tile)."
+                                    "The calculation of the risk depends on whether and for how long a user's attendance overlaps with the attendance of a person who later tested positive for COVID-19. If the attendance overlaps by less than 10 minutes, users receive a warning for a low-risk encounter (green tile). If a user's attendance overlaps by 10 minutes or more with that of a person who later tested positive for COVID-19, users will receive a warning about an encounter with increased risk (red tile). A warning can also be issued if one was checked in up to 30 minutes after the positive tested person checked out."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -907,7 +907,7 @@
                                 "anchor": "check_in_qr_warning_procedure",
                                 "active": false,
                                 "textblock": [
-                                    "Der Ablauf basiert auf dem bestehenden Warn-Prozess der CWA: falls eine Teilnehmerin/ein Teilnehmer eines Events oder eine Besucherin/ein Besucher eines Ortes positiv getestet ist, sollte sie/er dieses Ergebnis über die CWA teilen. Dann erhalten alle anderen, die sich dort zu dem Zeitpunkt eingecheckt haben, unverzüglich eine Warnung, ohne dass die Gesundheitsämter belastet werden müssen. Die kann, je nach epidemiologischer Situation, in zwei Versionen ausfallen: 'geringes Risiko' (grüne Kachel) oder eben 'hohes Risiko' (rote Kachel)."
+                                    "Der Ablauf basiert auf dem bestehenden Warn-Prozess der CWA: falls eine Teilnehmerin/ein Teilnehmer eines Events oder eine Besucherin/ein Besucher eines Ortes positiv getestet ist, sollte sie/er dieses Ergebnis über die CWA teilen. Dann erhalten alle anderen, die dort zur gleichen Zeit, oder bis zu 30 Minuten nachdem sich die positv getesetete Person ausgecheckt hat, eingecheckt waren, unverzüglich eine Warnung, ohne dass die Gesundheitsämter belastet werden müssen. Die kann, je nach epidemiologischer Situation, in zwei Versionen ausfallen: 'geringes Risiko' (grüne Kachel) oder eben 'hohes Risiko' (rote Kachel)."
                                 ]
                             },
                             {
@@ -915,7 +915,7 @@
                                 "anchor": "check_in_qr_warning_how",
                                 "active": false,
                                 "textblock": [
-                                    "Die Berechnung des Risikos hängt davon ab, ob und wie lange sich der Aufenthalt eines Nutzers oder einer Nutzerin mit einer später positiv auf COVID-19 getesteten Person überschneidet. Überschneidet sich der Aufenthalt um weniger als 10 Minuten, erhalten Nutzer*innen eine Warnung über eine Begegnung mit geringem Risiko (grüne Kachel). Hat sich der Aufenthalt mit der später positiv auf COVID-19 getesteten Person um 10 Minuten oder länger überschnitten, erhalten Nutzer*innen eine Warnung über eine Begegnung mit erhöhtem Risiko (rote Kachel)."
+                                    "Die Berechnung des Risikos hängt davon ab, ob und wie lange sich der Aufenthalt eines Nutzers oder einer Nutzerin mit einer später positiv auf COVID-19 getesteten Person überschneidet. Überschneidet sich der Aufenthalt um weniger als 10 Minuten, erhalten Nutzer*innen eine Warnung über eine Begegnung mit geringem Risiko (grüne Kachel). Hat sich der Aufenthalt mit der später positiv auf COVID-19 getesteten Person um 10 Minuten oder länger überschnitten, erhalten Nutzer*innen eine Warnung über eine Begegnung mit erhöhtem Risiko (rote Kachel). Es kann auch dann eine Warnung erfolgen, wenn man sich bis zu 30 Minuten nach der positv getesteten Person eingecheckt hat."
                                 ]
                             },
                             {


### PR DESCRIPTION
## Description

This PR gives more precise information when a warning can be issued based on a check in in the FAQ entries `check_in_qr_warning_procedure` & `check_in_qr_warning_how`.

## What was changed

- https://www.coronawarn.app/en/faq/results/#check_in_qr_warning_procedure
- https://www.coronawarn.app/de/faq/results/#check_in_qr_warning_procedure
- https://www.coronawarn.app/en/faq/results/#check_in_qr_warning_how
- https://www.coronawarn.app/de/faq/results/#check_in_qr_warning_how

## Screenshots

| German | English |
|---|---|
| <img width="1068" alt="German" src="https://user-images.githubusercontent.com/67682506/163433987-0e0e1381-b40d-44bf-b9bb-2d42e9e5e923.png"> | <img width="1068" alt="English" src="https://user-images.githubusercontent.com/67682506/163433980-f58f2293-3609-4050-b2cd-5551ddd778a6.png"> |

---

**Closes #1651**
