### PR TITLE
Change FAQ anchor from `hc_invalid_prefix` to `hc_prefix_invalid` & add FAQ redirect (Addresses #2792)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1545,7 +1545,7 @@
                         "accordion": [
                             {
                                 "title": "Error 'HC_PREFIX_INVALID'",
-                                "anchor": "hc_invalid_prefix",
+                                "anchor": "hc_prefix_invalid",
                                 "active": false,
                                 "textblock": [
                                     "Under the tab 'Certificates' the app can only scan '<b>EU Digital</b> COVID  Certificates'.",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1546,7 +1546,7 @@
                         "accordion": [
                             {
                                 "title": "Fehlermeldung 'HC_PREFIX_INVALID'",
-                                "anchor": "hc_invalid_prefix",
+                                "anchor": "hc_prefix_invalid",
                                 "active": false,
                                 "textblock": [
                                     "Unter dem Reiter Zertifikate kann die App nur '<b>EU Digitale</b> COVID-Zertifikate' scannen.",

--- a/src/data/faq_redirects.json
+++ b/src/data/faq_redirects.json
@@ -17,5 +17,6 @@
     "dissimilar_indication_of_risk_status": "risk_encounter_different_devices",
     "val_service_no_valid_dcc": "val_service_basics",
     "val_service_result": "val_service_basics",
-    "check_in_qr_warning": "check_in"
+    "check_in_qr_warning": "check_in",
+    "hc_invalid_prefix": "hc_prefix_invalid"
 }


### PR DESCRIPTION
## Description

This PR changes the FAQ entry anchor from `hc_invalid_prefix` to `hc_prefix_invalid` to match the error code. It also adds a FAQ entry from `hc_invalid_prefix` to `hc_prefix_invalid`.

## What was changed

- The anchor of the FAQ entry "Error 'HC_PREFIX_INVALID'"
- The anchor of the FAQ entry "Fehlermeldung 'HC_PREFIX_INVALID'"
- A FAQ redirect was added

## Screenshots

No visible changes. 🫣

---

**Fixes #2792**