### PR TITLE
Bump current iOS app version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -512,7 +512,7 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html", PATHS.dist + "/**/*.json"])
     .pipe(replace('[ios.latest-os-version]', '15.5'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.23.1'))
+    .pipe(replace('[ios.current-app-version]', '2.23.2'))
     .pipe(replace('[android.latest-os-version]', '12'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '2.23.2'))


### PR DESCRIPTION
This PR bumps the current iOS app version from 2.23.1 to 2.23.2.

---

GitHub release: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v2.23.0-rc.10