### PR TITLE
Add workflow for Cypress test on production with Chrome

### DIFF
--- a/.github/workflows/cypress-test-prod.yml
+++ b/.github/workflows/cypress-test-prod.yml
@@ -1,0 +1,25 @@
+name: Cypress Test Production
+# This workflow runs the Cypress test suite on the production server
+# https://coronawarn.app
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run daily at 9:00 UTC
+    - cron: "0 9 * * *"
+
+jobs:
+  Cypress-Test-Production:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v3
+        with:
+          browser: chrome
+          headless: true
+          config: baseUrl=https://coronawarn.app
+          # Only run tests in top level of integration directory
+          spec: cypress/integration/*.js


### PR DESCRIPTION
This draft PR partially implements the workflow requested in https://github.com/corona-warn-app/cwa-website/issues/2892 "Add new GitHub Actions workflow carrying out the cypress test suite".

It was suggested in https://github.com/corona-warn-app/cwa-website/issues/2892#issuecomment-1141760610 to run the test regularly.

It uses https://github.com/cypress-io/github-action to run Cypress tests on the production server https://coronawarn.app once a day. The tests selected are the ones in the top level of `cypress/integration`. The problematic test `check_links.js`, which is prone to failure, is already moved down one level to `cypress/integration/hybrid`, and is not selected.

Removing the line `spec: cypress/integration/*.js` would run all tests, if that is desired.

https://github.com/cypress-io/github-action can be used as the basis for other workflows, which might also be integrated into PR submission, and it allows build and test server start parameters to be added.

I only tested this so far by manually triggering it. I did not test the `cron` part.