### PR TITLE
Add Cypress test for mime types

### DIFF
--- a/cypress/integration/mime.js
+++ b/cypress/integration/mime.js
@@ -1,0 +1,25 @@
+/// <reference types="Cypress" />
+
+// To run this test on https://coronawarn.app execute the following
+// from the root directory of a local copy of cwa-website
+// npx cypress run -s cypress/integration/mime.js -c baseUrl=https://coronawarn.app
+
+describe("Test MIME types", () => {
+
+    it("css MIME type", () => {
+        cy.request("/assets/css/style.css").then((response) => {
+            const mime = response.headers['content-type'];
+            expect(mime).to.contain('text/css');
+        });
+    });
+
+    it("javascript MIME type", () => {
+        cy.request("/assets/js/app.js").then((response) => {
+            const mime = response.headers['content-type'];
+            // production server should contain 'text/javascript'
+            // local browswer-sync server should contain 'application/javascript'
+            expect(mime).to.contain('/javascript');
+        });
+    });
+
+});


### PR DESCRIPTION
This PR implements the enhancement request #2886 "Improve Cypress testing against non-functioning app.js" by checking the mime type of `/assets/js/app.js` to include `/javascript`. In addition, the mime type of `/assets/css/style.css` is checked to include `text/css`.

## JavaScript MIME type

According to https://www.rfc-editor.org/rfc/rfc9239 `application/javascript` is obsolete, however [browser-sync](https://www.npmjs.com/package/browser-sync) seems not to respect this and responds with
`Content-Type: application/javascript; charset=UTF-8`. This applies when running a local test copy of the web.

A simple compromise to accept both `application/javascript` (browser-sync) and `text/javascript` (production webserver) is to only check for `/javascript`, which allows the test to pass in both environments.

## Verification

### Local server verification

From a bash prompt at the root of the cloned [cwa-website repository](https://github.com/corona-warn-app/cwa-website) carry out the following steps:

1. `npm run test:open`
2. In Cypress test runner click on `mime.js`
3. 2 tests should pass, 0 tests should fail

### Production server verification

From a bash prompt at the root of the cloned [cwa-website repository](https://github.com/corona-warn-app/cwa-website) carry out the following steps:

1. `npx cypress open -c baseUrl=https://coronawarn.app`
2. In Cypress test runner click on `mime.js`
3. 2 tests should pass, 0 tests should fail

Alternatively, executing the following will run the test directly:<br>
`npx cypress run -s cypress/integration/mime.js -c baseUrl=https://coronawarn.app`