### PR TITLE
Correct current iOS app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -512,7 +512,7 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html", PATHS.dist + "/**/*.json"])
     .pipe(replace('[ios.latest-os-version]', '15.5'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.23.2'))
+    .pipe(replace('[ios.current-app-version]', '2.23.1'))
     .pipe(replace('[android.latest-os-version]', '12'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '2.23.1'))


### PR DESCRIPTION
This PR lowers the current iOS app version from 2.23.2 to 2.23.1.

**Fixes #2927**