### PR TITLE
Fixed glossary article not showing, when opening direct link on mobile devices

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -559,18 +559,24 @@ $(document).ready(function(){
                     if($(`${location.hash}`).hasClass("topic-container")) {
                         $($($($(`${location.hash}`).children()[0]).children()[0]).children()[0]).addClass("active");
                     }
+
                     //Open accordion and aim section title
-                    
                     if($(`${location.hash}`).hasClass("section-container")) {
                         $($(`${location.hash}`).parent().parent().parent().parent().children()[0]).addClass("active");
                     }
+
                     //Open accordion and aim question
-                    
                     if($(`${location.hash}`).hasClass("accordion-faq-item-title")){
                         $($(`${location.hash}`).parent().parent().parent().parent().parent().parent().parent().parent().children()[0]).addClass("active");
                     } 
+
+                    //Open glossary accordion
+                    if($(`${location.hash}`).hasClass("glossary-item-mobile-title")) {
+                        $($(`${location.hash}`).parent().parent().parent().parent().parent().parent().children()[0]).addClass("active");
+                    }
                 } 
                 const h3 =  $(`h3${location.hash}`);
+                const h5 = $(`h5${location.hash}`);
                 const topic = $(`${location.hash}.topic-title`);
                 const section = $(`${location.hash}.section-container`);
 
@@ -584,7 +590,11 @@ $(document).ready(function(){
                 } else if($(topic).length) { 
                     topic.click();
                     $(document).scrollTop(0)
-                } else if(hash === '#glossary') {
+                } else if ($(h5).length) {
+                    h5.click();
+                    if($(h5).hasClass("glossary-item-mobile-title")) $(document).scrollTop($(h5).offset().top);
+                }
+                 else if(hash === '#glossary') {
                     $('#glossary').click();
                 }
             },500)

--- a/src/partials/page-faq-results.html
+++ b/src/partials/page-faq-results.html
@@ -143,13 +143,13 @@
             {{#each letter as |content|}}
               {{#if @last}}
                 <div>
-                  <h5 class="mt-4 px-3" id="glossary_{{content.anchor}}"><b class="word">{{content.term}}</b></h5>
+                  <h5 class="mt-4 px-3 glossary-item-mobile-title" id="glossary_{{content.anchor}}"><b class="word">{{content.term}}</b></h5>
                   <div class="px-3 description">{{{content.description}}}</div>
                   <p class="px-3">{{#if anchor}}<a href="#glossary_{{anchor}}" class="faq-anchor">{{../../page-contents.glossary.permalink}}</a>{{/if}}</p>
                 </div>
               {{else}}
                 <div class="nav-tabs pb-3">
-                  <h5 class="mt-4 px-3" id="glossary_{{content.anchor}}"><b class="word">{{content.term}}</b></h5>
+                  <h5 class="mt-4 px-3 glossary-item-mobile-title" id="glossary_{{content.anchor}}"><b class="word">{{content.term}}</b></h5>
                   <div class="px-3 description">{{{content.description}}}</div>
                   <p class="px-3">{{#if anchor}}<a href="#glossary_{{anchor}}" class="faq-anchor">{{../../page-contents.glossary.permalink}}</a>{{/if}}</p>
                 </div>
@@ -166,13 +166,13 @@
             {{#each letter as |content|}}
               {{#if @last}}
                 <div>
-                  <h5 class="mt-4 px-3" id="glossary_{{content.anchor}}"><b class="word">{{content.term}}</b></h5>
+                  <h5 class="mt-4 px-3 glossary-item-mobile-title" id="glossary_{{content.anchor}}"><b class="word">{{content.term}}</b></h5>
                   <div class="px-3 description">{{{content.description}}}</div>
                   <p class="px-3">{{#if anchor}}<a href="#glossary_{{anchor}}" class="faq-anchor">{{../../page-contents.glossary.permalink}}</a>{{/if}}</p>
                 </div>
                 {{else}}
                 <div class="nav-tabs pb-3">
-                  <h5 class="mt-4 px-3" id="glossary_{{content.anchor}}"><b class="word">{{content.term}}</b></h5>
+                  <h5 class="mt-4 px-3 glossary-item-mobile-title" id="glossary_{{content.anchor}}"><b class="word">{{content.term}}</b></h5>
                   <div class="px-3 description">{{{content.description}}}</div>
                   <p class="px-3">{{#if anchor}}<a href="#glossary_{{anchor}}" class="faq-anchor">{{../../page-contents.glossary.permalink}}</a>{{/if}}</p>
                 </div>


### PR DESCRIPTION
I fixed the issue with glossary articles not showing, when opening a direct link to an article on mobile devices as mentioned in Issue #2914.