### PR TITLE
Add sitemap to Cypress check_links.js

### DIFF
--- a/cypress/integration/check_links.js
+++ b/cypress/integration/check_links.js
@@ -30,7 +30,9 @@ context("Check for broken links", () => {
                   '/de/simple-language/',
                   '/en/simple-language/',
                   '/de/sign-language/',
-                  '/en/sign-language/'
+                  '/en/sign-language/',
+                  '/de/sitemap/',
+                  '/en/sitemap/'
                 ]
     const allowlist = [
       'https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999',


### PR DESCRIPTION
This PR resolves issue #2767 "Cypress does not test sitemap links" by adding the following to `pages` in [cypress/integration/check_links.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/check_links.js)

- '/de/sitemap/'
- '/en/sitemap/'

## Verification

`npm run test:open`
select `check_links.js`
check that the sitemap directories `/de/sitemap/` and `/en/sitemap/` are listed in the Cypress log