### PR TITLE
Add glossary link #glossary_validity to FAQ dcc_replacement_howto

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -555,7 +555,7 @@
                                 "anchor": "dcc_replacement_howto",
                                 "active": false,
                                 "textblock": [
-                                    "The technical validity of COVID digital certificates expires automatically after 365 days. For all relevant certificates, you will receive a notification about this in the Corona-Warn-App 28 days before expiration. In order to continue to be able to prove your vaccination status with the app, the relevant certificates must be updated. You will soon be able to carry out the necessary reissue yourself in the app with just a few clicks."
+                                    "The technical validity of COVID digital certificates expires automatically after 365 days. For all relevant certificates, you will receive a notification about this in the Corona-Warn-App 28 days before expiration. In order to continue to be able to prove your vaccination status with the app, the relevant certificates must be updated. You will soon be able to carry out the necessary reissue yourself in the app with just a few clicks. See also <a href='#glossary_validity'>\"Validity of an EU Digital COVID Certificate\"</a>."
                                 ]
                             }
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -555,7 +555,7 @@
                                 "anchor": "dcc_replacement_howto",
                                 "active": false,
                                 "textblock": [
-                                    "Die technische Gültigkeit der digitalen COVID-Zertifikate läuft nach 365 Tagen automatisch ab. Für alle relevanten Zertifikate erhalten Sie dazu 28 Tage vor Ablauf eine Mitteilung in der Corona-Warn-App. Um Ihren Impfstatus weiterhin mit der App nachweisen zu können, müssen die entsprechenden Zertifikate aktualisiert werden. Die dazu notwendige Neuausstellung können Sie demnächst in der App mit wenigen Klicks selbst durchführen."
+                                    "Die technische Gültigkeit der digitalen COVID-Zertifikate läuft nach 365 Tagen automatisch ab. Für alle relevanten Zertifikate erhalten Sie dazu 28 Tage vor Ablauf eine Mitteilung in der Corona-Warn-App. Um Ihren Impfstatus weiterhin mit der App nachweisen zu können, müssen die entsprechenden Zertifikate aktualisiert werden. Die dazu notwendige Neuausstellung können Sie demnächst in der App mit wenigen Klicks selbst durchführen. Siehe auch <a href='#glossary_validity'>\"Gültigkeit eines EU digitalen COVID-Zertifikats\"</a>."
                                 ]
                             }
                         ]


### PR DESCRIPTION
This PR includes a link to _glossary_validity_ in _dcc_replacement_howto_ FAQ