### PR TITLE
Test type references for TAN hotline consistency

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -270,11 +270,11 @@
                                 ]
                             },
                             {
-                                "title": "Can I share my positive rapid antigen test or PCR rapid test result via the TAN hotline?",
+                                "title": "Can I share my positive rapid antigen test or rapid PCR test result via the TAN hotline?",
                                 "anchor": "rat_tan_hotline",
                                 "active": false,
                                 "textblock": [
-                                    "It is not possible to share a positive rapid test or rapid PCR test result via the TAN hotline."
+                                    "It is not possible to share a positive <a href='#glossary_rapid_antigen_test'>rapid antigen test</a> or <a href='#glossary_rapid_pcr_test'>rapid PCR test</a> result via the TAN hotline."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -270,11 +270,11 @@
                                 ]
                             },
                             {
-                                "title": "Kann ich mein positives Schnelltest- oder PCR-Schnelltest-Ergebnis über die TAN-Hotline teilen?",
+                                "title": "Kann ich mein positives Antigen-Schnelltest- oder PCR-Schnelltest-Ergebnis über die TAN-Hotline teilen?",
                                 "anchor": "rat_tan_hotline",
                                 "active": false,
                                 "textblock": [
-                                    "Es ist nicht möglich, ein positives Schnelltest- oder PCR-Schnelltest-Ergebnis über die TAN-Hotline zu teilen."
+                                    "Es ist nicht möglich, ein positives Ergebnis aus einem <a href='#glossary_rapid_antigen_test'>Antigen-Schnelltest</a> oder <a href='#glossary_rapid_pcr_test'>PCR-Schnelltest</a> über die TAN-Hotline zu teilen."
                                 ]
                             },
                             {


### PR DESCRIPTION
This PR resolves issue  https://github.com/corona-warn-app/cwa-website/issues/2978   "Terms for rapid tests in TAN hotline article".

It makes the terms for rapid antigen and rapid PCR tests used in the following articles consistent with the glossary and it links the terms to the glossary.

- https://www.coronawarn.app/en/faq/results/#rat_tan_hotline "Can I share my positive rapid antigen test or rapid PCR test result via the TAN hotline?"

![rapid tan hotline EN](https://user-images.githubusercontent.com/66998419/175323345-15097e27-7c2e-40fc-bf93-f1f67e0588ce.jpg)

- https://www.coronawarn.app/de/faq/results/#rat_tan_hotline "Kann ich mein positives Antigen-Schnelltest- oder PCR-Schnelltest-Ergebnis über die TAN-Hotline teilen?"

![image](https://user-images.githubusercontent.com/66998419/175512569-f7746db0-7023-4eef-9f5f-b06c2ea82b23.png)
