### PR TITLE
Change social media anchor link

### DIFF
--- a/src/data/community.json
+++ b/src/data/community.json
@@ -114,7 +114,7 @@
     },
     "section-social-media": {
         "title": "Social Media",
-        "anchor": "social-media",
+        "anchor": "socialmedia",
         "textblock": ["You can also find the most important information about the Corona-Warn-App, its features and its development on social media. Note that these accounts only publish German content."],
         "socialmedia": [{
             "title": "Twitter",

--- a/src/data/community_de.json
+++ b/src/data/community_de.json
@@ -114,7 +114,7 @@
     },
     "section-social-media": {
         "title": "Social Media",
-        "anchor": "social-media",
+        "anchor": "socialmedia",
         "textblock": ["Die wichtigsten Informationen zur Corona-Warn-App, zu ihren Funktionen und ihrer Entwicklung findet Ihr auch in den sozialen Medien."],
         "socialmedia": [{
             "title": "Twitter",


### PR DESCRIPTION
This PR changes the social media anchor link, so that it works with the link implemented in the app. 

[Social media link in Android repository](https://github.com/corona-warn-app/cwa-app-android/blob/c16276c3037054d09f5f095455735973c3264f1f/Corona-Warn-App/src/main/res/values/links.xml#L73)
[Social media link in iOS repository](https://github.com/corona-warn-app/cwa-app-ios/blob/b65edc14f30cc8654cec94afaab2222a03c10248/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings#L11)

---
Internal Tracking ID: [EXPOSUREAPP-12846](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12846)