### PR TITLE
Insert new FAQ #dcc_replacement_howto

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -549,6 +549,14 @@
                                     "The EU specifications for booster vaccination certificates have changed. If your certificate no longer meets the current specifications, it is still valid, but it may not be recognized as a booster vaccination during an inspection. In such a case, you can be informed about it via the Corona-Warn-App version 2.20.3 and later with an appropriate message. You can then voluntarily request a new vaccination certificate free of charge via the app. After you have given your consent, the app transmits the vaccination certificate to the RKI for verification, which issues an updated certificate and transmits it to your app. You will then find the updated certificate in the certificate tab. The old certificate is automatically moved to the recycle bin and deleted after 30 days. The old certificate can be restored at any time within the 30 days.",
                                     "For more information, visit the blog: <a href='../../blog/2022-03-30-cwa-2-20/' target='_blank'>Corona-Warn-App Version 2.20</a>"
                                 ]
+                            },
+                            {
+                                "title": "I receive a notification that the validity of a certificate is about to expire. What do I have to do?",
+                                "anchor": "dcc_replacement_howto",
+                                "active": false,
+                                "textblock": [
+                                    "The technical validity of COVID digital certificates expires automatically after 365 days. For all relevant certificates, you will receive a notification about this in the Corona-Warn-App 28 days before expiration. In order to continue to be able to prove your vaccination status with the app, the relevant certificates must be updated. You will soon be able to carry out the necessary reissue yourself in the app with just a few clicks."
+                                ]
                             }
                         ]
                     },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -549,6 +549,14 @@
                                     "Die Spezifikationen der EU für Impfzertifikate für Auffrischimpfungen wurden geändert. Sollte Ihr Zertifikat nicht mehr den aktuellen Spezifikationen entsprechen, ist es zwar weiterhin gültig, es kann jedoch sein, dass bei einer Prüfung die Auffrischimpfung nicht als solche erkannt wird. In solch einem Fall können Sie über die Corona-Warn-App ab Version 2.20.3 mit einer entsprechenden Nachricht darüber informiert werden. Sie können dann freiwillig ein neues Impfzertifikat kostenlos über die App anfordern. Nachdem Sie Ihr Einverständnis gegeben haben, übermittelt die App das Impfzertifikat zur Überprüfung an das RKI, welches ein aktualisiertes Zertifikat ausstellt und an Ihre App übermittelt. Sie finden das aktualisierte Zertifikat dann in der Zertifikate-Registerkarte. Das alte Zertifikat wird automatisch in den Papierkorb verschoben und nach 30 Tagen gelöscht. Das alte Zertifikat kann innerhalb der 30 Tage jederzeit wiederhergestellt werden.",
                                     "Weitere Informationen finden Sie im Blog: <a href='../../blog/2022-03-30-cwa-2-20/' target='_blank'>Corona-Warn-App Version 2.20</a>"
                                 ]
+                            },
+                            {
+                                "title": "Ich erhalte die Meldung, dass die Gültigkeit eines Zertifikats bald abläuft. Was muss ich tun?",
+                                "anchor": "dcc_replacement_howto",
+                                "active": false,
+                                "textblock": [
+                                    "Die technische Gültigkeit der digitalen COVID-Zertifikate läuft nach 365 Tagen automatisch ab. Für alle relevanten Zertifikate erhalten Sie dazu 28 Tage vor Ablauf eine Mitteilung in der Corona-Warn-App. Um Ihren Impfstatus weiterhin mit der App nachweisen zu können, müssen die entsprechenden Zertifikate aktualisiert werden. Die dazu notwendige Neuausstellung können Sie demnächst in der App mit wenigen Klicks selbst durchführen."
+                                ]
                             }
                         ]
                     },


### PR DESCRIPTION
This PR is for insert a new FAQ.

### DE

**Ich erhalte die Meldung, dass die Gültigkeit eines Zertifikats bald abläuft. Was muss ich tun?**

Die technische Gültigkeit der digitalen COVID-Zertifikate läuft nach 365 Tagen automatisch ab. Für alle relevanten Zertifikate erhalten Sie dazu 28 Tage vor Ablauf eine Mitteilung in der Corona-Warn-App. Um Ihren Impfstatus weiterhin mit der App nachweisen zu können, müssen die entsprechenden Zertifikate aktualisiert werden. Die dazu notwendige Neuausstellung können Sie demnächst in der App mit wenigen Klicks selbst durchführen.


### EN

**I receive a notification that the validity of a certificate is about to expire. What do I have to do?**

The technical validity of COVID digital certificates expires automatically after 365 days. For all relevant certificates, you will receive a notification about this in the Corona-Warn-App 28 days before expiration. In order to continue to be able to prove your vaccination status with the app, the relevant certificates must be updated. You will soon be able to carry out the necessary reissue yourself in the app with just a few clicks.

---
Internal Tracking ID: [EXPOSUREAPP-12829](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12829)
