### PR TITLE
EN blog no translation - change to "German version only"

### DIFF
--- a/blog/2021-05-11-How-to-Schnelltest-Partner/index.md
+++ b/blog/2021-05-11-How-to-Schnelltest-Partner/index.md
@@ -10,7 +10,7 @@ layout: blog
 *German version only*
 
 
-Seit der Anfang Mai veröffentlichten Version 2.1 der Corona-Warn-App haben Nutzer\*innen die Möglichkeit, Schnelltests, die sie bei teilnehmenden Partnern durchführen, in die Corona-Warn-App zu integrieren. Für die Partner **dm drogie-märkte, testbuchen.de/No-Q (Apotheken)** und **EcoCare (Lidl)**, erklären wir an dieser Stelle, wie die Registrierung genau abläuft.
+Seit der Anfang Mai veröffentlichten Version 2.1 der Corona-Warn-App haben Nutzer\*innen die Möglichkeit, Schnelltests, die sie bei teilnehmenden Partnern durchführen, in die Corona-Warn-App zu integrieren. Für die Partner **dm drogerie-märkte, testbuchen.de/No-Q (Apotheken)** und **EcoCare (Lidl)**, erklären wir an dieser Stelle, wie die Registrierung genau abläuft.
 
 <!-- overview -->
 

--- a/blog/2021-05-11-How-to-Schnelltest-Partner/index.md
+++ b/blog/2021-05-11-How-to-Schnelltest-Partner/index.md
@@ -7,7 +7,7 @@ author: Hanna Heine
 layout: blog
 ---
 
-*Currently, German version only.*
+*German version only*
 
 
 Seit der Anfang Mai veröffentlichten Version 2.1 der Corona-Warn-App haben Nutzer\*innen die Möglichkeit, Schnelltests, die sie bei teilnehmenden Partnern durchführen, in die Corona-Warn-App zu integrieren. Für die Partner **dm drogie-märkte, testbuchen.de/No-Q (Apotheken)** und **EcoCare (Lidl)**, erklären wir an dieser Stelle, wie die Registrierung genau abläuft.

--- a/blog/2021-05-11-How-to-Schnelltest-Partner/index_de.md
+++ b/blog/2021-05-11-How-to-Schnelltest-Partner/index_de.md
@@ -7,7 +7,7 @@ author: Hanna Heine
 layout: blog
 ---
 
-Seit der Anfang Mai veröffentlichten Version 2.1 der Corona-Warn-App haben Nutzer\*innen die Möglichkeit, Schnelltests, die sie bei teilnehmenden Partnern durchführen, in die Corona-Warn-App zu integrieren. Für die Partner **dm drogie-märkte, testbuchen.de/No-Q (Apotheken)** und **EcoCare (Lidl)**, erklären wir an dieser Stelle, wie die Registrierung genau abläuft.
+Seit der Anfang Mai veröffentlichten Version 2.1 der Corona-Warn-App haben Nutzer\*innen die Möglichkeit, Schnelltests, die sie bei teilnehmenden Partnern durchführen, in die Corona-Warn-App zu integrieren. Für die Partner **dm drogerie-märkte, testbuchen.de/No-Q (Apotheken)** und **EcoCare (Lidl)**, erklären wir an dieser Stelle, wie die Registrierung genau abläuft.
 
 Unternehmen, die interessiert sind, ebenfalls als Partner Schnelltest-Ergebnisse in die Corona-Warn-App zu integrieren, können sich bei der Telekom und SAP per [E-Mail](mailto:registrierung.labore.pandemietest@t-systems.com) melden.
 
@@ -157,6 +157,3 @@ Unter iOS:
 - Firefox mit der vom Hersteller voreingestellten Konfiguration (default)
 - Opera mit der vom Hersteller voreingestellten Konfiguration (default)
 - Edge mit der vom Hersteller voreingestellten Konfiguration (default)
-
-
-

--- a/blog/2022-01-11-omikron/index.md
+++ b/blog/2022-01-11-omikron/index.md
@@ -7,7 +7,7 @@ author: CWA Team
 layout: blog
 ---
 
-*Aktualisiert am 21. Januar 2022 um 08:30 Uhr; English version coming soon*
+*Updated on 21 January 2022 at 08:30 am; German version only*
 
 Omikron breitet sich auch in Deutschland extrem schnell aus, ist jetzt die dominierende Variante sein. Muss die Corona-Warn-App jetzt an Omikron angepasst werden? 
 

--- a/blog/2022-01-21-cwa-uhrzeit-rote-kachel/index.md
+++ b/blog/2022-01-21-cwa-uhrzeit-rote-kachel/index.md
@@ -7,7 +7,7 @@ author: CWA Team
 layout: blog
 ---
 
-*English version coming soon*
+*German version only*
 
 In den vergangenen Tagen haben das Projektteam der CWA (Robert Koch-Institut, Deutsche Telekom und SAP) immer wieder Anfragen zu **Darstellung der genauen Uhrzeit und des Ortes bei Risikokontakten** erreicht. Viele Nutzerinnen und Nutzer wollen wissen, warum diese Details nicht angezeigt werden – und ob wir das ändern könnten.  
 


### PR DESCRIPTION
This PR resolves issue #2683 "Missing blog translations into English" by replacing promises that an English translation may come soon using the replacement text "_German version only_".

Also one typo regarding "*dm drogerie-märkte" is corrected.