### PR TITLE
Bump current iOS app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -515,7 +515,7 @@ function replaceVersionNumbers() {
     .pipe(replace('[ios.current-app-version]', '2.23.1'))
     .pipe(replace('[android.latest-os-version]', '12'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.23.1'))
+    .pipe(replace('[android.current-app-version]', '2.23.2'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
This PR bumps the current iOS app version from 2.23.1 to 2.23.2.

---

There is no GitHub release for this version yet. 