### PR TITLE
Change Android RTP button label to upper case in Blog 2.22 text

### DIFF
--- a/blog/2022-05-04-cwa-2-22/index.md
+++ b/blog/2022-05-04-cwa-2-22/index.md
@@ -13,7 +13,7 @@ The project team of the Robert Koch-Institute (RKI), Deutsche Telekom, and SAP h
 
 The new feature completes the test management for family members that the project team introduced with version 2.21. The rapid test profile contains the **personal data, such as name and contact details, in the form of a QR code**. At participating test sites, the QR code can be scanned to speed up on-site test registration.
 
-With version 2.22, users can create rapid test profiles for family members who do not have a smartphone, for example. To do this, they can tap on **“Manage Your Tests” on the app’s home screen and after that select "Rapid Test Profiles”** where they can tap **"Create rapid test profile" (iOS) or "+ rapid test profile" (Android)**. In the next step, users can enter the data for the relevant person. Under "Manage Your Tests" they will then be shown a list of all the rapid test profiles they have stored under the persons’ respective names. 
+With version 2.22, users can create rapid test profiles for family members who do not have a smartphone, for example. To do this, they can tap on **“Manage Your Tests” on the app’s home screen and after that select "Rapid Test Profiles”** where they can tap **"Create rapid test profile" (iOS) or "+ RAPID TEST PROFILE" (Android)**. In the next step, users can enter the data for the relevant person. Under "Manage Your Tests" they will then be shown a list of all the rapid test profiles they have stored under the persons’ respective names. 
 
 
 <br></br>
@@ -41,4 +41,3 @@ When users tap "Continue" from the rapid test profile, they can **scan the QR co
 Version 2.22, like previous versions, will be rolled out to all users in stages over 48 hours. iOS users can now download the latest app version manually from the Apple Store. The Google Play Store does not offer the option of triggering a manual update. The new version of the Corona-Warn-App will be available to users here within the next 48 hours.
 
 Up-to-date information on the status of the roll-out can be found on the Twitter channel of [#coronawarnapp](https://twitter.com/coronawarnapp) (German only).
-

--- a/blog/2022-05-04-cwa-2-22/index_de.md
+++ b/blog/2022-05-04-cwa-2-22/index_de.md
@@ -13,7 +13,7 @@ Das Projektteam aus Robert Koch-Institut (RKI), Deutscher Telekom und SAP hat Ve
 
 Die neue Funktion vervollständigt die Testverwaltung für Familienmitglieder, die das Projektteam mit Version 2.21 eingeführt hat. Das Schnelltest-Profil enthält die **persönlichen Daten wie Name und Kontaktdaten in Form eines QR-Codes**. An teilnehmenden Teststellen wird dann lediglich der QR-Code in der App zur Anmeldung gescannt. So kann die Registrierung vor Ort beschleunigt werden.
 
-Mit Version 2.22 können Nutzer\*innen Schnelltest-Profile auch für Familienmitglieder, die beispielsweise kein Smartphone besitzen, anlegen. Dazu können sie **unter „Sie lassen sich testen?“ zum „Schnelltest-Profil“** gehen und dort auf **„Schnelltest-Profil erstellen“** (iOS) beziehungsweise auf **„+ Schnelltest-Profil“** (Android) tippen und die Daten der entsprechenden Person eintragen. Unter dem Punkt "Schnelltest-Profil" wird ihnen dann eine Liste aller Schnelltest-Profile angezeigt, die sie unter dem jeweiligen Namen der Person hinterlegt haben. 
+Mit Version 2.22 können Nutzer\*innen Schnelltest-Profile auch für Familienmitglieder, die beispielsweise kein Smartphone besitzen, anlegen. Dazu können sie **unter „Sie lassen sich testen?“ zum „Schnelltest-Profil“** gehen und dort auf **„Schnelltest-Profil erstellen“** (iOS) beziehungsweise auf **„+ SCHNELLTEST-PROFIL“** (Android) tippen und die Daten der entsprechenden Person eintragen. Unter dem Punkt "Schnelltest-Profil" wird ihnen dann eine Liste aller Schnelltest-Profile angezeigt, die sie unter dem jeweiligen Namen der Person hinterlegt haben. 
 
 
 <br></br>


### PR DESCRIPTION
This PR corrects text in the blog announcements for CWA 2.22

- https://www.coronawarn.app/en/blog/2022-05-04-cwa-2-22/ "CWA 2.22: Rapid test profiles for family members"
- https://www.coronawarn.app/de/blog/2022-05-04-cwa-2-22/ "CWA 2.22: Schnelltest-Profile für Familienmitglieder"

In Android the button to create a rapid test profile, as seen in the screenshots, is labelled:

- "+ RAPID TEST PROFILE" (English)
- "+ SCHNELLTEST-PROFIL" (Deutsch)

The blog texts are aligned in this PR to conform to the respective screenshots showing creation of an RTP. In the English version it was confusing to read the description of the label in complete lower case in the text as "+ rapid test profile" when it appears in the app completely in upper case as "+ RAPID TEST PROFILE".
