### PR TITLE
count glossary results correctly

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -240,16 +240,15 @@ $(document).ready(function(){
         let glossaryList = 0;
         
         if(topicString === "glossary" || topicString === "all") {
+            glossaryList = countGlossaryResults(searchString);
             $(".word").each((index, word) => {
                 if($(word).text().toLowerCase().includes(searchString.toLowerCase())) {
                     $($($(word).parent().get(0)).parent().get(0)).appendTo(".glossary-result")
-                    glossaryList++;
                 }
             })
             $(".description").each((index, desc) => {
                 if($(desc).text().toLowerCase().includes(searchString.toLowerCase())) {
                     $($(desc).parent().get(0)).appendTo(".glossary-result")
-                    glossaryList++;
                 }
             })
             if(glossaryList > 0) $(".section-item a[href='#glossary']").addClass("active").parent().addClass("active");


### PR DESCRIPTION
With PR #2647 I implemented a function to count the glossary results and added this function in several places, but I forgot one place. Now the search result counter for the glossary works as expected.

@MikeMcC399 I looked through my issues again, but I couldn't find a corresponding issue. I think I forgot to open an issue for this problem. Thanks for researching.