### PR TITLE
Extend Cypress app_to_web.js test spec

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -37,7 +37,8 @@
         "#val_service_result", "#val_service_basics"
     ],
     "blogEntry": [
-        "2021-08-05-statistictiles"
+        "2021-08-05-statistictiles",
+        "2021-08-05-statistictiles/"
     ],
     "accessibilityTab": [
         "#website",

--- a/cypress/integration/app_to_web.js
+++ b/cypress/integration/app_to_web.js
@@ -8,6 +8,15 @@ describe("Test cwa-webserver links used by Corona-Warn-App", () => {
         cy.fixture('appToWebLinks').then(webLinks => links = webLinks);
     });
 
+    it("Test FAQ landing page", () => {
+        languages.forEach(lang => {
+            cy.visit("/" + lang + "/faq/").then(() => {
+                cy.get('a[href=results]').click();
+                cy.url().should('include', 'results');
+            });
+        });
+    });
+
     it("Test FAQ direct links", () => {
         languages.forEach(lang => {
             cy.visit("/" + lang + "/faq/results/").then(() => {


### PR DESCRIPTION
This PR implements suggestions from issue  https://github.com/corona-warn-app/cwa-website/issues/3028  "Testing of web links from app".

1. A simple test is added to [cypress/integration/app_to_web.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/app_to_web.js) to check the ability of the FAQ landing page https://www.coronawarn.app/en/faq/ and https://www.coronawarn.app/de/faq/ to access the detailed FAQ page `faq/results`.
2. The alternate blog link `2021-08-05-statistictiles/` is added to [cypress/fixtures/appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json)

## Verification

`npm run test:open`
select `app_to_web.js`

7 tests should run successfully with 0 failures

![image](https://user-images.githubusercontent.com/66998419/178922553-93fe71ec-6201-480c-86cb-d6bb695f0328.png)