### PR TITLE
Correct screenshot text typos

### DIFF
--- a/src/data/screenshots-archive-2-20.json
+++ b/src/data/screenshots-archive-2-20.json
@@ -97,7 +97,7 @@
             {
                 "title": "Statistics",
                 "anchor": "android_stats",
-                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doeses administered.",
+                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doses administered.",
                 "images": [
                     { "filename": "/assets/screenshots/2-20/en/android/HomeFragment_statistics_card_0", "alt": "Statistics image 1 of 12" },
                     { "filename": "/assets/screenshots/2-20/en/android/HomeFragment_statistics_card_1", "alt": "Statistics image 2 of 12" },
@@ -379,7 +379,7 @@
             {
                 "title": "Statistics",
                 "anchor": "ios_stats",
-                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doeses administered.",
+                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doses administered.",
                 "images": [
                     { "filename": "/assets/screenshots/2-20/en/ios/iPhone 13-statistics_add_local_statistics", "alt": "Statistics image 1 of 13" },
                     { "filename": "/assets/screenshots/2-20/en/ios/iPhone 13-statistics_local_7day_values", "alt": "Statistics image 2 of 13" },

--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -92,7 +92,7 @@
             {
                 "title": "Statistics",
                 "anchor": "android_stats",
-                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doeses administered.",
+                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doses administered.",
                 "images": [
                     { "filename": "/assets/screenshots/2-21/en/android/HomeFragment_statistics_card_0", "alt": "Statistics image 1 of 11" },
                     { "filename": "/assets/screenshots/2-21/en/android/HomeFragment_statistics_card_1", "alt": "Statistics image 2 of 11" },
@@ -361,7 +361,7 @@
             {
                 "title": "Statistics",
                 "anchor": "ios_stats",
-                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doeses administered.",
+                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doses administered.",
                 "images": [
                     { "filename": "/assets/screenshots/2-21/en/ios/iPhone 13-statistics_add_local_statistics", "alt": "Statistics image 1 of 13" },
                     { "filename": "/assets/screenshots/2-21/en/ios/iPhone 13-statistics_local_7day_values", "alt": "Statistics image 2 of 13" },
@@ -381,7 +381,7 @@
             {
                 "title": "Test Registration & Key Sharing",
                 "anchor": "ios_registertest",
-                "description": "In this section you will find screenshots of test registration and key sharing. If you press \"Continue\" on the \"Status\" page at \"You are getting tested\" you will get to the test administration. Here you have the possibility to register your PCR test or the PCR test of a famlily member. Press \"Enter TAN for PCR test\" so that a window appears where you can enter your 10-digit TAN. Once you have done this, you still need to give your consent. Then your test result can have three different statuses. These are \"Your result is not yet available\" \"SARS-CoV-2 negative,\" and \"SARS-CoV-2 positive.\" With the latter, you still have the option to record the onset and type of symptoms.",
+                "description": "In this section you will find screenshots of test registration and key sharing. If you press \"Continue\" on the \"Status\" page at \"You are getting tested\" you will get to the test administration. Here you have the possibility to register your PCR test or the PCR test of a family member. Press \"Enter TAN for PCR test\" so that a window appears where you can enter your 10-digit TAN. Once you have done this, you still need to give your consent. Then your test result can have three different statuses. These are \"Your result is not yet available\" \"SARS-CoV-2 negative,\" and \"SARS-CoV-2 positive.\" With the latter, you still have the option to record the onset and type of symptoms.",
                 "images": [
                     { "filename": "/assets/screenshots/2-21/en/ios/iPhone 13-tan_submissionflow_qr_0001", "alt": "Test registration & Key sharing image 1 of 11" },
                     { "filename": "/assets/screenshots/2-21/en/ios/iPhone 13-screenshot_family_member_tests_selection", "alt": "Test registration & Key sharing image 2 of 11"},


### PR DESCRIPTION
This PR corrects typos in the Screenshot description text for:

- https://www.coronawarn.app/en/screenshots/#ios_screenshots
- https://www.coronawarn.app/en/screenshots/#android_screenshots
- https://www.coronawarn.app/en/screenshots-archive/2-20.html#ios_screenshots
- https://www.coronawarn.app/en/screenshots-archive/2-20.html#android_screenshots
