### PR TITLE
Add Cypress test app_to_web

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -1,0 +1,41 @@
+{
+    "appVersion": "2.23",
+    "faqEntry": [
+        "#admission_policy",
+        "#android_location",
+        "#cause9002_recovery",
+        "#cert_eu_travel",
+        "#encounter_but_green",
+        "#ENError5",
+        "#ENError11",
+        "#ENError13",
+        "#error_log",
+        "#eu_dcc_check",
+        "#eu_dcc_export",
+        "#full_incompat",
+        "#further_details",
+        "#hc_signature_invalid",
+        "#notification_settings",
+        "#part_incompat",
+        "#quarantine_measures",
+        "#red_card_how_to_test",
+        "#root_detection_android",
+        "#voluntary_self_quarantine",
+        "#where_can_i_get_tested"
+    ],
+    "faqSection": [
+        "#eu_dcc",
+        "#test_cert"
+    ],
+    "faqRedirect": [
+        "#hc_prefix_invalid", "#eu_dcc",
+        "#vac_booster", "#vac_cert",
+        "#val_service_no_valid_dcc", "#val_service_basics",
+        "#val_service_result", "#val_service_basics"
+    ],
+    "accessibilityTab": [
+        "#website",
+        "#android",
+        "#ios"
+    ]
+}

--- a/cypress/integration/app_to_web.js
+++ b/cypress/integration/app_to_web.js
@@ -1,0 +1,58 @@
+/// <reference types="Cypress" />
+
+describe("Test cwa-webserver links used by Corona-Warn-App", () => {
+
+    let languages = ["en", "de"];
+    let links;
+    before(() => {
+        cy.fixture('appToWebLinks').then(webLinks => links = webLinks);
+    });
+
+    it("Test FAQ direct links", () => {
+        languages.forEach(lang => {
+            cy.visit("/" + lang + "/faq/results/").then(() => {
+                links.faqEntry.forEach(faqItem => {
+                    cy.get(faqItem).parent().next().find('.faq-anchor').invoke('attr', 'href').should('include', faqItem);
+                });
+            });
+        });
+    });
+
+    it("Test FAQ section links", () => {
+        languages.forEach(lang => {
+            cy.visit("/" + lang + "/faq/results/").then(() => {
+                links.faqSection.forEach(faqItem => {
+                    cy.get(faqItem).find('.faq').should('have.length.greaterThan', 0);
+                });
+            });
+        });
+    });
+
+    it("Test FAQ redirected links", () => {
+        var redirectFAQs = links.faqRedirect;
+        languages.forEach(lang => {
+            var i;
+            for (i = 0; i < redirectFAQs.length; i = i + 2) {
+                cy.testFaqRedirect(lang, redirectFAQs[i], redirectFAQs[i + 1]);
+            }
+        });
+    });
+
+    it("Test Accessibility links", () => {
+        languages.forEach(lang => {
+            cy.visit("/" + lang + "/accessibility/").then(() => {
+                links.accessibilityTab.forEach(tab => {
+                    cy.get(tab);
+                });
+            });
+        });
+    });
+
+    it("Test Social Media links", () => {
+        languages.forEach(lang => {
+            cy.visit("/" + lang + "/community/").then(() => {
+                cy.get("#socialmedia").should('have.text', "Social Media");
+            });
+        });
+    });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -11,6 +11,17 @@ Cypress.Commands.add('expectPathToBe', (pathToCheck, timeout = undefined) =>
   })
 );
 
+Cypress.Commands.add('testFaqRedirect', (lang, from, to) => {
+  cy.log("Test FAQ redirect from " + from + " to " + to);
+  cy.visit("/" + lang) // workaround to visit homepage between redirect tests
+    .then(() => {
+      cy.visit("/" + lang + "/faq/results/" + from)
+        .then(() => {
+          cy.url().should('contain', to);
+        });
+    });
+});
+
 //overide application error
 Cypress.on('uncaught:exception', (err, runnable) => {
   // returning false here prevents Cypress from


### PR DESCRIPTION
This PR implements the enhancement request https://github.com/corona-warn-app/cwa-website/issues/2909 "Extend Cypress testing to coronawarn.app links used by CWA app".

The PR:

- adds a new Cypress test `/cypress/integration/app_to_web.js`, which is data-driven from `/cypress/fixtures/appToWebLinks.json` for easier maintenance of any new links which need to be added
- adds a new Cypress command `testFaqRedirect` into `/cypress/support/index.js`. This works around a Cypress issue by returning to the homepage in between testing redirected links.

Links were manually harvested from:

- [links.xml](https://github.com/corona-warn-app/cwa-app-android/blob/main/Corona-Warn-App/src/main/res/values/links.xml) at the CWA Android 2.23 version level.
- [Localizable.links.strings](https://github.com/corona-warn-app/cwa-app-ios/blob/release/2.23.x/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings) at the CWA iOS 2.23 version level.

## Local test

To run the test locally execute<br>
`npm run test:open`<br>
then click on `app_to_web.js` in the Cypress test runner

## Production test

To run the test on the production website, execute<br>
`npx cypress run -s 'cypress/integration/app_to_web.js' -c baseUrl=https://coronawarn.app`


---
Internal Tracking ID: [EXPOSUREAPP-13210](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13210)