### PR TITLE
Revert "Fix some screenshot JSON issues"

### DIFF
--- a/src/data/screenshots-archive-2-6.json
+++ b/src/data/screenshots-archive-2-6.json
@@ -169,7 +169,7 @@
             },
             {
                 "title": "Check certificates for validity before a trip",
-                "anchor": "android_check_validity_certificate",
+                "anchor": "ios_check_validity_certificate",
                 "images": [
                     { "filename": "/assets/screenshots/2-6/en/ios/iPhone 11 Pro-screenshot_first_vaccination_certificate_details_part1", "alt": "Certificate check image 1 of 4" },
                     { "filename": "/assets/screenshots/2-6/en/ios/iPhone 11 Pro-screenshot_certificate_validation_date_selection", "alt": "Certificate check image 2 of 4" },

--- a/src/data/screenshots-archive-2-6_de.json
+++ b/src/data/screenshots-archive-2-6_de.json
@@ -169,7 +169,7 @@
             },
             {
                 "title": "Zertifikate vor einer Reise auf Gültigkeit prüfen",
-                "anchor": "android_check_validity_certificate",
+                "anchor": "ios_check_validity_certificate",
                 "images": [
                     { "filename": "/assets/screenshots/2-6/de/ios/iPhone 11 Pro-screenshot_first_vaccination_certificate_details_part1", "alt": "Zertifikate auf Gültigkeit prüfen Bild 1 von 4" },
                     { "filename": "/assets/screenshots/2-6/de/ios/iPhone 11 Pro-screenshot_certificate_validation_date_selection", "alt": "Zertifikate auf Gültigkeit prüfen Bild 2 von 4" },

--- a/src/data/screenshots-archive-2-7_de.json
+++ b/src/data/screenshots-archive-2-7_de.json
@@ -143,7 +143,7 @@
             },
             {
                 "title": "Testzertifikat",
-                "anchor": "android_test_certificate",
+                "anchor": "android_vaccination_certificate",
                 "images": [
                     { "filename": "/assets/screenshots/2-7/de/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Testzertifikat Bild 1 von 6" },
                     { "filename": "/assets/screenshots/2-7/de/android/RequestCovidCertificateFragment_pcr", "alt": "Testzertifikat Bild 2 von 6" },


### PR DESCRIPTION
Reverts corona-warn-app/cwa-website#2454

This seems to cause problems with the 2.23 branch. We will investigate this further once the release is over