### PR TITLE
Remove bad link in red tile (EN) blog

### DIFF
--- a/blog/2021-12-15-handlungsempfehlung-rote-kachel/index.md
+++ b/blog/2021-12-15-handlungsempfehlung-rote-kachel/index.md
@@ -106,7 +106,7 @@ The red tile remains until the underlying risk exposure is more than 14 days in 
 
 Even with a green tile, there can be indications of encounters with people tested positively later. However, the Corona-Warn-App does not rate these encounters as an increased risk due to the circumstances (for example, short exposure period or long distance to that person). Therefore, it is not necessary for you to behave as stated above.
 
-Nevertheless, you should **adhere to the usual hygiene rules**: When you encounter other people, wear a medical mask, keep your distance from other people, sneeze or cough into your elbow or a handkerchief, wash your hands regularly with soap, and let fresh air in several times a day (see also [Coronavirus infection - this is how the coronavirus spreads](https://www.zusammengegencorona.de/en/ansteckung-mit-corona-so-wird-das-coronavirus-uebertragen/) for background information about reducing your risk of infection).
+Nevertheless, you should **adhere to the usual hygiene rules**: When you encounter other people, wear a medical mask, keep your distance from other people, sneeze or cough into your elbow or a handkerchief, wash your hands regularly with soap, and let fresh air in several times a day.
 
 
 


### PR DESCRIPTION
This PR resolves issue  https://github.com/corona-warn-app/cwa-website/issues/2976  "Link failure in red tile blog (EN)".

It removes the failing link to https://www.zusammengegencorona.de/en/ansteckung-mit-corona-so-wird-das-coronavirus-uebertragen/ in the blog article https://www.coronawarn.app/en/blog/2021-12-15-cwa-red-tile-guidance/ "What should you do if you see a red tile?".

![red tile blog EN 2](https://user-images.githubusercontent.com/66998419/174796853-4620dbf1-ae47-42b8-b939-0e833639c69e.jpg)

This paragraph in the English language blog is then equivalent to the German language blog, which already had no link.