### PR TITLE
Use standard name "Corona-Warn-App" in EN blogs

### DIFF
--- a/blog/2020-12-15-iOS12x-statement/index.md
+++ b/blog/2020-12-15-iOS12x-statement/index.md
@@ -11,7 +11,7 @@ Apple now makes its Exposure Notification Framework available for the iOS 12.5 o
 <!-- overview -->
 
 We are pleased that Apple has now made its Exposure Notification Framework available for the iOS 12.5 operating system. The company is accommodating the request to also enable users of the older iPhone models 5s and 6 to download tracing apps.<br>
-Deutsche Telekom and SAP are in contact with Apple to make the federal government's Corona warning app available for these models in the future. Transferring the Corona warning app to iOS 12.5 is possible, but requires work.<br>
+Deutsche Telekom and SAP are in contact with Apple to make the federal government's Corona-Warn-App available for these models in the future. Transferring the Corona-Warn-App to iOS 12.5 is possible, but requires work.<br>
 The companies are working diligently with Apple to make the necessary adjustments.<br>
 An exact date when the Corona-Warn-App can be made available for download on iPhones 5s and 6 cannot be estimated at this time. The companies will share that information as soon as it is available.<br>
-The federal government's Corona warning app has been downloaded more than 24 million times to date.
+The federal government's Corona-Warn-App has been downloaded more than 24 million times to date.

--- a/blog/2022-03-16-cwa-2-19/index.md
+++ b/blog/2022-03-16-cwa-2-19/index.md
@@ -25,6 +25,6 @@ With the update, this is no longer necessary, as the CWA can now break down the 
 
 The CWA will inform the users for whom the adjustment changes something in the grouping of their certificates. 
 
-Version 2.19, like previous versions, will be rolled out to all users in stages over 48 hours. iOS users can now download the latest app version manually from the Apple Store. The Google Play Store does not offer the option of triggering a manual update. The new version of the Corona warning app will be available to users here within the next 48 hours. 
+Version 2.19, like previous versions, will be rolled out to all users in stages over 48 hours. iOS users can now download the latest app version manually from the Apple Store. The Google Play Store does not offer the option of triggering a manual update. The new version of the Corona-Warn-App will be available to users here within the next 48 hours. 
 
 Up-to-date information on the status of the roll-out can be found on the **Twitter channel of [#coronawarnapp](https://twitter.com/coronawarnapp) (German only)**.

--- a/blog/2022-03-30-cwa-2-20/index.md
+++ b/blog/2022-03-30-cwa-2-20/index.md
@@ -100,7 +100,6 @@ Second, the project team has **removed the QR code for the currently used certif
 
 In addition, the CWA is now capable of **running on Android 13**, which Google says will be released in the fall of 2022. 
 
-Version 2.20, like previous versions, will be rolled out to all users in stages over 48 hours. iOS users can now download the latest app version manually from the Apple Store. The Google Play Store does not offer the option of triggering a manual update. The new version of the Corona warning app will be available to users here within the next 48 hours.
+Version 2.20, like previous versions, will be rolled out to all users in stages over 48 hours. iOS users can now download the latest app version manually from the Apple Store. The Google Play Store does not offer the option of triggering a manual update. The new version of the Corona-Warn-App will be available to users here within the next 48 hours.
 
 Up-to-date information on the status of the roll-out can be found on the **[Twitter channel of #coronawarnapp](https://twitter.com/coronawarnapp)** (German only).
-

--- a/blog/2022-04-19-cwa-2-21/index.md
+++ b/blog/2022-04-19-cwa-2-21/index.md
@@ -39,6 +39,6 @@ With version 2.21, the project team has also adapted the **texts about the vacci
 
 The CWA now **informs users in more detail**, for example, whether they are considered as initially immunized because of recovery, whether they have received all currently recommended vaccinations, or whether they should inform themselves about a recommended booster vaccination.
 
-Version 2.21 , like previous versions, will be rolled out to all users in stages over 48 hours. iOS users can now download the latest app version manually from the Apple Store. The Google Play Store does not offer the option of triggering a manual update. The new version of the Corona warning app will be available to users here within the next 48 hours.
+Version 2.21, like previous versions, will be rolled out to all users in stages over 48 hours. iOS users can now download the latest app version manually from the Apple Store. The Google Play Store does not offer the option of triggering a manual update. The new version of the Corona-Warn-App will be available to users here within the next 48 hours.
 
 Up-to-date information on the status of the roll-out can be found on the Twitter channel of [#coronawarnapp](https://twitter.com/coronawarnapp) (German only).


### PR DESCRIPTION
This PR resolves issue #2783 "Harmonize on app name in EN version announcement blogs" by replacing "Corona warning app" by "Corona-Warn-App" in all English language blogs where the term is specifically referring to RKI's CWA app.

No change is made where "Corona warning app" is used in blogs in a generic sense.