### PR TITLE
Adjust heading width to avoid overlaps cancel box in Dashboard

### DIFF
--- a/src/assets/scss/_analyse.scss
+++ b/src/assets/scss/_analyse.scss
@@ -803,7 +803,9 @@
 		border: 1px solid transparent;
 
 
-		&-title {}
+		&-title {
+			width: calc(100% - 55px);
+		}
 
 		&-content {
 			overflow: auto;

--- a/src/assets/scss/_analyse.scss
+++ b/src/assets/scss/_analyse.scss
@@ -804,7 +804,7 @@
 
 
 		&-title {
-			width: calc(100% - 55px);
+			width: calc(100% - 100px);
 		}
 
 		&-content {


### PR DESCRIPTION
Due to issue #2966, I had controlled the heading width according to the cancel box width.

https://user-images.githubusercontent.com/44208107/174785325-0429ba5a-ec5d-48c8-8260-ce0067a56316.mp4


---
Internal Tracking ID: [EXPOSUREAPP-13402](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13402)