### PR TITLE
Bump app versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -512,10 +512,10 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + "/**/*.html", PATHS.dist + "/**/*.json"])
     .pipe(replace('[ios.latest-os-version]', '15.5'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
-    .pipe(replace('[ios.current-app-version]', '2.24.0'))
+    .pipe(replace('[ios.current-app-version]', '2.24.1'))
     .pipe(replace('[android.latest-os-version]', '12'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.24.0'))
+    .pipe(replace('[android.current-app-version]', '2.24.1'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist))
 }


### PR DESCRIPTION
This PR bumps the iOS & Android app versions from 2.24.0 to 2.24.1.

--- 

Android release: https://github.com/corona-warn-app/cwa-app-android/releases/tag/v2.24.1
iOS release: https://github.com/corona-warn-app/cwa-app-ios/releases/tag/v2.24.1