### PR TITLE
Create check_videos.js Cypress Test

### DIFF
--- a/cypress/integration/check_videos.js
+++ b/cypress/integration/check_videos.js
@@ -1,0 +1,31 @@
+const { softAssert, softExpect } = chai;
+
+                context("Check for broken links", () => {
+                    const pages = [ '/de/faq/results/', '/en/faq/results/']
+
+
+  it('Check if txt results exist',() => {
+    cy.writeFile("cypress/logs/broken_videos_result.txt", "==================== Broken videos ====================\n")
+  })
+  pages.forEach(page => {
+    it(`"${page}" - Check for broken videos`, (done) => {
+      cy.visit({log: false, url: page})
+            cy.get('video').each(video => {
+                if (video.prop('paused') == true && video.prop('ended') == false) {         
+                    video[0].play().then(() => {
+                    softExpect(video.prop('paused')).to.eq(false)
+                    softExpect(video.prop('readyState') > 2).to.eq(true)
+                    if(video.prop('paused') == true) {
+                    cy.readFile("cypress/logs/broken_links_result.txt")
+                    .then((text) => {
+                        cy.writeFile("cypress/logs/broken_links_result.txt", `${text}\n${video.prop('src')} on '${page}' `, {flags: 'as+'})
+                    })
+                    } else {
+                        video[0].pause()
+                    }
+                })
+                }         
+            })
+    })
+  })
+})


### PR DESCRIPTION
Create the cypress test to check video tags to ensure videos are playable.

**NOTE: This is not ready to merge and is a work in progress. As suggested by @dsarkar and @MikeMcC399, I am opening this PR to facilitate collaboration. The current test script is able to locate videos and confirm the video is paused initially and start the video, but I am having difficulty properly checking that the video is actually playable/playing. Hoping that someone else may have some suggestions or want to take a stab at it while I try to work through the kinks on my side.**