### PR TITLE
Add faq anchor #eu_dcc_export_error to Cypress test for release 2.24

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -1,5 +1,5 @@
 {
-    "appVersion": "2.23",
+    "appVersion": "2.24",
     "faqEntry": [
         "#admission_policy",
         "#android_location",
@@ -12,6 +12,7 @@
         "#error_log",
         "#eu_dcc_check",
         "#eu_dcc_export",
+        "#eu_dcc_export_error",
         "#full_incompat",
         "#further_details",
         "#hc_signature_invalid",


### PR DESCRIPTION
This PR adds a new link
`#eu_dcc_export_error`
to be tested by [cypress/integration/app_to_web.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/app_to_web.js)

- The link was added to CWA Android [release/2.24.x](https://github.com/corona-warn-app/cwa-app-android/tree/release/2.24.x) through PR https://github.com/corona-warn-app/cwa-app-android/pull/5271 and is included in [v2.24.0-rc.1](https://github.com/corona-warn-app/cwa-app-android/releases/tag/v2.24.0-rc.1).

## Verification

The pre-requisite for a successful test is the creation of the FAQ articles to be finally published under:

- https://www.coronawarn.app/en/faq/#eu_dcc_export_error
- https://www.coronawarn.app/de/faq/#eu_dcc_export_error

### Verify pre-release

On branch [cwa-website/tree/release/2.24](https://github.com/corona-warn-app/cwa-website/tree/release/2.24)

`npm run test:open`
select test `app_to_web.js`

### Verify post release

`npx cypress run -s 'cypress/integration/app_to_web.js' -c baseUrl=https://coronawarn.app`
