### PR TITLE
Cypress video test

### DIFF
--- a/cypress/integration/check_videos.js
+++ b/cypress/integration/check_videos.js
@@ -40,26 +40,20 @@ context("Check for broken videos", () => {
         cy.writeFile("cypress/logs/broken_videos_result.txt", "==================== Broken videos ====================\n")
     })
 
-    pages.forEach(page => {
+    pages.map(page => {
+        console.log(page);
         it(`"${page}" - Check for broken videos`, () => {
+            console.log("enter in test")
             cy.visit({log: false, url: page});
-            cy.get('#main').then($main => {
+            cy.get('main').then($main => {
                 if ($main.find('video').length > 0) {
-                    cy.get('video').each(video => {
-                        cy.request({
-                            failOnStatusCode: false, 
-                            log: false,
-                            url: video.prop('src')
-                        }).then((response) => {
-                            softExpect(response.status === 200 ? true : false, "Link: " + video.prop('src')).to.eq(true)
-                            if(response.status !== 200) {
-                                cy.readFile("cypress/logs/broken_videos_result.txt")
-                                .then((text) => {
-                                    cy.writeFile("cypress/logs/broken_videos_result.txt", `${text}\n[RESPONSE ${response.status}] ${video.prop('src')} on '${page}' `, {flags: 'as+'})
-                                })
-                            }
-                        })
+                    cy.get('video')
+                    .should(($video) => {
+                        expect(Number.isNaN($video.prop('duration')), `duration should be a number - broken '${$video.prop('src')}' on '${page}' `).to.eq(false);
+                        expect($video.prop('duration')).to.be.gt(0)
                     })
+                    .and('have.prop', 'paused', true)
+                    .and('have.prop', 'ended', false)
                 }
             })
         })
@@ -69,32 +63,23 @@ context("Check for broken videos", () => {
 context("Check for broken links on entries", () => {
     const pages = ['/de/blog/','/en/blog/','/de/science/', '/en/science/']
 
-    pages.forEach(sub => {
-        it(`"${sub}" entries - Check for broken videos`, () => {
-            cy.visit({log: false, url: sub} )
+    pages.map(page => {
+        it(`"${page}" entries - Check for broken videos`, () => {
+            cy.visit({log: false, url: page} )
             cy.get("a.blog-read-more").each(url => {
                 cy.visit({log: false, url: url.prop('href')} )
                 cy.get('main').then($main => {
-                    if ($main.find('source').length > 0) {
-                        cy.get('source').each(video => {
-                            cy.request({
-                                failOnStatusCode: false, 
-                                log: false,
-                                url: video.prop('src'),
-                                timeout: 100000
-                        }).then((response) => {
-                            softExpect(response.status === 200 ? true : false, "Link: " + video.prop('src')).to.eq(true)
-                            if(response.status !== 200) {
-                                cy.readFile("cypress/logs/broken_videos_result.txt")
-                                .then((text) => {
-                                    cy.writeFile("cypress/logs/broken_videos_result.txt", `${text}\n[RESPONSE ${response.status}] ${video.prop('src')} on '${url.prop('href')}' `, {flags: 'as+'})
-                                })
-                            }
+                    if ($main.find('video').length > 0) {
+                        cy.get('video')
+                        .should(($video) => {
+                            expect(Number.isNaN($video.prop('duration')), `duration should be a number - broken '${$video.prop('src')}' on '${page}' `).to.eq(false);
+                            expect($video.prop('duration')).to.be.gt(0)
                         })
-                    })
-                } 
+                        .and('have.prop', 'paused', true)
+                        .and('have.prop', 'ended', false)
+                    }
+                })
             })
-        })  
         })
     })
 })

--- a/cypress/integration/check_videos.js
+++ b/cypress/integration/check_videos.js
@@ -1,0 +1,100 @@
+const { softAssert, softExpect } = chai;
+
+context("Check for broken videos", () => {
+    const pages = [
+        '/de',
+        '/en',
+        '/de/eventregistration/',
+        '/en/eventregistration/',
+        '/de/community/',
+        '/en/community/',
+        '/de/analysis/',
+        '/en/analysis/',
+        '/de/blog/archiv/',
+        '/en/blog/archive/',
+        '/de/screenshots/',
+        '/en/screenshots/',
+        '/de/faq/', '/de/faq/results/',
+        '/en/faq/', '/en/faq/results/',
+        '/de/rat-partner/',
+        '/en/rat-partner/',
+        '/de/privacy/',
+        '/en/privacy/',
+        '/de/terms-of-use/',
+        '/en/terms-of-use/',
+        '/de/event-qr-code-guide/',
+        '/en/event-qr-code-guide/',
+        '/de/blog/','/en/blog/',
+        '/de/science/',
+        '/en/science/',
+        '/de/simple-language/',
+        '/en/simple-language/',
+        '/de/sign-language/',
+        '/en/sign-language/',
+        '/de/sitemap/',
+        '/en/sitemap/'
+    ];
+
+
+    it('Check if txt results exist',() => {
+        cy.writeFile("cypress/logs/broken_videos_result.txt", "==================== Broken videos ====================\n")
+    })
+
+    pages.forEach(page => {
+        it(`"${page}" - Check for broken videos`, () => {
+            cy.visit({log: false, url: page});
+            cy.get('#main').then($main => {
+                if ($main.find('video').length > 0) {
+                    cy.get('video').each(video => {
+                        cy.request({
+                            failOnStatusCode: false, 
+                            log: false,
+                            url: video.prop('src')
+                        }).then((response) => {
+                            softExpect(response.status === 200 ? true : false, "Link: " + video.prop('src')).to.eq(true)
+                            if(response.status !== 200) {
+                                cy.readFile("cypress/logs/broken_videos_result.txt")
+                                .then((text) => {
+                                    cy.writeFile("cypress/logs/broken_videos_result.txt", `${text}\n[RESPONSE ${response.status}] ${video.prop('src')} on '${page}' `, {flags: 'as+'})
+                                })
+                            }
+                        })
+                    })
+                }
+            })
+        })
+    })
+})
+
+context("Check for broken links on entries", () => {
+    const pages = ['/de/blog/','/en/blog/','/de/science/', '/en/science/']
+
+    pages.forEach(sub => {
+        it(`"${sub}" entries - Check for broken videos`, () => {
+            cy.visit({log: false, url: sub} )
+            cy.get("a.blog-read-more").each(url => {
+                cy.visit({log: false, url: url.prop('href')} )
+                cy.get('main').then($main => {
+                    if ($main.find('source').length > 0) {
+                        cy.get('source').each(video => {
+                            cy.request({
+                                failOnStatusCode: false, 
+                                log: false,
+                                url: video.prop('src'),
+                                timeout: 100000
+                        }).then((response) => {
+                            softExpect(response.status === 200 ? true : false, "Link: " + video.prop('src')).to.eq(true)
+                            if(response.status !== 200) {
+                                cy.readFile("cypress/logs/broken_videos_result.txt")
+                                .then((text) => {
+                                    cy.writeFile("cypress/logs/broken_videos_result.txt", `${text}\n[RESPONSE ${response.status}] ${video.prop('src')} on '${url.prop('href')}' `, {flags: 'as+'})
+                                })
+                            }
+                        })
+                    })
+                } 
+            })
+        })  
+        })
+    })
+})

--- a/cypress/integration/check_videos.js
+++ b/cypress/integration/check_videos.js
@@ -41,9 +41,7 @@ context("Check for broken videos", () => {
     })
 
     pages.map(page => {
-        console.log(page);
         it(`"${page}" - Check for broken videos`, () => {
-            console.log("enter in test")
             cy.visit({log: false, url: page});
             cy.get('main').then($main => {
                 if ($main.find('video').length > 0) {


### PR DESCRIPTION
I'm creating this PR to implement a Cypress test to check the videos' status from all the site. I want to thank @ahodzic2  for his PR #2907, which has helped me a lot to elaborate the test.

This new test is actually running without problems and has been tested by breaking the sources of some videos. The only drawback is that it doesn't save the broken URLs in a TXT file, but since there are so few videos on CWA website, I think we can avoid it.