### PR TITLE
Fix heading order

### DIFF
--- a/src/partials/page-imprint.html
+++ b/src/partials/page-imprint.html
@@ -4,8 +4,13 @@
         <div class="container-inner container-inner_lg">
             <div class="row">
                 <div class="col col-12 col-md-8 col-lg-7">
-                <h1 class="h2 headline">{{page-contents.section-main.headline.title}}</h1>
-                {{> text-component page-contents.section-main.content}}
+                    <h1 class="h2 headline">{{page-contents.section-main.headline.title}}</h1>
+                    <h2 class="h3"><b>{{page-contents.section-main.content.title}}</b></h2>
+                    <div>
+                        {{#each page-contents.section-main.content.textblock}}
+                        <p>{{{.}}}</p>
+                        {{/each}}
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/partials/page-privacy.html
+++ b/src/partials/page-privacy.html
@@ -7,8 +7,12 @@
             </div>
             <div class="row">
                 <div class="col">
-                {{> headline-small-component page-contents.section-main.website-headline}}
-                {{> text-component page-contents.section-main.website-content}}
+                    <h2 class="h3"><b>{{page-contents.section-main.website-headline.title}}</b></h2>
+                    <div>
+                        {{#each page-contents.section-main.website-content.textblock}}
+                        <p>{{{.}}}</p>
+                        {{/each}}
+                    </div>
                 </div>
             </div>
             <div class="row">

--- a/src/partials/page-terms-of-use.html
+++ b/src/partials/page-terms-of-use.html
@@ -11,8 +11,12 @@
             <div class="row">
                 <div class="col ">
                     <br/>
-                {{> headline-small-component page-contents.section-main.previous-headline}}
-                {{> text-component page-contents.section-main.previous-content}}
+                    <h2 class="h3"><b>{{page-contents.section-main.previous-headline.title}}</b></h2>
+                    <div>
+                        {{#each page-contents.section-main.previous-content.textblock}}
+                        <p>{{{.}}}</p>
+                        {{/each}}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Follow-up to #2755 and #2752 

In order to make the pages more accessible, headings should follow a sequential, descending order, and shouldn't skip a level. With this PR, this will fix it for

-  https://www.coronawarn.app/en/terms-of-use/
-  https://www.coronawarn.app/en/imprint/
-  https://www.coronawarn.app/en/privacy/
