### PR TITLE
Update Cypress test app_to_web.js

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -1,5 +1,6 @@
 {
-    "appVersion": "2.24",
+    "appVersionFirst": "2.23",
+    "appVersionLast": "2.25",
     "faqEntry": [
         "#admission_policy",
         "#android_location",
@@ -15,6 +16,7 @@
         "#eu_dcc_export_error",
         "#full_incompat",
         "#further_details",
+        "#hc_already_registered",
         "#hc_signature_invalid",
         "#notification_settings",
         "#part_incompat",

--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -35,7 +35,7 @@
         "#val_service_result", "#val_service_basics"
     ],
     "blogEntry": [
-
+        "2021-08-05-statistictiles"
     ],
     "accessibilityTab": [
         "#website",

--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -34,6 +34,9 @@
         "#val_service_no_valid_dcc", "#val_service_basics",
         "#val_service_result", "#val_service_basics"
     ],
+    "blogEntry": [
+
+    ],
     "accessibilityTab": [
         "#website",
         "#android",

--- a/cypress/integration/app_to_web.js
+++ b/cypress/integration/app_to_web.js
@@ -38,6 +38,21 @@ describe("Test cwa-webserver links used by Corona-Warn-App", () => {
         });
     });
 
+    it("Test Blog links", () => {
+        var blogUrl = "";
+        if (links.blogEntry.length > 0) {
+            languages.forEach(lang => {
+                links.blogEntry.forEach(blogItem => {
+                    blogUrl = "/" + lang + "/blog/" + blogItem;
+                    cy.visit(blogUrl);
+                    cy.url().should("include", blogUrl);
+                });
+            });
+        } else {
+            cy.log("No blog links to test");
+        }
+    });
+
     it("Test Accessibility links", () => {
         languages.forEach(lang => {
             cy.visit("/" + lang + "/accessibility/").then(() => {


### PR DESCRIPTION
This PR provides an enhancement update to the Cypress test [cypress/integration/app_to_web.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/app_to_web.js) which tests that links used in the Android and iOS apps are working on the website https://www.coronawarn.app/.

## Updates

### Add blog test

The issue https://github.com/corona-warn-app/cwa-website/issues/3003 "Missing test for app to web blog link" is resolved through the following changes:

1. add a new test for blogs to [cypress/integration/app_to_web.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/app_to_web.js)
2. add a blog test data section `blogEntry` to [cypress/fixtures/appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json)
3. add the sub-link `2021-08-05-statistictiles` to [cypress/fixtures/appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json) in order to test that the related blog article is reachable and displays

### Add FAQ test 

The link `#hc_already_registered` is added to the list of FAQ links to be tested by the Cypress [cypress/integration/app_to_web.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/app_to_web.js) test as listed in [cypress/fixtures/appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json).

This change follows on from Android issue https://github.com/corona-warn-app/cwa-app-android/issues/5099 "Wrong FAQ link for VC_ALREADY_REGISTERED error" Internal Tracking ID: [EXPOSUREAPP-13218](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13218) and PR https://github.com/corona-warn-app/cwa-app-android/pull/5310 "Correct FAQ link hc_already_registered (EXPOSUREAPP-13218) (COMMUNITY) (closes #5099)".

### Add first and last app version

The documentary key `appVersion`  [cypress/fixtures/appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json) is extended to document the first and last version of the app covered by the test data file:

```
"appVersionFirst": "2.23"
"appVersionLast":  "2.25"
```
 
## Verification

### Unit test on production web

`npx cypress run -s cypress/integration/app_to_web.js -c baseUrl=https://coronawarn.app`

Expect 6 passing tests and All specs passed.

### Unit test on local clone

`npm run test:open`
select `app_to_web.js`

Expect green tick 6, red tick --.

### Integration test on local clone

`npm test`

Expect 134 tests passed and All specs passed.

---
Internal Tracking ID: [EXPOSUREAPP-13537](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13537)