### PR TITLE
changing heroku to auto updating standalone

### DIFF
--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -21,8 +21,7 @@ jobs:
     steps:
       - name: Install requirements
         run: |
-          curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
-          curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+          curl https://cli-assets.heroku.com/install.sh | sh
           sudo apt-get install -y libnode-dev libssl-dev automake npm nodejs libpng-dev libjpeg-dev s3cmd
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Trying to fix

```
E: The repository 'https://cli-assets.heroku.com/apt ./ InRelease' is not signed.
```

in

https://github.com/corona-warn-app/cwa-website/runs/6194463380?check_suite_focus=true#step:3:59