### PR TITLE
Update links: Open all FAQ links in a new tab

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -274,7 +274,7 @@
                                 "anchor": "rat_tan_hotline",
                                 "active": false,
                                 "textblock": [
-                                    "It is not possible to share a positive <a href='#glossary_rapid_antigen_test'>rapid antigen test</a>, <a href='#glossary_selftest'>self-test</a> or <a href='#glossary_rapid_pcr_test'>rapid PCR test</a> result via the TAN hotline."
+                                    "It is not possible to share a positive <a href='#glossary_rapid_antigen_test' target='_blank'>rapid antigen test</a>, <a href='#glossary_selftest' target='_blank'>self-test</a> or <a href='#glossary_rapid_pcr_test' target='_blank'>rapid PCR test</a> result via the TAN hotline."
                                 ]
                             },
                             {
@@ -825,7 +825,7 @@
                                     "Case 1: Basic immunization with Johnson & Johnson (J&J) vaccine.",
                                     "Case 2: After recovery from COVID-19, a second booster vaccination is given.",
                                     "Case 3: After recovery from COVID-19, an initial vaccination with J&J is given.",
-                                    "The reason is the limitation of the current EU guidelines for the creation of the different vaccination certificates/sequences, which is mapped accordingly by the apps. See: <a href='https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf'>https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf</a> (in English)",
+                                    "The reason is the limitation of the current EU guidelines for the creation of the different vaccination certificates/sequences, which is mapped accordingly by the apps. See: <a href='https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf' target='_blank'>https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf</a> (in English)",
                                     "Reason:",
                                     "Regarding case 1 and case 2:",
                                     "In the case of a basic immunization with vaccines other than J&J, such as BioNTech, Moderna, or AstraZeneca, the entry \"2 of 2\" for the second dose is made in the certificate under \"Number of vaccination\". However, regardless of the vaccine used, a waiting period of 14 days is always required after the last vaccination of the basic immunization, since full vaccine protection is only given after the formation of a sufficient amount of antibodies.",
@@ -1330,12 +1330,12 @@
                                 "textblock": [
                                     "The technical hotline (<a href='#international_phone_numbers' target='_blank' >click here to see the phone numbers</a>) will help you with technical questions about the Corona-Warn-App, for instance if you have problems with exposure logging. You can reach the technical hotline from Monday to Friday from 7 a.m. to 5 p.m. (except on German national holidays), and it is free of charge for you within Germany.",
                                     "The TAN hotline (<a href='#international_phone_numbers' target='_blank' >click here to see the phone numbers</a>) will help you to enter the TAN if you have a positive PCR test result and if you have not received a TAN or document with a PCR-Test QR code. The TAN hotline is available Monday to Sunday from 7 a.m. to 8 p.m. German local time. The call is free of charge from within Germany.",
-                                    "If the test result is not available in the Corona-Warn-App, the relevant service personnel, test centre or health authority should be contacted to obtain the test result.  <br/>In order to make it easier for you to find the responsible health authority, the RKI has provided a corresponding tool. By entering the postal code or the city of residence, the responsible health authority (including contact details) is immediately displayed: <a href='https://tools.rki.de/PLZTool/en-GB'>Robert Koch Institute Tool: Health authority by postal code or place</a>",
-                                    "Further information on the PCR-Test QR Code procedure can be found in this FAQ entry: <a href='#qr_test'>I have scanned a PCR-Test QR code, but the test result could not be retrieved for days.</a>",
-                                    "The websites of the Federal Government are offering general information and videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch</a>.",
-                                    "The Robert Koch Institute also provides information on epidemiological aspects: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html'>https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html (German only)</a>.",
+                                    "If the test result is not available in the Corona-Warn-App, the relevant service personnel, test centre or health authority should be contacted to obtain the test result.  <br/>In order to make it easier for you to find the responsible health authority, the RKI has provided a corresponding tool. By entering the postal code or the city of residence, the responsible health authority (including contact details) is immediately displayed: <a href='https://tools.rki.de/PLZTool/en-GB' target='_blank'>Robert Koch Institute Tool: Health authority by postal code or place</a>",
+                                    "Further information on the PCR-Test QR Code procedure can be found in this FAQ entry: <a href='#qr_test' target='_blank'>I have scanned a PCR-Test QR code, but the test result could not be retrieved for days.</a>",
+                                    "The websites of the Federal Government are offering general information and videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch' target='_blank'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch</a>.",
+                                    "The Robert Koch Institute also provides information on epidemiological aspects: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html' target='_blank'>https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html (German only)</a>.",
                                     "As a media representative, please direct your enquiries to <a href='press...sap...com' class='email'>press...sap...com</a>.",
-                                    "The various feedback channels of the <a href='/en/community/'>Corona-Warn-App-Community<a/> will help you with your questions about the open source project of the Corona-Warn-App."
+                                    "The various feedback channels of the <a href='/en/community/' target='_blank'>Corona-Warn-App-Community<a/> will help you with your questions about the open source project of the Corona-Warn-App."
                                 ]
                             },
                             {
@@ -1507,7 +1507,7 @@
                                 "textblock": [
                                     "<b>Updated 30 March, 2022</b>",
                                     "The app is currently available in the following languages:<ul><li>German</li><li>English</li><li>Turkish (as of version 1.1.1)</li><li>Bulgarian (as of version 1.2.0)</li><li>Polish (as of version 1.2.0)</li><li>Romanian (as of version 1.2.0)</li><li>Ukrainian (as of version 2.20.0 for iOS and version 2.20.4 for Android)</li></ul>",
-                                    "The technical hotline (<a href='tel:08007540001'>0800 7540001</a>) answers in German.",
+                                    "The technical hotline (<a href='tel:08007540001' target='_blank'>0800 7540001</a>) answers in German.",
                                     "The language of the app is derived from the language that is configured in the smartphone's language settings. To display the app in German, for example, change the language settings to German.",
                                     "Please note that many countries release their own Corona tracking apps. Because the German Corona-Warn-App is also available in the app stores and play stores of these countries, the Corona tracking apps could be mixed up. Therefore, make sure that you download the app for your country.",
                                     "See also <a href='#international_phone_numbers' target='_blank' >How to reach us from abroad</a>."
@@ -1529,7 +1529,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<img src='/assets/img/faq/eu-flag.png' width=100px alt='EU flag'> This project was funded by the European Commission.",
-                                    "Together with the European Commission, an infrastructure for secure information exchange has been developed, known as the \"Interoperability Gateway\". This gateway enables the Corona-Warn-App to operate across national borders and to receive potential warning messages abroad. Detailed information about the Gateway is available from the European Commission in <a href='https://ec.europa.eu/commission/presscorner/detail/en/qanda_20_1905#gateway'>Coronavirus: EU interoperability gateway for contact tracing and warning apps – Questions and Answers</a>. In order to also enable warnings between users of the Swiss coronavirus app and the Corona-Warn-App, the RKI also operates another exchange server (deactivated April 1st, 2022) together with Switzerland (Federal Office of Public Health of the Swiss Confederation).",
+                                    "Together with the European Commission, an infrastructure for secure information exchange has been developed, known as the \"Interoperability Gateway\". This gateway enables the Corona-Warn-App to operate across national borders and to receive potential warning messages abroad. Detailed information about the Gateway is available from the European Commission in <a href='https://ec.europa.eu/commission/presscorner/detail/en/qanda_20_1905#gateway' target='_blank'>Coronavirus: EU interoperability gateway for contact tracing and warning apps – Questions and Answers</a>. In order to also enable warnings between users of the Swiss coronavirus app and the Corona-Warn-App, the RKI also operates another exchange server (deactivated April 1st, 2022) together with Switzerland (Federal Office of Public Health of the Swiss Confederation).",
                                     "To view more information in the app, tap",
                                     "<ol><li>'EXPOSURE LOGGING ACTIVE/STOPPED'</li><li>Then tap 'Transnational Exposure Logging'.</li><li>Scroll down to the list of countries.</li></ol>",
                                     "Below is a list of currently participating countries and details of the responsible health authorities:",
@@ -1794,7 +1794,7 @@
                                 "textblock": [
                                     "Since version 2.2, the Corona-Warn-App for Android checks whether your device supports all necessary Bluetooth features. If you are seeing this message, the operating system of your device lacks the ability to <i>send</i> random IDs via Bluetooth. However, it is still able to <i>receive</i> random IDs. <b>Your own risk assessment is therefore not affected</b>.",
                                     "The only limitation caused by this is that you cannot warn contacts discovered via Bluetooth when sharing a positive test result. However, users who were checked in to the same event or the same location, at the same time as you were, will still be warned. The Check-In functionality, the retrieval of PCR and rapid test results as well as the contact journal feature are not affected and can be used normally.",
-                                    "To resolve the problem, please update to the latest version of your device's operating system. If this doesn't help, please <a href='https://support.google.com/android/answer/3094742?hl=en'>contact your device manufacturer</a>.",
+                                    "To resolve the problem, please update to the latest version of your device's operating system. If this doesn't help, please <a href='https://support.google.com/android/answer/3094742?hl=en' target='_blank'>contact your device manufacturer</a>.",
                                     "<hr/>",
                                     "<b>Technical explanation</b>",
                                     "Your device's Bluetooth hardware supports the Bluetooth Low Energy technology which is necessary for distributing random IDs. However, the Bluetooth driver of your operating system is missing a capability called “peripheral mode”. Without this capability, the Corona-Warn-App cannot initiate your device to periodically broadcast its own random IDs via Bluetooth. This can only be fixed by your device manufacturer via an update of your operating system."
@@ -1808,7 +1808,7 @@
                                     "Since version 2.2, the Corona-Warn-App for Android checks whether your device supports all necessary Bluetooth features. If you are seeing this message, your device does not support the Bluetooth functionality needed for sending and receiving random IDs. Your risk assessment will therefore only be based on events and locations where you checked in.",
                                     "The Check-In functionality, the retrieval of PCR and rapid test results as well as the contact journal feature are not affected and can be used normally.",
                                     "Possible reasons for this message are:<ul><li>Your device does not contain the hardware that is required to use Bluetooth Low Energy.</li><li>Your device does not contain the software required to use the Bluetooth Low Energy capabilities of your hardware.</li><li>You are running the app in the Android Emulator.</li></ul>",
-                                    "To resolve the problem, please update to the latest version of your device's operating system. If this doesn't help, please <a href='https://support.google.com/android/answer/3094742?hl=en'>contact your device manufacturer</a>.",
+                                    "To resolve the problem, please update to the latest version of your device's operating system. If this doesn't help, please <a href='https://support.google.com/android/answer/3094742?hl=en' target='_blank'>contact your device manufacturer</a>.",
                                     "<hr/>",
                                     "<b>Technical explanation</b>",
                                     "The Corona-Warn-App needs the Bluetooth Low Energy technology for the distribution of random IDs. However, this technology is not available on your device due to missing hardware or software support. Without this capability, the Corona-Warn-App can neither initiate your device to periodically broadcast its own random IDs via Bluetooth nor receive random IDs from other devices."
@@ -1993,7 +1993,7 @@
                                     "'Settings' > 'WiFi' > Switch 'WiFi' off.",
                                     "'Settings' > 'Exposure notifications' > 'Active region' (Corona-Warn-App) > 'Corona-Warn-App' > Switch 'Share exposure information' off and on again.",
                                     "'Settings' > 'WiFi' > Switch 'WiFi' on again.",
-                                    "If the error still occurs although you have performed all steps, you have to reset and reinstall the application once. Your collected random ids will not be lost (<a href='#delete_random_ids'>see also here</a>). However, it will take 24 hours until the app resumes the data collected so."
+                                    "If the error still occurs although you have performed all steps, you have to reset and reinstall the application once. Your collected random ids will not be lost (<a href='#delete_random_ids' target='_blank'>see also here</a>). However, it will take 24 hours until the app resumes the data collected so."
                                 ]
                             },
                             {
@@ -2035,7 +2035,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>UPDATE</b><br/>This issue has been fixed in version 1.7.1.<hr/>",
-                                    "The notification <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633'>can be ignored</a>. The CWA is still working correctly and this issue will be solved with a <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510'>future release</a>."
+                                    "The notification <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497' target='_blank'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633' target='_blank'>can be ignored</a>. The CWA is still working correctly and this issue will be solved with a <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510' target='_blank'>future release</a>."
                                 ]
                             },
                             {
@@ -2334,7 +2334,7 @@
                                     "It is very important that you follow the quarantine/isolation and hygiene rules exactly - even if you should not have any symptoms. Follow the protective measures, i.e., follow coughing and sneezing rules, good hand hygiene, and keep your distance from others.",
                                     "Currently, the following quarantine options are recommended:",
                                     "<ul><li>5 days quarantine from last high-risk encounter without final testing.</li><li>5 days with PCR testing if sample is collected no earlier than day 5. Release from quarantine will not occur until negative test result is received. For individuals who are tested regularly as part of a serial testing strategy (e.g., schoolchildren), negative detection may also be considered using rapid antigen testing. Testing by rapid antigen test should be performed as a third-party test by or under the supervision on-site of trained individuals (supervised antigen test for self-testing).</li><li>5 days with rapid antigen test when sample is collected on day 5 at the earliest. Release from quarantine will not occur until negative test result is received. Testing should be performed as a third-party test by or under the supervision of trained individuals on site (supervised antigen test for self-testing).</li></ul>",
-                                    "See also: <ul><li>Robert Koch Institute: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html' target='_blank' rel='nofollow'>Recommendations on isolation and quarantine for SARS-CoV-2 infection and exposure (German only)</a></li><li>zusammengegencorona.de: <a href='https://www.zusammengegencorona.de/en/when-do-i-have-to-quarantine-or-self-isolate/' target='_blank' rel='nofollow'>When to quarantine or self-isolate</a></li><li>FAQ: <a href='#voluntary_self_quarantine'>Why is voluntary self-quarantine recommended?</a></li><li>FAQ: <a href='#where_can_i_get_tested'>Where can I get tested?</a></li><li>FAQ: <a href='#red_card_how_to_test'>Red Card? How to get the Corona Test</a></li></ul>"
+                                    "See also: <ul><li>Robert Koch Institute: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html' target='_blank' rel='nofollow'>Recommendations on isolation and quarantine for SARS-CoV-2 infection and exposure (German only)</a></li><li>zusammengegencorona.de: <a href='https://www.zusammengegencorona.de/en/when-do-i-have-to-quarantine-or-self-isolate/' target='_blank' rel='nofollow'>When to quarantine or self-isolate</a></li><li>FAQ: <a href='#voluntary_self_quarantine' target='_blank'>Why is voluntary self-quarantine recommended?</a></li><li>FAQ: <a href='#where_can_i_get_tested' target='_blank'>Where can I get tested?</a></li><li>FAQ: <a href='#red_card_how_to_test' target='_blank'>Red Card? How to get the Corona Test</a></li></ul>"
                                 ]
                             },
                             {
@@ -2346,7 +2346,7 @@
                                     "<b>Health departments are used to capacity:</b><br/>Currently, COVID-19 infection numbers are at very high levels and a high number of positive test results are being submitted through the Corona-Warn-App. Therefore, please understand that the health department cannot serve all contacts. Let the health department handle its important tasks, so contact your health department only if you absolutely need assistance, for example, because your employer or educational institution requires a certificate.",
                                     "<b>Recommendations for action:</b>",
                                     "<ul><li>Get tested. More information can be found here: <a href='https://www.bundesgesundheitsministerium.de/coronavirus/nationale-teststrategie/faq-covid-19-tests.html#c23926' target='_blank' rel='noopener'>Fragen und Antworten zu COVID-19 Tests (BMG, German only)</a></li><li>5 days is recommended for the period of self-quarantine from the date of the last increased risk encounter. Refer to the red tile for the date of the last increased risk encounter.</li><li>If possible, refrain from visits and activities where you will be with other people. Have groceries delivered or ask someone to do the shopping; avoid public transportation and refrain from air and train travel.</li><li>In particular, avoid contact with vulnerable persons and groups, such as the elderly and those with pre-existing conditions.</li><li>Also minimize contacts in your own household.</li><li>If your employer gives you the option, work from home.</li><li>Watch for symptoms of illness for at least 10 days (from the date of the increased risk encounter) and contact your primary care physician's office if you feel ill or experience symptoms.</li><li>Follow the rules of hygiene.</li></ul>",
-                                    "See also: <ul><li>Robert Koch Institute: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html' target='_blank' rel='nofollow'>Recommendations on isolation and quarantine for SARS-CoV-2 infection and exposure (German only)</a></li><li>zusammengegencorona.de: <a href='https://www.zusammengegencorona.de/en/when-do-i-have-to-quarantine-or-self-isolate/' target='_blank' rel='nofollow'>When to quarantine or self-isolate</a></li><li>FAQ: <a href='#quarantine_measures'>Questions about quarantine measures</a></li><li>FAQ: <a href='#where_can_i_get_tested'>Where can I get tested?</a></li><li>FAQ: <a href='#red_card_how_to_test'>Red Card? How to get the Corona Test</a></li></ul>"
+                                    "See also: <ul><li>Robert Koch Institute: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html' target='_blank' rel='nofollow'>Recommendations on isolation and quarantine for SARS-CoV-2 infection and exposure (German only)</a></li><li>zusammengegencorona.de: <a href='https://www.zusammengegencorona.de/en/when-do-i-have-to-quarantine-or-self-isolate/' target='_blank' rel='nofollow'>When to quarantine or self-isolate</a></li><li>FAQ: <a href='#quarantine_measures' target='_blank'>Questions about quarantine measures</a></li><li>FAQ: <a href='#where_can_i_get_tested' target='_blank'>Where can I get tested?</a></li><li>FAQ: <a href='#red_card_how_to_test' target='_blank'>Red Card? How to get the Corona Test</a></li></ul>"
                                 ]
                             },
                             {
@@ -2539,7 +2539,7 @@
                                 "anchor": "oss_complete",
                                 "active": false,
                                 "textblock": [
-                                    "Yes. The full source code of the app is openly available on <a href='https://github.com/corona-warn-app'>GitHub</a>. Code reviews and comments are possible before and after a version of the app is released. Questions about development topics such as security, data privacy will be clarified with the community. Each person can create their own build of the app and test it. Apart from the source code, we also discuss other central issues relevant for the app there. The discussion posts remain publicly available on GitHub."
+                                    "Yes. The full source code of the app is openly available on <a href='https://github.com/corona-warn-app' target='_blank'>GitHub</a>. Code reviews and comments are possible before and after a version of the app is released. Questions about development topics such as security, data privacy will be clarified with the community. Each person can create their own build of the app and test it. Apart from the source code, we also discuss other central issues relevant for the app there. The discussion posts remain publicly available on GitHub."
                                 ]
                             },
                             {
@@ -2557,7 +2557,7 @@
                                 "active": false,
                                 "textblock": [
                                     "The open-source project uses GitHub, a globally known online service that hosts software development projects on its servers. Anyone interested is encouraged to get involved in the project here, for example, by fixing bugs in the source code, making feature requests, helping with the documentation, raising questions or commenting on the project.",
-                                    "Collaboration within the community follows a defined code of conduct. You can find all the guidelines for participation <a href='/en/community/'>here</a>."
+                                    "Collaboration within the community follows a defined code of conduct. You can find all the guidelines for participation <a href='/en/community/' target='_blank'>here</a>."
                                 ]
                             },
                             {
@@ -2804,7 +2804,7 @@
                                 "anchor": "days_last_risk_encounter",
                                 "active": false,
                                 "textblock": [
-                                    "The number of days is counted as normal - '1 day since the last encounter' means 'yesterday', '2' the day before yesterday. The details of the technical implementation <a href='https://developer.apple.com/documentation/exposurenotification/enexposuredetectionsummary/3583708-dayssincelastexposure'>are explained here by Apple.</a>"
+                                    "The number of days is counted as normal - '1 day since the last encounter' means 'yesterday', '2' the day before yesterday. The details of the technical implementation <a href='https://developer.apple.com/documentation/exposurenotification/enexposuredetectionsummary/3583708-dayssincelastexposure' target='_blank'>are explained here by Apple.</a>"
                                 ]
                             },
                             {
@@ -3074,7 +3074,7 @@
                 {
                     "term": "Android",
                     "anchor": "android",
-                    "description": "Android is one of the two operating systems currently supported by the Corona-Warn-App, along with <a href='#glossary_ios'>iOS</a>, and the most widely used mobile operating system in the world. It is an <a href='#glossary_open_source'>open-source</a> operating system for mobile devices (such as smartphones or tablets) and other devices (such as TVs or cars). It is jointly developed by Google and the Open Handset Alliance (OHA)."
+                    "description": "Android is one of the two operating systems currently supported by the Corona-Warn-App, along with <a href='#glossary_ios' target='_blank'>iOS</a>, and the most widely used mobile operating system in the world. It is an <a href='#glossary_open_source' target='_blank'>open-source</a> operating system for mobile devices (such as smartphones or tablets) and other devices (such as TVs or cars). It is jointly developed by Google and the Open Handset Alliance (OHA)."
                 },
                 {
                     "term": "API",
@@ -3097,19 +3097,19 @@
                     "term": "Business Rules",
                     "anchor": "business_rules",
 
-                    "description": "<p>For the introduction of <a href='#glossary_digital_certificate'>Digital COVID Certificates</a>, the eHealth network of the European Commission and the EU member states agreed that every country compiles the individual rules which have to be checked for transnational traveling. These \"Business Rules\" have two categories:</p><ul><li>Invalidation Rules of the Country of Administration, which decide under which circumstances a <a href='#glossary_digital_certificate'>certificate</a> is rejected</li><li>Acceptance Rules of the Country of Arrival, which must be fulfilled to enter the country</li></ul>"
+                    "description": "<p>For the introduction of <a href='#glossary_digital_certificate' target='_blank'>Digital COVID Certificates</a>, the eHealth network of the European Commission and the EU member states agreed that every country compiles the individual rules which have to be checked for transnational traveling. These \"Business Rules\" have two categories:</p><ul><li>Invalidation Rules of the Country of Administration, which decide under which circumstances a <a href='#glossary_digital_certificate' target='_blank'>certificate</a> is rejected</li><li>Acceptance Rules of the Country of Arrival, which must be fulfilled to enter the country</li></ul>"
                 }
             ],
             "C": [
                 {
                     "term": "Certificate",
                     "anchor": "certificate",
-                    "description": "See <a href='#glossary_digital_certificate'>Digital Certificate</a>"
+                    "description": "See <a href='#glossary_digital_certificate' target='_blank'>Digital Certificate</a>"
                 },
                 {
                     "term": "Certificate of Recovery",
                     "anchor": "recovery_certificate",
-                    "description": "The certificate of recovery is a <a href='#glossary_digital_certificate'>digital certificate</a> issued for a person who has demonstrably recovered from COVID-19 and proved immunity by a PCR test."
+                    "description": "The certificate of recovery is a <a href='#glossary_digital_certificate' target='_blank'>digital certificate</a> issued for a person who has demonstrably recovered from COVID-19 and proved immunity by a PCR test."
                 },
                 {
                     "term": "Check-in",
@@ -3156,7 +3156,7 @@
                 {
                     "term": "Data Donation",
                     "anchor": "data_donation",
-                    "description": "A voluntary and anonymous way to provide the RKI with data on the use of the CWA. Voluntary data donation can help experts evaluate the effectiveness of the app and further improve it. More information is summarized here: <a href='../../blog/2021-03-04-corona-warn-app-version-1-13/'>Science Blog: Users can provide data voluntarily to help improve the Corona-Warn-App further</a>."
+                    "description": "A voluntary and anonymous way to provide the RKI with data on the use of the CWA. Voluntary data donation can help experts evaluate the effectiveness of the app and further improve it. More information is summarized here: <a href='../../blog/2021-03-04-corona-warn-app-version-1-13/' target='_blank'>Science Blog: Users can provide data voluntarily to help improve the Corona-Warn-App further</a>."
                 },
                 {
                     "term": "DCC",
@@ -3166,29 +3166,29 @@
                 {
                     "term": "Diagnosis Key",
                     "anchor": "diagnosis_key",
-                    "description": "See <a href='#glossary_temporary_exposure_keys'>Temporary Exposure Keys</a>"
+                    "description": "See <a href='#glossary_temporary_exposure_keys' target='_blank'>Temporary Exposure Keys</a>"
                 },
                 {
                     "term": "Digital Certificate",
                     "anchor": "digital_certificate",
-                    "description": "<p>A digital certificate is an authenticated digital document. It contains at least the holder's name, the holder's public key, and the digital signature (<a href='#glossary_signature'>signature</a>) of the issuing entity.</p> <p>Each digital certificate has an issue date and a time-limited <a href='#glossary_validity'>validity</a> (expiration date). After the validity expires, the certificate must be renewed. As of version 2.23, this can be done directly in the app.</p> <p>In the CWA, we distinguish between:</p> <ul><li>Vaccination certificate</li><li>Test certificate</li><li>Certificates of recovery</li></ul>"
+                    "description": "<p>A digital certificate is an authenticated digital document. It contains at least the holder's name, the holder's public key, and the digital signature (<a href='#glossary_signature' target='_blank'>signature</a>) of the issuing entity.</p> <p>Each digital certificate has an issue date and a time-limited <a href='#glossary_validity' target='_blank'>validity</a> (expiration date). After the validity expires, the certificate must be renewed. As of version 2.23, this can be done directly in the app.</p> <p>In the CWA, we distinguish between:</p> <ul><li>Vaccination certificate</li><li>Test certificate</li><li>Certificates of recovery</li></ul>"
                 },
                 {
                     "term": "Digital Signature",
                     "anchor": "digital_signature",
-                    "description": "See <a href='#glossary_signature'>Signature</a>"
+                    "description": "See <a href='#glossary_signature' target='_blank'>Signature</a>"
                 },
                 {
                     "term": "Digital Vaccination Certificate",
                     "anchor": "digital_vaccination_certificate",
-                    "description": "See <a href='#glossary_digital_certificate'>Digital Certificate</a>"
+                    "description": "See <a href='#glossary_digital_certificate' target='_blank'>Digital Certificate</a>"
                 }
             ],
             "E": [
                 {
                     "term": "Effective validity",
                     "anchor": "effective_validity",
-                    "description": "We refer to the duration of vaccination protection as 'effective validity'. The effective validity of the vaccination thus counts from the last vaccination date. While in Germany the effective validity is currently set at one year, the validity of the vaccination protection in other countries may differ from this. In the case of a <a href='#glossary_recovery_certificate'>certificates of recovery</a>, the effective validity is set at 90 days, according to the <a href='https://www.gesetze-im-internet.de/ifsg/__22a.html' target='_blank' rel='noopener noreferrer'>German Infection Protection Act (IfSG)</a>."
+                    "description": "We refer to the duration of vaccination protection as 'effective validity'. The effective validity of the vaccination thus counts from the last vaccination date. While in Germany the effective validity is currently set at one year, the validity of the vaccination protection in other countries may differ from this. In the case of a <a href='#glossary_recovery_certificate' target='_blank'>certificates of recovery</a>, the effective validity is set at 90 days, according to the <a href='https://www.gesetze-im-internet.de/ifsg/__22a.html' target='_blank' rel='noopener noreferrer'>German Infection Protection Act (IfSG)</a>."
                 },
                 {
                     "term": "Error report",
@@ -3198,12 +3198,12 @@
                 {
                     "term": "EU DCC",
                     "anchor": "eu_dcc",
-                    "description": "See <a href='#glossary_dcc'>DCC</a>"
+                    "description": "See <a href='#glossary_dcc' target='_blank'>DCC</a>"
                 },
                 {
                     "term": "European Federation Gateway Service (EFGS)",
                     "anchor": "efgs",
-                    "description": "A central infrastructure that is used to exchange and check <a href='#glossary_diagnosis_key'>diagnosis keys</a> across national borders."
+                    "description": "A central infrastructure that is used to exchange and check <a href='#glossary_diagnosis_key' target='_blank'>diagnosis keys</a> across national borders."
                 },
                 {
                     "term": "Event registration",
@@ -3228,7 +3228,7 @@
                 {
                     "term": "Exposure Notification System (ENS)",
                     "anchor": "ens",
-                    "description": "See <a href='#glossary_enf'>Exposure Notification Framework (ENF)</a>"
+                    "description": "See <a href='#glossary_enf' target='_blank'>Exposure Notification Framework (ENF)</a>"
                 }
             ],
             "G": [
@@ -3242,11 +3242,11 @@
                 {
                     "term": "iOS",
                     "anchor": "ios",
-                    "description": "iOS is a mobile operating system developed by Apple for the iPhone, iPod touch and formerly also iPad. Along with <a href='#glossary_android'>Android</a>, it is one of the two operating systems that the Corona-Warn-App supports."
+                    "description": "iOS is a mobile operating system developed by Apple for the iPhone, iPod touch and formerly also iPad. Along with <a href='#glossary_android' target='_blank'>Android</a>, it is one of the two operating systems that the Corona-Warn-App supports."
                 },{
                     "term": "Isolation",
                     "anchor": "isolation",
-                    "description": "Isolation is a government-ordered measure for persons who have been confirmed to have SARS-CoV-2 infection by a PCR-Test. Isolation can be gone through at home or, if the disease is severe, in a hospital. Release from isolation is based on specified <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Entlassmanagement.html?nn=13490888'> criteria (German only)</a>. At the time of release, the person is considered to no longer be infectious. See also <a href='#glossary_quarantine'>Quarantine</a>. "
+                    "description": "Isolation is a government-ordered measure for persons who have been confirmed to have SARS-CoV-2 infection by a PCR-Test. Isolation can be gone through at home or, if the disease is severe, in a hospital. Release from isolation is based on specified <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Entlassmanagement.html?nn=13490888' target='_blank'> criteria (German only)</a>. At the time of release, the person is considered to no longer be infectious. See also <a href='#glossary_quarantine' target='_blank'>Quarantine</a>. "
 
                 }
             ],
@@ -3254,7 +3254,7 @@
                 {
                     "term": "Molecular biological test",
                     "anchor": "molecular_biological_test",
-                    "description": "See <a href='#glossary_pcr_test'>PCR test</a>"
+                    "description": "See <a href='#glossary_pcr_test' target='_blank'>PCR test</a>"
                 }
             ],
             "O": [
@@ -3268,17 +3268,17 @@
                 {
                     "term": "PCR Test",
                     "anchor": "pcr_test",
-                    "description": "Among PCR tests, it is important to differentiate between the laboratory-based PCR test and the <a href='#glossary_rapid_pcr_test'>Rapid PCR Tests</a>. Since the term \"PCR Test\" usually refers to the laboratory-based PCR test, this entry will refer to it. Laboratory-based PCR tests are considered the most accurate among corona tests. In this type of test, medical personnel collect the sample and have it analyzed by a laboratory. Unlike the <a href='#glossary_rapid_pcr_test'>Rapid PCR Test</a>, the result of a PCR test can be received in the Corona-Warn-App."
+                    "description": "Among PCR tests, it is important to differentiate between the laboratory-based PCR test and the <a href='#glossary_rapid_pcr_test' target='_blank'>Rapid PCR Tests</a>. Since the term \"PCR Test\" usually refers to the laboratory-based PCR test, this entry will refer to it. Laboratory-based PCR tests are considered the most accurate among corona tests. In this type of test, medical personnel collect the sample and have it analyzed by a laboratory. Unlike the <a href='#glossary_rapid_pcr_test' target='_blank'>Rapid PCR Test</a>, the result of a PCR test can be received in the Corona-Warn-App."
                 },
                 {
                     "term": "Privacy Preserving Analytics (PPA)",
                     "anchor": "ppa",
-                    "description": "With the help of the procedure, which is called Privacy Preserving Analytics or PPA for short, it is possible for users of the Corona-Warn-App to make data collected on their smartphone available to an evaluating authority without revealing their identity. Since March 5, 2021, operational data has been donated anonymously but authenticated by Corona-Warn-App users on a daily basis via this procedure. Verification of the donating endpoint is performed to ensure that only a genuine Corona-Warn-App is submitting data from a genuine endpoint (for detailed documentation, see <a href='https://github.com/corona-warn-app/cwa-ppa-server' target='_blank' rel='noopener noreferrer'>GitHub repository: cwa-ppa-server</a>). See also <a href='#glossary_data_donation'>Data Donation</a>."
+                    "description": "With the help of the procedure, which is called Privacy Preserving Analytics or PPA for short, it is possible for users of the Corona-Warn-App to make data collected on their smartphone available to an evaluating authority without revealing their identity. Since March 5, 2021, operational data has been donated anonymously but authenticated by Corona-Warn-App users on a daily basis via this procedure. Verification of the donating endpoint is performed to ensure that only a genuine Corona-Warn-App is submitting data from a genuine endpoint (for detailed documentation, see <a href='https://github.com/corona-warn-app/cwa-ppa-server' target='_blank' rel='noopener noreferrer'>GitHub repository: cwa-ppa-server</a>). See also <a href='#glossary_data_donation' target='_blank'>Data Donation</a>."
                 },
                 {
                     "term": "Proof of Vaccination",
                     "anchor": "vaccination_proof",
-                    "description": "<p>The proof of vaccination documents a vaccination procedure with a vaccine recommended by the Paul Ehrlich Institute. A vaccination proof must contain at least the following attributes:</p> <ul><li>the personal data of the vaccinated person (at least surname, first name and date of birth)</li><li>date of vaccination, number of vaccinations,</li><li>designation of the vaccine,</li><li>name of the disease against which the vaccination was carried out, and</li><li>characteristics that indicate the person or institution responsible for carrying out the vaccination or issuing the proof of vaccination, for example, an official symbol or the name of the issuer. </li></ul><p>For entry, according to § 2 number 10 Coronavirus-Einreiseverordnung, the vaccination certificate must still meet additional requirements (regarding languages and vaccination schema).</p><p>The proof of vaccination can be documented in different ways, one form is the digital <a href='#glossary_vaccination_certificate'>vaccination certificate</a>.</p>"
+                    "description": "<p>The proof of vaccination documents a vaccination procedure with a vaccine recommended by the Paul Ehrlich Institute. A vaccination proof must contain at least the following attributes:</p> <ul><li>the personal data of the vaccinated person (at least surname, first name and date of birth)</li><li>date of vaccination, number of vaccinations,</li><li>designation of the vaccine,</li><li>name of the disease against which the vaccination was carried out, and</li><li>characteristics that indicate the person or institution responsible for carrying out the vaccination or issuing the proof of vaccination, for example, an official symbol or the name of the issuer. </li></ul><p>For entry, according to § 2 number 10 Coronavirus-Einreiseverordnung, the vaccination certificate must still meet additional requirements (regarding languages and vaccination schema).</p><p>The proof of vaccination can be documented in different ways, one form is the digital <a href='#glossary_vaccination_certificate' target='_blank'>vaccination certificate</a>.</p>"
                 },
                 {
                     "term": "Pseudonymity",
@@ -3290,29 +3290,29 @@
                 {
                     "term": "Quarantine",
                     "anchor": "quarantine",
-                    "description": "A protective measure that helps contain the spread of infectious diseases through human isolation. See also <a href='#glossary_isolation'>Isolation</a>."
+                    "description": "A protective measure that helps contain the spread of infectious diseases through human isolation. See also <a href='#glossary_isolation' target='_blank'>Isolation</a>."
                 }
             ],
             "R": [
                 {
                     "term": "RAT",
                     "anchor": "rat",
-                    "description": "Short for Rapid Antigen Test. See <a href='#glossary_rapid_antigen_test'>Rapid Antigen Test</a>"
+                    "description": "Short for Rapid Antigen Test. See <a href='#glossary_rapid_antigen_test' target='_blank'>Rapid Antigen Test</a>"
                 },
                 {
                     "term": "Rapid Antigen Test",
                     "anchor": "rapid_antigen_test",
-                    "description": "<p>Rapid antigen tests are similar in procedure to the <a href='#glossary_selftest'>self-test</a>, but are performed by trained personnel. A comparison of the two antigen test types has been provided by the RKI: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Downloads/Flyer-Antigentests.pdf?__blob=publicationFile'>Link to the comparison from the RKI</a></p><p>Not all rapid antigen tests are similarly reliable. For this reason, the Paul Ehrlich Institute has published so-called minimum criteria for rapid antigen tests: <a href='https://www.pei.de/SharedDocs/Downloads/DE/newsroom/dossiers/mindestkriterien-sars-cov-2-antigentests?__blob=publicationFile&v=9'>Link to minimum criteria</a></p><p>A positive result from a rapid antigen test is not a final diagnosis and should be confirmed by a <a href='#glossary_pcr_test'>PCR test</a>.</p>"
+                    "description": "<p>Rapid antigen tests are similar in procedure to the <a href='#glossary_selftest' target='_blank'>self-test</a>, but are performed by trained personnel. A comparison of the two antigen test types has been provided by the RKI: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Downloads/Flyer-Antigentests.pdf?__blob=publicationFile' target='_blank'>Link to the comparison from the RKI</a></p><p>Not all rapid antigen tests are similarly reliable. For this reason, the Paul Ehrlich Institute has published so-called minimum criteria for rapid antigen tests: <a href='https://www.pei.de/SharedDocs/Downloads/DE/newsroom/dossiers/mindestkriterien-sars-cov-2-antigentests?__blob=publicationFile&v=9' target='_blank'>Link to minimum criteria</a></p><p>A positive result from a rapid antigen test is not a final diagnosis and should be confirmed by a <a href='#glossary_pcr_test' target='_blank'>PCR test</a>.</p>"
                 },
                 {
                     "term": "Rapid PCR Test",
                     "anchor": "rapid_pcr_test",
-                    "description": "Rapid PCR tests, also often referred to as \"PoC-NAAT-tests\", are based on the same technology as regular <a href='#glossary_pcr_test'>PCR tests</a>, but can be evaluated quickly and on-site and are therefore particularly suitable in situations where a relatively reliable test result is required within a short time. Unlike regular PCR tests, their application is not limited to a medical laboratory. At the moment it is not possible to get a Rapid PCR Test result in the Corona-Warn-App, but the technical preparations have already been implemented in version 2.19."
+                    "description": "Rapid PCR tests, also often referred to as \"PoC-NAAT-tests\", are based on the same technology as regular <a href='#glossary_pcr_test' target='_blank'>PCR tests</a>, but can be evaluated quickly and on-site and are therefore particularly suitable in situations where a relatively reliable test result is required within a short time. Unlike regular PCR tests, their application is not limited to a medical laboratory. At the moment it is not possible to get a Rapid PCR Test result in the Corona-Warn-App, but the technical preparations have already been implemented in version 2.19."
                 },
                 {
                     "term": "Rapid Test",
                     "anchor": "rapid_test",
-                    "description": "See <a href='#glossary_rapid_antigen_test'>Rapid Antigen Test</a> or <a href='#glossary_rapid_pcr_test'>Rapid PCR Test</a>"
+                    "description": "See <a href='#glossary_rapid_antigen_test' target='_blank'>Rapid Antigen Test</a> or <a href='#glossary_rapid_pcr_test' target='_blank'>Rapid PCR Test</a>"
                 },
                 {
                     "term": "Rapid Test Profile",
@@ -3322,7 +3322,7 @@
                 {
                     "term": "Recovery Certificate",
                     "anchor": "recovery_certificate_alt",
-                    "description": "Please see the glossary entry <a href='#glossary_recovery_certificate'>Certificate of Recovery</a>."
+                    "description": "Please see the glossary entry <a href='#glossary_recovery_certificate' target='_blank'>Certificate of Recovery</a>."
                 },
                 {
                     "term": "Release",
@@ -3354,17 +3354,17 @@
                 {
                     "term": "SARS-CoV-2",
                     "anchor": "sars_cov_2",
-                    "description": "See <a href='#glossary_corona_virus'>Corona Virus</a>"
+                    "description": "See <a href='#glossary_corona_virus' target='_blank'>Corona Virus</a>"
                 },
                 {
                     "term": "Science-Blog",
                     "anchor": "science_blog",
-                    "description": "The Corona-Warn-App Science Blog covers various scientific topics related to the Corona-Warn-App, such as its effectiveness, benefits, as well as results of scientific evaluations conducted by the Robert Koch Institute. See <a href='../../science'>Science-Blog</a>."
+                    "description": "The Corona-Warn-App Science Blog covers various scientific topics related to the Corona-Warn-App, such as its effectiveness, benefits, as well as results of scientific evaluations conducted by the Robert Koch Institute. See <a href='../../science' target='_blank'>Science-Blog</a>."
                 },
                 {
                     "term": "Self-test",
                     "anchor": "selftest",
-                    "description": "Self-tests are freely available and can be used safely even by untrained individuals. For the evaluation of a self-test, which will be done within 15 to 30 minutes, there is no need for a laboratory. Therefore, you do not have to go to a doctor, the health department or a testing station, but can test yourself comfortably at home. However, a self-test is only reliable if it has been carried out correctly. Because this is difficult to detect, self-test results are not sufficient for testing to free yourself from a prescribed quarantine, nor for confirmation of infection. In both cases, a certified <a href='#glossary_rapid_antigen_test'>rapid antigen test</a> is necessary."
+                    "description": "Self-tests are freely available and can be used safely even by untrained individuals. For the evaluation of a self-test, which will be done within 15 to 30 minutes, there is no need for a laboratory. Therefore, you do not have to go to a doctor, the health department or a testing station, but can test yourself comfortably at home. However, a self-test is only reliable if it has been carried out correctly. Because this is difficult to detect, self-test results are not sufficient for testing to free yourself from a prescribed quarantine, nor for confirmation of infection. In both cases, a certified <a href='#glossary_rapid_antigen_test' target='_blank'>rapid antigen test</a> is necessary."
                 },
                 {
                     "term": "Short Lived Random Bluetooth ID",
@@ -3391,7 +3391,7 @@
                 {
                     "term": "Technical Validity",
                     "anchor": "technical_validity",
-                    "description": "The certificate as a document has an issue date and a technical expiration date, just like your passport or ID card, for example. For all certificates, the expiration date is set by the issuer of the certificate. Currently in Germany, the EU digital vaccination, test and certificates of recovery are usually issued with a technical validity of one year from the date of issue. As of version 2.23, you can reissue the currently used <a href='#glossary_dcc'>DCC</a> in the app."
+                    "description": "The certificate as a document has an issue date and a technical expiration date, just like your passport or ID card, for example. For all certificates, the expiration date is set by the issuer of the certificate. Currently in Germany, the EU digital vaccination, test and certificates of recovery are usually issued with a technical validity of one year from the date of issue. As of version 2.23, you can reissue the currently used <a href='#glossary_dcc' target='_blank'>DCC</a> in the app."
                 },
                 {
                     "term": "Temporary Exposure Keys",
@@ -3401,19 +3401,19 @@
                 {
                     "term": "Test Certificate",
                     "anchor": "test_certificate",
-                    "description": "A test certificate is a <a href='#glossary_digital_certificate'>digital certificate</a> issued for a person who has completed a COVID-19 test with a negative result."
+                    "description": "A test certificate is a <a href='#glossary_digital_certificate' target='_blank'>digital certificate</a> issued for a person who has completed a COVID-19 test with a negative result."
                 }
             ],
             "V": [
                 {
                     "term": "Validity of an EU Digital COVID Certificate",
                     "anchor": "validity",
-                    "description": "<p>Basically, we distinguish between</p><ul><li>the validity of the digital certificate (the technical validity) and</li><li>the validity of the vaccination protection (the effective validity).</li></ul><p>The digital certificate has an issue date and a technical expiration date (so does your passport and PA). The validity of the certificate ends 1 year after issuance. As of version 2.23, you can reissue the currently used <a href='#glossary_dcc'>DCC</a> in the app.</p><p><b>Vaccination Certificate</b></p><p>In the certificate data is transported, in this case information about vaccination. This vaccination took place on a date X and is valid from then (according to the current state of scientific knowledge) e.g., in Germany 1 year. After that the vaccination protection has expired. We call the duration of the vaccination protection 'effective (vaccination) validity'. So, the effective validity of the vaccination counts from the last vaccination date (date X).</p><p><b>Certificate of recovery</b></p><p>For a recovery certificate, the maximum effective validity is set at 90 days according to the <a href='https://www.gesetze-im-internet.de/ifsg/__22a.html' target='_blank' rel='noopener noreferrer'>German Infection Protection Act (IfSG)</a></p><p><b>Test Certificate</b></p><p>Test certificates are usually issued with a technical validity of 2 days. How long such a test result is accepted depends on the federal state. Typically, in Germany, negative PCR test results are accepted for 48 hours and rapid test results for 24 hours.</p><p>A certificate is valid until either the technical validity or the effective validity expires.</p>"
+                    "description": "<p>Basically, we distinguish between</p><ul><li>the validity of the digital certificate (the technical validity) and</li><li>the validity of the vaccination protection (the effective validity).</li></ul><p>The digital certificate has an issue date and a technical expiration date (so does your passport and PA). The validity of the certificate ends 1 year after issuance. As of version 2.23, you can reissue the currently used <a href='#glossary_dcc' target='_blank'>DCC</a> in the app.</p><p><b>Vaccination Certificate</b></p><p>In the certificate data is transported, in this case information about vaccination. This vaccination took place on a date X and is valid from then (according to the current state of scientific knowledge) e.g., in Germany 1 year. After that the vaccination protection has expired. We call the duration of the vaccination protection 'effective (vaccination) validity'. So, the effective validity of the vaccination counts from the last vaccination date (date X).</p><p><b>Certificate of recovery</b></p><p>For a recovery certificate, the maximum effective validity is set at 90 days according to the <a href='https://www.gesetze-im-internet.de/ifsg/__22a.html' target='_blank' rel='noopener noreferrer'>German Infection Protection Act (IfSG)</a></p><p><b>Test Certificate</b></p><p>Test certificates are usually issued with a technical validity of 2 days. How long such a test result is accepted depends on the federal state. Typically, in Germany, negative PCR test results are accepted for 48 hours and rapid test results for 24 hours.</p><p>A certificate is valid until either the technical validity or the effective validity expires.</p>"
                 },
                 {
                     "term": "Vaccination Certificate",
                     "anchor": "vaccination_certificate",
-                    "description": "<p>The vaccination certificate is a <a href='#glossary_digital_certificate'>digital certificate</a> issued for a person who has received a vaccination with a vaccine approved in the EU. Each vaccination certificate documents exactly one vaccination event (one dose).</p><p>The vaccination certificate represents a digital form of a <a href='#glossary_vaccination_proof'>proof of vaccination</a>.</p>"
+                    "description": "<p>The vaccination certificate is a <a href='#glossary_digital_certificate' target='_blank'>digital certificate</a> issued for a person who has received a vaccination with a vaccine approved in the EU. Each vaccination certificate documents exactly one vaccination event (one dose).</p><p>The vaccination certificate represents a digital form of a <a href='#glossary_vaccination_proof' target='_blank'>proof of vaccination</a>.</p>"
                 },
                 {
                     "term": "Vaccination Certificate Token",
@@ -3428,7 +3428,7 @@
                 {
                     "term": "Verifier-App / Checking a certificate / Verifying a certificate",
                     "anchor": "verify",
-                    "description": "<p>The mere existence of a (digital) document has no verification/evidence power. Rather, <b>each document/certificate must</b> also be checked for validity and validation.</p><p>This check is done by a special app (in Germany the <a href='#glossary_covpasscheck'>CovPassCheck-App</a>), the check app.</p><p>Individual countries may have different implementations of the check app. However, all check apps use the same keys - consolidated on a European gateway - of the participating countries as well as the stored <a href='#glossary_business_rules'>Business Rules</a>. Therefore, all check apps will be able to validate all EU certificates in the future, as long as they follow the specification of the European eHealth Network.</p>"
+                    "description": "<p>The mere existence of a (digital) document has no verification/evidence power. Rather, <b>each document/certificate must</b> also be checked for validity and validation.</p><p>This check is done by a special app (in Germany the <a href='#glossary_covpasscheck' target='_blank'>CovPassCheck-App</a>), the check app.</p><p>Individual countries may have different implementations of the check app. However, all check apps use the same keys - consolidated on a European gateway - of the participating countries as well as the stored <a href='#glossary_business_rules' target='_blank'>Business Rules</a>. Therefore, all check apps will be able to validate all EU certificates in the future, as long as they follow the specification of the European eHealth Network.</p>"
                 }
             ]
         },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -274,7 +274,7 @@
                                 "anchor": "rat_tan_hotline",
                                 "active": false,
                                 "textblock": [
-                                    "Es ist nicht möglich, ein positives Ergebnis aus einem <a href='#glossary_rapid_antigen_test'>Antigen-Schnelltest</a>, <a href='#glossary_selftest'>Selbsttest</a> oder <a href='#glossary_rapid_pcr_test'>PCR-Schnelltest</a> über die TAN-Hotline zu teilen."
+                                    "Es ist nicht möglich, ein positives Ergebnis aus einem <a href='#glossary_rapid_antigen_test' target='_blank'>Antigen-Schnelltest</a>, <a href='#glossary_selftest' target='_blank'>Selbsttest</a> oder <a href='#glossary_rapid_pcr_test' target='_blank'>PCR-Schnelltest</a> über die TAN-Hotline zu teilen."
                                 ]
                             },
                             {
@@ -825,7 +825,7 @@
                                     "Fall 1: Die Grundimmunisierung erfolgt mit dem Impfstoff von Johnson & Johnson (J&J).",
                                     "Fall 2: Nach einer Genesung von COVID-19 erfolgt eine zweite Auffrischimpfung",
                                     "Fall 3: Nach einer Genesung von COVID-19 erfolgt eine erste Impfung mit J&J.",
-                                    "Die Ursache liegt in der Limitierung der aktuellen EU Richtlinien zur Erstellung der verschiedenen Impfzertifikate/-reihenfolge, die durch die Apps entsprechend abgebildet wird. Siehe: <a href='https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf'>https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf</a> (auf Englisch)",
+                                    "Die Ursache liegt in der Limitierung der aktuellen EU Richtlinien zur Erstellung der verschiedenen Impfzertifikate/-reihenfolge, die durch die Apps entsprechend abgebildet wird. Siehe: <a href='https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf' target='_blank'>https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf</a> (auf Englisch)",
                                     "Begründung:",
                                     "Zu Fall 1 und Fall 2:",
                                     "Bei der Grundimmunisierung mit anderen Impfstoffen als J&J, also BioNTech, Moderna, oder AstraZeneca, wird im Zertifikat unter „Nummer der Impfung“ der Eintrag „2 von 2“ für die zweite Dosis vorgenommen. Da, unabhängig vom verwendeten Impfstoff, der volle Impfschutz aber erst nach der Ausbildung einer ausreichenden Menge von Antikörpern gegeben ist, wird nach dem letzten Impfvorgang der Grundimmunisierung immer eine Wartezeit von 14 Tagen gefordert.",
@@ -1328,12 +1328,12 @@
                                 "textblock": [
                                     "Die technische Hotline (<a href='#international_phone_numbers' target='_blank'>klicken Sie hier um zu den Telefonnummern zu gelangen</a>) hilft Ihnen bei technischen Fragen rund um die Corona-Warn-App, zum Beispiel bei Problemen mit der Risiko-Ermittlung. Sie erreichen sie von Montag bis Freitag von 7 bis 17 Uhr (außer an bundesweiten Feiertagen), und sie ist für Sie innerhalb Deutschlands kostenfrei.",
                                     "Die TAN-Hotline (<a href='#international_phone_numbers' target='_blank'>klicken Sie hier um zu den Telefonnummern zu gelangen</a>) hilft Ihnen bei der Eingabe der TAN, wenn Sie ein positives PCR-Testergebnis haben, und wenn Sie keine TAN oder kein Dokument mit PCR-Test-QR-Code erhalten haben. Sie erreichen sie von Montag bis Sonntag von 7 bis 20 Uhr Ortszeit in Deutschland. Der Anruf ist innerhalb Deutschlands kostenfrei.",
-                                    "Falls das Testergebnis nicht in der Corona-Warn-App abrufbar ist, sollte das zuständige Fachpersonal, Testcenter oder Gesundheitsamt kontaktiert werden, um das Testergebnis zu erhalten. <br/>Um Ihnen die Suche nach dem zuständigen Gesundheitsamt zu erleichtern, hat das RKI ein entsprechendes Tool zur Verfügung gestellt. Durch die Angabe der Postleitzahl oder des Wohnortes, wird sofort das zuständige Gesundheitsamt inklusive der Kontaktdaten angezeigt: <a href='https://tools.rki.de/PLZTool'>Robert Koch-Institut Tool: Gesundheitsamt nach Postleitzahl oder Ort</a>",
-                                    "Weitere Hinweise zum PCR-Test-QR-Code Verfahren finden Sie in diesem FAQ Eintrag: <a href='#qr_test'>Ich habe einen PCR-Test-QR-Code eingescannt, aber das Testergebnis konnte über Tage nicht abgerufen werden.</a>",
-                                    "Die Webseiten der Bundesregierung bieten allgemeine Informationen und Videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app</a>.",
-                                    "Das Robert Koch-Institut stellt auch Informationen zu epidemiologischen Aspekten zur Verfügung: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html'>https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html</a>.",
+                                    "Falls das Testergebnis nicht in der Corona-Warn-App abrufbar ist, sollte das zuständige Fachpersonal, Testcenter oder Gesundheitsamt kontaktiert werden, um das Testergebnis zu erhalten. <br/>Um Ihnen die Suche nach dem zuständigen Gesundheitsamt zu erleichtern, hat das RKI ein entsprechendes Tool zur Verfügung gestellt. Durch die Angabe der Postleitzahl oder des Wohnortes, wird sofort das zuständige Gesundheitsamt inklusive der Kontaktdaten angezeigt: <a href='https://tools.rki.de/PLZTool' target='_blank'>Robert Koch-Institut Tool: Gesundheitsamt nach Postleitzahl oder Ort</a>",
+                                    "Weitere Hinweise zum PCR-Test-QR-Code Verfahren finden Sie in diesem FAQ Eintrag: <a href='#qr_test' target='_blank'>Ich habe einen PCR-Test-QR-Code eingescannt, aber das Testergebnis konnte über Tage nicht abgerufen werden.</a>",
+                                    "Die Webseiten der Bundesregierung bieten allgemeine Informationen und Videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app' target='_blank'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app</a>.",
+                                    "Das Robert Koch-Institut stellt auch Informationen zu epidemiologischen Aspekten zur Verfügung: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html' target='_blank'>https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html</a>.",
                                     "Als Medienvertreter richten Sie bitte Ihre Anfragen an <a href='press...sap...com' class='email'>press...sap...com</a>.",
-                                    "Die verschiedenen Feedback-Kanäle der <a href='/de/community/'>Corona-Warn-App-Community<a/> helfen Ihnen bei Fragen zum Open Source Projekt der Corona-Warn-App."
+                                    "Die verschiedenen Feedback-Kanäle der <a href='/de/community/' target='_blank'>Corona-Warn-App-Community<a/> helfen Ihnen bei Fragen zum Open Source Projekt der Corona-Warn-App."
                                 ]
                             },
                             {
@@ -1508,7 +1508,7 @@
                                 "textblock": [
                                     "<b>Aktualisiert am 30. März 2022</b>",
                                     "Die App ist in den folgenden Sprachen verfügbar:<ul><li>Deutsch</li><li>Englisch</li><li>Türkisch (ab Version 1.1.1)</li><li>Bulgarisch (ab Version 1.2.0)</li><li>Polnisch (ab Version 1.2.0)</li><li>Rumänisch (ab Version 1.2.0)</li><li>Ukrainisch (ab Version 2.20.0 für iOS und Version 2.20.4 für Android)</li></ul>",
-                                    "Die technische Hotline (<a href='tel:08007540001'>0800 7540001</a>) wird auf Deutsch bedient.",
+                                    "Die technische Hotline (<a href='tel:08007540001' target='_blank'>0800 7540001</a>) wird auf Deutsch bedient.",
                                     "Die Sprache der App orientiert sich an der Sprache, die in den Systemeinstellungen Ihres Smartphones eingestellt ist. Um die App etwa auf Englisch anzuzeigen, ändern Sie die Sprache in den Einstellungen Ihres Smartphones auf Englisch.",
                                     "Bitte beachten Sie, dass viele Länder eigene Corona-Apps haben. Weil die deutsche Corona-Warn-App auch in den App Stores und Play Stores dieser Länder verfügbar ist, könnten die Corona-Apps verwechselt werden. Achten Sie daher darauf, dass Sie die App Ihres Landes herunterladen.",
                                     "Siehe auch <a href='#international_phone_numbers' target='_blank' >So erreichen Sie uns außerhalb Deutschlands</a>."
@@ -1530,7 +1530,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<img src='/assets/img/faq/eu-flag.png' width=100px alt='EU flag'> Dieses Vorhaben wurde mit Mitteln der Europäischen Kommission gefördert.",
-                                    "Gemeinsam mit der EU-Kommission wurde eine Infrastruktur für einen sicheren Informationsaustausch entwickelt, die als sog. \"Interoperability Gateway\" bezeichnet wird. Dieses Gateway ermöglicht, dass die Corona-Warn-App über Landesgrenzen hinaus funktioniert und auch im Ausland potentielle Warnmeldungen empfangen werden können. Detaillierte Informationen zum Gateway bietet die EU-Kommission unter <a href='https://ec.europa.eu/commission/presscorner/detail/de/qanda_20_1905#gateway'>Coronavirus: EU-Datenabgleichsdienst für Kontaktnachverfolgungs- und Warn-Apps – Fragen und Antworten</a>. Damit auch Warnungen zwischen Nutzern der Schweizer Corona-App und der Corona-Warn-App möglich sind, betreibt das RKI zudem gemeinsam mit der Schweiz (Bundesamt für Gesundheit der Schweizerischen Eidgenossenschaft) einen weiteren Austausch-Server (deaktiviert am 1.04.2022).",
+                                    "Gemeinsam mit der EU-Kommission wurde eine Infrastruktur für einen sicheren Informationsaustausch entwickelt, die als sog. \"Interoperability Gateway\" bezeichnet wird. Dieses Gateway ermöglicht, dass die Corona-Warn-App über Landesgrenzen hinaus funktioniert und auch im Ausland potentielle Warnmeldungen empfangen werden können. Detaillierte Informationen zum Gateway bietet die EU-Kommission unter <a href='https://ec.europa.eu/commission/presscorner/detail/de/qanda_20_1905#gateway' target='_blank'>Coronavirus: EU-Datenabgleichsdienst für Kontaktnachverfolgungs- und Warn-Apps – Fragen und Antworten</a>. Damit auch Warnungen zwischen Nutzern der Schweizer Corona-App und der Corona-Warn-App möglich sind, betreibt das RKI zudem gemeinsam mit der Schweiz (Bundesamt für Gesundheit der Schweizerischen Eidgenossenschaft) einen weiteren Austausch-Server (deaktiviert am 1.04.2022).",
                                     "Um weitere Informationen in der App zu sehen, klicken Sie",
                                     "<ol><li>'RISIKO-ERMITTLUNG AKTIV (bzw. GESTOPPT) an'</li><li>Dann auf 'Länderübergreifende Risiko Ermittlung' klicken.</li><li>Scrollen Sie nach unten zu der Liste der Länder.</li></ol>",
                                     "Nachstehend finden Sie eine Liste der derzeit teilnehmenden Länder und Angaben zu den zuständigen Gesundheitsbehörden:",
@@ -1795,7 +1795,7 @@
                                 "textblock": [
                                     "Seit Version 2.2 prüft die Corona-Warn-App für Android, ob Ihr Gerät alle benötigten Bluetooth-Funktionen unterstützt. Wenn Sie diese Meldung sehen, kann das Betriebssystem Ihres Geräts keine Zufalls-IDs per Bluetooth <i>versenden</i>, allerdings jedoch <i>empfangen</i>. <b>Ihre eigene Risiko-Ermittlung ist daher nicht betroffen</b>.",
                                     "Die einzige dadurch verursachte Einschränkung ist, dass Sie Ihre Bluetooth-Kontakte beim Teilen Ihres positiven Testergebnisses nicht warnen können. Personen, die gleichzeitig mit Ihnen an einem Ort oder einem Event eingecheckt waren, werden jedoch weiterhin gewarnt. <b>Die Check-in-Funktion, das Abrufen von PCR- und Schnelltestergebnissen sowie die Nutzung des Kontakt-Tagebuchs sind nicht von der Inkompatibilität betroffen und können normal genutzt werden</b>.",
-                                    "Um das Problem zu beheben, aktualisieren Sie bitte auf die neuste Version des Betriebssystems für Ihr Gerät. Wenn das nicht weiterhilft, <a href='https://support.google.com/android/answer/3094742?hl=de'>wenden Sie sich bitte an Ihren Gerätehersteller</a>.",
+                                    "Um das Problem zu beheben, aktualisieren Sie bitte auf die neuste Version des Betriebssystems für Ihr Gerät. Wenn das nicht weiterhilft, <a href='https://support.google.com/android/answer/3094742?hl=de' target='_blank'>wenden Sie sich bitte an Ihren Gerätehersteller</a>.",
                                     "<hr/>",
                                     "<b>Technische Erklärung</b>",
                                     "Ihre Bluetooth-Hardware in Ihrem Gerät unterstützt zwar die für die Verteilung der Zufalls-IDs notwendige Technologie Bluetooth Low Energy, jedoch fehlt im Bluetooth-Treiber Ihres Betriebssystems eine Funktion namens „peripheral mode”. Ohne diese Funktion kann die Corona-Warn-App Ihr Gerät nicht periodisch eigene Zufalls-IDs aussenden lassen. Dies kann nur von Ihrem Gerätehersteller durch ein Softwareupdate behoben werden."
@@ -1809,7 +1809,7 @@
                                     "Seit Version 2.2 prüft die Corona-Warn-App für Android, ob Ihr Gerät alle benötigten Bluetooth-Funktionen unterstützt. Wenn Sie diese Meldung sehen, unterstützt Ihr Gerät nicht die notwendige Bluetooth-Funktionalität für das Versenden und Empfangen von Zufalls-IDs. Ihre Risiko-Ermittlung basiert daher lediglich auf Orten und Events, bei denen Sie sich eingecheckt haben.",
                                     "Die Check-in-Funktion, das Abrufen von PCR- und Schnelltestergebnissen sowie die Nutzung des Kontakt-Tagebuchs sind nicht von der Inkompatibilität betroffen und können normal genutzt werden.",
                                     "Mögliche Ursachen für diese Nachricht sind:<ul><li>Ihrem Gerät fehlt die Hardware, die für Bluetooth Low Energy notwendig ist.</li><li>Ihrem Gerät fehlt die Software, die benötigt wird, um die Bluetooth Low Energy-Funktionen Ihrer Hardware zu benutzen.</li><li>Sie führen die App im Android-Emulator aus.</li></ul>",
-                                    "Um das Problem zu beheben, aktualisieren Sie bitte auf die neuste Version des Betriebssystems für Ihr Gerät. Wenn das nicht weiterhilft, <a href='https://support.google.com/android/answer/3094742?hl=de'>wenden Sie sich bitte an Ihren Gerätehersteller</a>.",
+                                    "Um das Problem zu beheben, aktualisieren Sie bitte auf die neuste Version des Betriebssystems für Ihr Gerät. Wenn das nicht weiterhilft, <a href='https://support.google.com/android/answer/3094742?hl=de' target='_blank'>wenden Sie sich bitte an Ihren Gerätehersteller</a>.",
                                     "<hr/>",
                                     "<b>Technische Erklärung</b>",
                                     "Die Corona-Warn-App benötigt für die Verteilung von Zufalls-IDs die Technologie Bluetooth Low Energy. Diese steht jedoch aufgrund fehlender Hardware- oder Softwareunterstützung auf ihrem Gerät nicht zur Verfügung. Ohne diese Funktion kann die Corona-Warn-App Ihr Gerät weder periodisch eigene Zufalls-IDs aussenden lassen noch Zufalls-IDs von anderen Geräten empfangen."
@@ -1991,7 +1991,7 @@
                                     "'Einstellungen' > 'WLAN' > 'WLAN' ausschalten.",
                                     "'Einstellungen' > 'Begegnungsmitteilungen' > 'Aktive Region' (Corona-Warn-App) > 'Corona-Warn-App' > 'Begegnungsinformationen teilen' einmal aus- und wieder einschalten.",
                                     "'Einstellungen' > 'WLAN' > 'WLAN' wieder einschalten.",
-                                    "Wenn der Fehler weiterhin auftritt, obwohl Sie alle Schritte ausgeführt haben, müssen Sie die Anwendung 1x zurücksetzen und neu installieren. Ihre gesammelten Zufalls-IDs gehen dabei nicht verloren (<a href='#delete_random_ids'>siehe auch hier</a>). Es dauert jedoch 24 Stunden bis die App wieder auf die bisher gesammelten Daten zurückgreift."
+                                    "Wenn der Fehler weiterhin auftritt, obwohl Sie alle Schritte ausgeführt haben, müssen Sie die Anwendung 1x zurücksetzen und neu installieren. Ihre gesammelten Zufalls-IDs gehen dabei nicht verloren (<a href='#delete_random_ids' target='_blank'>siehe auch hier</a>). Es dauert jedoch 24 Stunden bis die App wieder auf die bisher gesammelten Daten zurückgreift."
                                 ]
                             },
                             {
@@ -2042,7 +2042,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>AKTUELL</b><br/> Das Problem ist in Version 1.7.1 behoben worden.<hr/>",
-                                    "Die Meldung <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633'>kann ignoriert werden</a>. Die CWA funktioniert korrekt und dieses Problem wird in einem <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510'> bevorstehenden Update korrigiert</a>."
+                                    "Die Meldung <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497' target='_blank'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633' target='_blank'>kann ignoriert werden</a>. Die CWA funktioniert korrekt und dieses Problem wird in einem <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510' target='_blank'> bevorstehenden Update korrigiert</a>."
                                 ]
                             },
                             {
@@ -2341,7 +2341,7 @@
                                     "Es ist sehr wichtig, dass sie die Quarantäne/Isolation und die Hygieneregeln genau einhalten - auch wenn Sie keine Beschwerden haben sollten. Beachten Sie die Schutzmaßnahmen, d.&nbsp;h. befolgen Sie Husten- und Nies-Regeln, eine gute Händehygiene und halten Sie Abstand zu anderen Personen.",
                                     "Derzeit werden folgende Quarantäneoptionen empfohlen:",
                                     "<ul><li>5 Tage Quarantäne ab der letzten Risiko-Begegnung ohne abschließenden Test</li><li>5 Tage mit PCR-Test bei Probenahme frühestens am 5. Tag. Die Entlassung aus der Quarantäne erfolgt erst nach Erhalt des negativen Testergebnisses. Bei Personen, die regelmäßig im Rahmen einer seriellen Teststrategie getestet werden (z.&nbsp;B. Schülerinnen und Schüler), kann der negative Nachweis auch mittels Antigen-Schnelltests erwogen werden. Die Testung mittels Antigen-Schnelltest sollte als Fremdtestung durch oder unter Aufsicht vor Ort von geschulten Personen (überwachter Antigen-Test zur Eigenanwendung) erfolgen.</li><li>5 Tage mit Antigen-Schnelltest bei Probenahme frühestens am 5. Tag. Die Entlassung aus der Quarantäne erfolgt erst nach Erhalt des negativen Testergebnisses. Die Testung sollte als Fremdtestung durch oder unter Aufsicht vor Ort von geschulten Personen (überwachter Antigen-Test zur Eigenanwendung) erfolgen.</li></ul>",
-                                    "Siehe auch: <ul><li>Robert Koch-Institut: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html' target='_blank' rel='nofollow'>Empfehlungen zu Isolierung und Quarantäne bei SARS-CoV-2-Infektion und -Exposition</a></li><li>zusammengegencorona.de: <a href='https://www.zusammengegencorona.de/covid-19/wann-muss-ich-in-quarantaene-und-wann-nicht/' target='_blank' rel='nofollow'>Wann sollte ich in Quarantäne, wann muss ich in Isolation?</a></li><li>FAQ: <a href='#voluntary_self_quarantine'>Warum wird die freiwillige Selbstquarantäne empfohlen?</a></li><li>FAQ: <a href='#where_can_i_get_tested'>Wo kann ich mich testen lassen?</a></li><li>FAQ: <a href='#red_card_how_to_test'>Rote Karte? So geht es zum Corona Test</a></li></ul>"
+                                    "Siehe auch: <ul><li>Robert Koch-Institut: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html' target='_blank' rel='nofollow'>Empfehlungen zu Isolierung und Quarantäne bei SARS-CoV-2-Infektion und -Exposition</a></li><li>zusammengegencorona.de: <a href='https://www.zusammengegencorona.de/covid-19/wann-muss-ich-in-quarantaene-und-wann-nicht/' target='_blank' rel='nofollow'>Wann sollte ich in Quarantäne, wann muss ich in Isolation?</a></li><li>FAQ: <a href='#voluntary_self_quarantine' target='_blank'>Warum wird die freiwillige Selbstquarantäne empfohlen?</a></li><li>FAQ: <a href='#where_can_i_get_tested' target='_blank'>Wo kann ich mich testen lassen?</a></li><li>FAQ: <a href='#red_card_how_to_test' target='_blank'>Rote Karte? So geht es zum Corona Test</a></li></ul>"
                                 ]
                             },
                             {
@@ -2353,7 +2353,7 @@
                                     "<b>Die Gesundheitsämter sind ausgelastet:</b><br/>Derzeit bewegen sich die COVID-19-Infektionzahlen auf sehr hohem Niveau und eine hohe Zahl von positiven Testergebnissen wird über die CWA übermittelt. Bitte haben Sie daher Verständnis, dass das Gesundheitsamt nicht alle Kontaktpersonen betreuen kann. Halten Sie dem Gesundheitsamt den Rücken frei für Aufgaben, die es nicht abgeben kann. Kontaktieren Sie Ihr Gesundheitsamt nur, wenn Sie unbedingt Unterstützung brauchen, z.&nbsp;B. weil Ihr Arbeitgeber oder Ihre Ausbildungsstätte eine Bescheinigung verlangt.",
                                     "<b>Handlungsempfehlungen:</b>",
                                     "<ul><li>Lassen Sie sich testen. Weitere Informationen dazu finden Sie hier: <a href='https://www.bundesgesundheitsministerium.de/coronavirus/nationale-teststrategie/faq-covid-19-tests.html#c23926' target='_blank' rel='noopener'>Fragen und Antworten zu COVID-19 Tests (BMG)</a></li><li>Für die Selbstquarantäne werden 5 Tage ab dem Datum der letzten Begegnung mit einem erhöhten Risiko empfohlen. Das Datum des letzten Auftretens eines erhöhten Risikos ist auf der roten Kachel angegeben.</li><li>Verzichten Sie nach Möglichkeit auf Besuche und Aktivitäten, bei denen Sie mit anderen Menschen zusammenkommen. Lassen Sie sich Lebensmittel liefern oder bitten Sie jemanden, die Einkäufe zu erledigen; meiden Sie öffentliche Verkehrsmittel und verzichten Sie auf Flug- und Zugreisen.</li><li>Vermeiden Sie insbesondere Kontakte zu vulnerablen Personen und Gruppen, beispielsweise zu Älteren und Vorerkrankten.</li><li>Minimieren Sie auch Kontakte im eigenen Haushalt.</li><li>Wenn Ihr Arbeitgeber Ihnen die Möglichkeit gibt, arbeiten Sie von zu Hause aus.</li><li>Achten Sie mindestens für 10 Tage (ab Risiko-Begegnung) auf Krankheitssymptome und wenden Sie sich an Ihre Hausarztpraxis, falls Sie sich krank fühlen oder Symptome auftreten sollten.</li><li>Halten Sie die Hygieneregeln ein.</li></ul>",
-                                    "Siehe auch: <ul><li>Robert Koch-Institut: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html' target='_blank' rel='nofollow'>Empfehlungen zu Isolierung und Quarantäne bei SARS-CoV-2-Infektion und -Exposition</a></li><li>zusammengegencorona.de: <a href='https://www.zusammengegencorona.de/covid-19/wann-muss-ich-in-quarantaene-und-wann-nicht/' target='_blank' rel='nofollow'>Wann sollte ich in Quarantäne, wann muss ich in Isolation?</a></li><li>FAQ: <a href='#quarantine_measures'>Fragen zu Quarantäne-Maßnahmen?</a></li><li>FAQ: <a href='#where_can_i_get_tested'>Wo kann ich mich testen lassen?</a></li><li>FAQ: <a href='#red_card_how_to_test'>Rote Karte? So geht es zum Corona Test</a></li></ul>"
+                                    "Siehe auch: <ul><li>Robert Koch-Institut: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html' target='_blank' rel='nofollow'>Empfehlungen zu Isolierung und Quarantäne bei SARS-CoV-2-Infektion und -Exposition</a></li><li>zusammengegencorona.de: <a href='https://www.zusammengegencorona.de/covid-19/wann-muss-ich-in-quarantaene-und-wann-nicht/' target='_blank' rel='nofollow'>Wann sollte ich in Quarantäne, wann muss ich in Isolation?</a></li><li>FAQ: <a href='#quarantine_measures' target='_blank'>Fragen zu Quarantäne-Maßnahmen?</a></li><li>FAQ: <a href='#where_can_i_get_tested' target='_blank'>Wo kann ich mich testen lassen?</a></li><li>FAQ: <a href='#red_card_how_to_test' target='_blank'>Rote Karte? So geht es zum Corona Test</a></li></ul>"
                                 ]
                             },
                             {
@@ -2546,7 +2546,7 @@
                                 "anchor": "oss_complete",
                                 "active": false,
                                 "textblock": [
-                                    "Ja. Der gesamte Quelltext der App ist auf <a href='https://github.com/corona-warn-app'>GitHub</a> öffentlich verfügbar. Der Code kann dort sowohl vor als auch nach der Veröffentlichung einer neuen App-Version überprüft und kommentiert werden. Fragestellungen zu Entwicklungsthemen wie Sicherheit, Datenschutz usw. werden zusammen mit der Community geklärt. Jede Person kann einen eigenen Build der App erstellen und diesen testen. Abgesehen vom Quellcode diskutieren wir dort auch offen über zentrale Themen, die für die App relevant sind. Die Diskussionsbeiträge bleiben auf GitHub dauerhaft öffentlich einsehbar."
+                                    "Ja. Der gesamte Quelltext der App ist auf <a href='https://github.com/corona-warn-app' target='_blank'>GitHub</a> öffentlich verfügbar. Der Code kann dort sowohl vor als auch nach der Veröffentlichung einer neuen App-Version überprüft und kommentiert werden. Fragestellungen zu Entwicklungsthemen wie Sicherheit, Datenschutz usw. werden zusammen mit der Community geklärt. Jede Person kann einen eigenen Build der App erstellen und diesen testen. Abgesehen vom Quellcode diskutieren wir dort auch offen über zentrale Themen, die für die App relevant sind. Die Diskussionsbeiträge bleiben auf GitHub dauerhaft öffentlich einsehbar."
                                 ]
                             },
                             {
@@ -2564,7 +2564,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Das Open-Source-Projekt verwendet GitHub, einen in dem Bereich weltbekannten Onlinedienst, der Software-Entwicklungsprojekte auf seinen Servern bereitstellt. Dort können sich alle Interessierten am Projekt beteiligen, z.&nbsp;B. durch das Beheben von Fehlern im Code, Vorschlagen von neuen Funktionen, Erstellen von Dokumentation oder durch das Einbringen von Fragen und Kommentaren zum Projekt.",
-                                    "Die Zusammenarbeit innerhalb der Community unterliegt einem Code of Conduct. Alle Richtlinien zur Beteiligung können unter <a href='/de/community/'>hier</a> eingesehen werden."
+                                    "Die Zusammenarbeit innerhalb der Community unterliegt einem Code of Conduct. Alle Richtlinien zur Beteiligung können unter <a href='/de/community/' target='_blank'>hier</a> eingesehen werden."
                                 ]
                             },
                             {
@@ -2812,7 +2812,7 @@
                                 "anchor": "days_last_risk_encounter",
                                 "active": false,
                                 "textblock": [
-                                    "Die Anzahl der Tage werden normal numerisch gezählt - '1 Tag seit der letzten Begegnung' heißt somit 'gestern', '2' demnach 'vorgestern'. Die Details zur technischen Implementation <a href='https://developer.apple.com/documentation/exposurenotification/enexposuredetectionsummary/3583708-dayssincelastexposure'>erklärt Apple hier.</a>"
+                                    "Die Anzahl der Tage werden normal numerisch gezählt - '1 Tag seit der letzten Begegnung' heißt somit 'gestern', '2' demnach 'vorgestern'. Die Details zur technischen Implementation <a href='https://developer.apple.com/documentation/exposurenotification/enexposuredetectionsummary/3583708-dayssincelastexposure' target='_blank'>erklärt Apple hier.</a>"
                                 ]
                             },
                             {
@@ -3081,12 +3081,12 @@
                 {
                     "term": "Android",
                     "anchor": "android",
-                    "description": "Android ist neben <a href='#glossary_ios'>iOS</a> eines der beiden Betriebssysteme, welche die Corona-Warn-App aktuell unterstützt, und das am weitesten verbreitete mobile Betriebssystem der Welt. Es ist ein <a href='#glossary_open_source'>Open-Source</a> Betriebssystem für mobile Geräte (wie Smartphones oder Tablets) und andere Geräte (wie Fernseher oder Autos). Es wird gemeinsam von Google und der Open Handset Alliance (OHA) entwickelt."
+                    "description": "Android ist neben <a href='#glossary_ios' target='_blank'>iOS</a> eines der beiden Betriebssysteme, welche die Corona-Warn-App aktuell unterstützt, und das am weitesten verbreitete mobile Betriebssystem der Welt. Es ist ein <a href='#glossary_open_source' target='_blank'>Open-Source</a> Betriebssystem für mobile Geräte (wie Smartphones oder Tablets) und andere Geräte (wie Fernseher oder Autos). Es wird gemeinsam von Google und der Open Handset Alliance (OHA) entwickelt."
                 },
                 {
                     "term": "Antigen-Schnelltest",
                     "anchor": "rapid_antigen_test",
-                    "description": "<p>Antigen-Schnelltests ähneln von der Vorgehensweise dem <a href='#glossary_selftest'>Selbsttest</a>, werden allerdings von geschultem Personal durchgeführt. Eine Gegenüberstellung der beiden Antigentest-Typen wurde vom RKI bereit gestellt: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Downloads/Flyer-Antigentests.pdf?__blob=publicationFile'>Link zur Gegenüberstellung vom RKI</a></p><p>Nicht alle Antigen-Schnelltests sind ähnlich zuverlässig. Aus diesem Grund hat das Paul-Ehrlich-Institut sog. Mindestkriterien an Antigen-Schnelltests veröffentlicht: <a href='https://www.pei.de/SharedDocs/Downloads/DE/newsroom/dossiers/mindestkriterien-sars-cov-2-antigentests.pdf?__blob=publicationFile&v=9'>Link zu den Mindestkriterien</a></p><p>Ein positives Ergebnis eines Antigen-Schnelltests ist noch keine finale Diagnose und sollte durch einen <a href='#glossary_pcr_test'>PCR-Test</a> bestätigt werden.</p>"
+                    "description": "<p>Antigen-Schnelltests ähneln von der Vorgehensweise dem <a href='#glossary_selftest' target='_blank'>Selbsttest</a>, werden allerdings von geschultem Personal durchgeführt. Eine Gegenüberstellung der beiden Antigentest-Typen wurde vom RKI bereit gestellt: <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Downloads/Flyer-Antigentests.pdf?__blob=publicationFile' target='_blank'>Link zur Gegenüberstellung vom RKI</a></p><p>Nicht alle Antigen-Schnelltests sind ähnlich zuverlässig. Aus diesem Grund hat das Paul-Ehrlich-Institut sog. Mindestkriterien an Antigen-Schnelltests veröffentlicht: <a href='https://www.pei.de/SharedDocs/Downloads/DE/newsroom/dossiers/mindestkriterien-sars-cov-2-antigentests.pdf?__blob=publicationFile&v=9' target='_blank'>Link zu den Mindestkriterien</a></p><p>Ein positives Ergebnis eines Antigen-Schnelltests ist noch keine finale Diagnose und sollte durch einen <a href='#glossary_pcr_test' target='_blank'>PCR-Test</a> bestätigt werden.</p>"
                 },
                 {
                     "term": "API",
@@ -3113,7 +3113,7 @@
                 {
                     "term": "Business Rules",
                     "anchor": "business_rules",
-                    "description": "<p>Im Kontext der Einführung <a href='#glossary_digital_certificate'>digitaler Zertifikate</a> für COVID-19 wurde durch das eHealth Network der Europäischen Kommission und durch die EU-Länder abgestimmt, dass jedes Land die individuellen Regeln zusammenstellt, die im grenzüberschreitenden Reiseverkehr zu prüfen sind. Diese „Business Rules“ bestehen in der Regel aus zwei Kategorien:</p> <ul><li>Ungültigkeitsregeln (invalidation rules) des Herausgeber-Landes (country of administration), die bestimmen, unter welchen Umständen ein <a href='#glossary_digital_certificate'>digitales Zertifikat</a> nicht anerkannt wird</li><li>Akzeptanz-Regeln (acceptance rules) des Ziel-Landes (country of arrival), die erfüllt sein müssen, um in das Land einreisen zu können</li></ul>"
+                    "description": "<p>Im Kontext der Einführung <a href='#glossary_digital_certificate' target='_blank'>digitaler Zertifikate</a> für COVID-19 wurde durch das eHealth Network der Europäischen Kommission und durch die EU-Länder abgestimmt, dass jedes Land die individuellen Regeln zusammenstellt, die im grenzüberschreitenden Reiseverkehr zu prüfen sind. Diese „Business Rules“ bestehen in der Regel aus zwei Kategorien:</p> <ul><li>Ungültigkeitsregeln (invalidation rules) des Herausgeber-Landes (country of administration), die bestimmen, unter welchen Umständen ein <a href='#glossary_digital_certificate' target='_blank'>digitales Zertifikat</a> nicht anerkannt wird</li><li>Akzeptanz-Regeln (acceptance rules) des Ziel-Landes (country of arrival), die erfüllt sein müssen, um in das Land einreisen zu können</li></ul>"
                 }
             ],
             "C": [
@@ -3157,7 +3157,7 @@
                 {
                     "term": "Datenspende",
                     "anchor": "data_donation",
-                    "description": "Eine freiwillige und anonyme Möglichkeit dem RKI Daten über die Nutzung der CWA zukommen zu lassen. Die freiwillige Datenspende kann den Expert*innen helfen, die Wirksamkeit der App zu bewerten und sie weiter zu verbessern. Weitere Informationen sind hier zusammengefasst: <a href='../../blog/2021-03-04-corona-warn-app-version-1-13/'>Science Blog: Corona-Warn-App nun mit Datenspende und Link zu wissenschaftlicher Befragung</a>"
+                    "description": "Eine freiwillige und anonyme Möglichkeit dem RKI Daten über die Nutzung der CWA zukommen zu lassen. Die freiwillige Datenspende kann den Expert*innen helfen, die Wirksamkeit der App zu bewerten und sie weiter zu verbessern. Weitere Informationen sind hier zusammengefasst: <a href='../../blog/2021-03-04-corona-warn-app-version-1-13/' target='_blank'>Science Blog: Corona-Warn-App nun mit Datenspende und Link zu wissenschaftlicher Befragung</a>"
                 },
                 {
                     "term": "DCC",
@@ -3167,34 +3167,34 @@
                 {
                     "term": "Diagnoseschlüssel",
                     "anchor": "diagnosis_key",
-                    "description": "Siehe <a href='#glossary_temporary_exposure_keys'>Temporary Exposure Keys</a>"
+                    "description": "Siehe <a href='#glossary_temporary_exposure_keys' target='_blank'>Temporary Exposure Keys</a>"
                 },
                 {
                     "term": "Digitaler Impfnachweis",
                     "anchor": "digital_vaccination_certificate",
-                    "description": "Siehe <a href='#glossary_digital_certificate'>Digitales Zertifikat</a>"
+                    "description": "Siehe <a href='#glossary_digital_certificate' target='_blank'>Digitales Zertifikat</a>"
                 },
                 {
                     "term": "Digitales Zertifikat",
                     "anchor": "digital_certificate",
-                    "description": "<p>Ein digitales Zertifikat ist ein beglaubigtes digitales Dokument. Es enthält mindestens den Namen des Inhabers, den öffentlichen Schlüssel des Inhabers und die digitale Unterschrift (<a href='#glossary_signature'>Signatur</a>) der ausstellenden Instanz.</p><p>Jedes digitale Zertifikat hat ein Ausstellungsdatum und eine zeitlich begrenzte <a href='#glossary_validity'>Gültigkeit</a> (Ablaufdatum). Nach Ablauf der Gültigkeit muss das Zertifikat erneuert werden. Dies ist ab Version 2.23 direkt in der App möglich.</p><p>In der CWA unterscheiden wir zwischen:</p><ul><li>Impfzertifikat</li><li>Testzertifikat</li><li>Genesenenzertifikat</li></ul>"
+                    "description": "<p>Ein digitales Zertifikat ist ein beglaubigtes digitales Dokument. Es enthält mindestens den Namen des Inhabers, den öffentlichen Schlüssel des Inhabers und die digitale Unterschrift (<a href='#glossary_signature' target='_blank'>Signatur</a>) der ausstellenden Instanz.</p><p>Jedes digitale Zertifikat hat ein Ausstellungsdatum und eine zeitlich begrenzte <a href='#glossary_validity' target='_blank'>Gültigkeit</a> (Ablaufdatum). Nach Ablauf der Gültigkeit muss das Zertifikat erneuert werden. Dies ist ab Version 2.23 direkt in der App möglich.</p><p>In der CWA unterscheiden wir zwischen:</p><ul><li>Impfzertifikat</li><li>Testzertifikat</li><li>Genesenenzertifikat</li></ul>"
                 },
                 {
                     "term": "Digitale Signatur",
                     "anchor": "digital_signature",
-                    "description": "Siehe <a href='#glossary_signature'>Signatur</a>"
+                    "description": "Siehe <a href='#glossary_signature' target='_blank'>Signatur</a>"
                 }
             ],
             "E": [
                 {
                     "term": "EU DCC",
                     "anchor": "eu_dcc",
-                    "description": "Siehe <a href='#glossary_dcc'>DCC</a>"
+                    "description": "Siehe <a href='#glossary_dcc' target='_blank'>DCC</a>"
                 },
                 {
                     "term": "European Federation Gateway Service (EFGS)",
                     "anchor": "efgs",
-                    "description": "Eine zentrale Infrastruktur, welche dazu dient, <a href='#glossary_diagnosis_key'>Diagnoseschlüssel</a> über Ländergrenzen hinweg auszutauschen und zu prüfen."
+                    "description": "Eine zentrale Infrastruktur, welche dazu dient, <a href='#glossary_diagnosis_key' target='_blank'>Diagnoseschlüssel</a> über Ländergrenzen hinweg auszutauschen und zu prüfen."
                 },
                 {
                     "term": "Event Registrierung",
@@ -3214,14 +3214,14 @@
                 {
                     "term": "Exposure Notification System (ENS)",
                     "anchor": "ens",
-                    "description": "Siehe <a href='#glossary_enf'>Exposure Notification Framework (ENF)</a>"
+                    "description": "Siehe <a href='#glossary_enf' target='_blank'>Exposure Notification Framework (ENF)</a>"
                 }
             ],
             "F": [
                 {
                     "term": "Fachliche Gültigkeit",
                     "anchor": "effective_validity",
-                    "description": "Die Dauer des Impfschutzes bezeichnen wir als 'fachliche Gültigkeit'. Die fachliche Gültigkeit der Impfung zählt also ab dem letzten Impfdatum.​Die fachliche Gültigkeit des Impfschutzes kann von Land zu Land abweichen. Bei einem <a href='#glossary_recovery_certificate'>Genesenenzertifikat</a> ist die maximale fachliche Gültigkeit laut dem <a href='https://www.gesetze-im-internet.de/ifsg/__22a.html' target='_blank' rel='noopener noreferrer'>Infektionsschutzgesetz (IfSG)</a> festgelegt auf 90 Tage."
+                    "description": "Die Dauer des Impfschutzes bezeichnen wir als 'fachliche Gültigkeit'. Die fachliche Gültigkeit der Impfung zählt also ab dem letzten Impfdatum.​Die fachliche Gültigkeit des Impfschutzes kann von Land zu Land abweichen. Bei einem <a href='#glossary_recovery_certificate' target='_blank'>Genesenenzertifikat</a> ist die maximale fachliche Gültigkeit laut dem <a href='https://www.gesetze-im-internet.de/ifsg/__22a.html' target='_blank' rel='noopener noreferrer'>Infektionsschutzgesetz (IfSG)</a> festgelegt auf 90 Tage."
                 },
                 {
                     "term": "Fehlerbericht",
@@ -3233,7 +3233,7 @@
                 {
                     "term": "Genesenenzertifikat",
                     "anchor": "recovery_certificate",
-                    "description": "Das Genesenenzertifikat ist ein <a href='#glossary_digital_certificate'>digitales Zertifikat</a>, das einer Person ausgestellt wird, die nachweislich eine COVID-19-Erkrankung überstanden und die Immunität durch einen (PCR-)Test nachgewiesen hat."
+                    "description": "Das Genesenenzertifikat ist ein <a href='#glossary_digital_certificate' target='_blank'>digitales Zertifikat</a>, das einer Person ausgestellt wird, die nachweislich eine COVID-19-Erkrankung überstanden und die Immunität durch einen (PCR-)Test nachgewiesen hat."
                 },
                 {
                     "term": "GitHub",
@@ -3243,7 +3243,7 @@
                 {
                     "term": "Gültigkeit eines EU digitalen COVID-Zertifikats",
                     "anchor": "validity",
-                    "description": "<p>Wir unterscheiden grundsätzlich</p><ul><li>die Gültigkeit des digitalen Zertifikats (die technische Gültigkeit) und</li><li>die Gültigkeit des Impfschutzes (die fachliche Gültigkeit).</li></ul><p>Das digitale Zertifikat hat ein Ausstellungsdatum und ein technisches Ablaufdatum (so wie auch Ihr Reisepass und PA). Die Gültigkeit des Zertifikats endet 1 Jahr nach Ausstellung. Seit Version 2.23 kann man das aktuell verwendete <a href='#glossary_dcc'>DCC</a> in der App neu ausstellen lassen.</p><p><b> Impfzertifikat </b></p><p>In dem Zertifikat werden Daten transportiert, in diesem Falle Informationen zur Impfung. Diese Impfung fand an einem Datum X statt und gilt ab dann (nach aktuellem Stand der wissenschaftlichen Erkenntnisse) z.&nbsp;B. in Deutschland 1 Jahr. Danach ist der Impfschutz erloschen. Die Dauer des Impfschutzes bezeichnen wir als 'fachliche' Gültigkeit. Die fachliche Gültigkeit der Impfung zählt also ab dem letzten Impfdatum (Datum X).</p><p><b>Genesenenzertifikat</b></p><p>Bei einem Genesenenzertifikat ist die maximale fachliche Gültigkeit laut dem <a href='https://www.gesetze-im-internet.de/ifsg/__22a.html' target='_blank' rel='noopener noreferrer'>Infektionsschutzgesetz (IfSG)</a> festgelegt auf 90 Tage.</p><p><b>Testzertifikat</b></p><p>Testzertifikate werden üblicherweise mit einer technischen Gültigkeit von 2 Tagen ausgestellt. Wie lange so ein Testergebnis akzeptiert wird hängt vom Bundesland ab. Typischerweise werden in Deutschland negative PCR-Testergebnisse 48 Stunden und Schnelltestergebnisse 24 Stunden lang akzeptiert</p><p>Ein Zertifikat ist solange valide, bis entweder die <a href='#glossary_technical_validity'>technische Gültigkeit</a> oder die <a href='#glossary_effective_validity'>fachliche Gültigkeit</a> abläuft.</p>"
+                    "description": "<p>Wir unterscheiden grundsätzlich</p><ul><li>die Gültigkeit des digitalen Zertifikats (die technische Gültigkeit) und</li><li>die Gültigkeit des Impfschutzes (die fachliche Gültigkeit).</li></ul><p>Das digitale Zertifikat hat ein Ausstellungsdatum und ein technisches Ablaufdatum (so wie auch Ihr Reisepass und PA). Die Gültigkeit des Zertifikats endet 1 Jahr nach Ausstellung. Seit Version 2.23 kann man das aktuell verwendete <a href='#glossary_dcc' target='_blank'>DCC</a> in der App neu ausstellen lassen.</p><p><b> Impfzertifikat </b></p><p>In dem Zertifikat werden Daten transportiert, in diesem Falle Informationen zur Impfung. Diese Impfung fand an einem Datum X statt und gilt ab dann (nach aktuellem Stand der wissenschaftlichen Erkenntnisse) z.&nbsp;B. in Deutschland 1 Jahr. Danach ist der Impfschutz erloschen. Die Dauer des Impfschutzes bezeichnen wir als 'fachliche' Gültigkeit. Die fachliche Gültigkeit der Impfung zählt also ab dem letzten Impfdatum (Datum X).</p><p><b>Genesenenzertifikat</b></p><p>Bei einem Genesenenzertifikat ist die maximale fachliche Gültigkeit laut dem <a href='https://www.gesetze-im-internet.de/ifsg/__22a.html' target='_blank' rel='noopener noreferrer'>Infektionsschutzgesetz (IfSG)</a> festgelegt auf 90 Tage.</p><p><b>Testzertifikat</b></p><p>Testzertifikate werden üblicherweise mit einer technischen Gültigkeit von 2 Tagen ausgestellt. Wie lange so ein Testergebnis akzeptiert wird hängt vom Bundesland ab. Typischerweise werden in Deutschland negative PCR-Testergebnisse 48 Stunden und Schnelltestergebnisse 24 Stunden lang akzeptiert</p><p>Ein Zertifikat ist solange valide, bis entweder die <a href='#glossary_technical_validity' target='_blank'>technische Gültigkeit</a> oder die <a href='#glossary_effective_validity' target='_blank'>fachliche Gültigkeit</a> abläuft.</p>"
                 }
             ],
             "I": [
@@ -3255,12 +3255,12 @@
                 {
                     "term": "Impfnachweis",
                     "anchor": "vaccination_proof",
-                    "description": "<p>Digitale Bestätigung, die durch das Einlesen von <a href='#glossary_vaccination_certificate'>Impfzertifikaten</a> in der App erstellt wird. Sie gibt Auskunft über den gebotenen Impfschutz. Der Impfnachweis dokumentiert einen Impfvorgang mit einem vom Paul-Ehrlich-Institut empfohlenen Impfstoff. Ein Impfnachweis muss mindestens folgende Attribute enthalten:</p> <ul><li>die personenbezogenen Daten des Geimpften (mindestens Name, Vorname und Geburtsdatum)</li><li>Datum der Schutzimpfung, Anzahl der Schutzimpfungen</li><li>Bezeichnung des Impfstoffes</li><li>Name der Krankheit, gegen die geimpft wurde sowie</li><li>Merkmale, die auf die für die Durchführung der Schutzimpfung oder die Ausstellung des <a href='#glossary_certificate'>Zertifikats</a> verantwortliche Person oder Institution schließen lassen, zum Beispiel ein offizielles Symbol oder der Name des Ausstellers.</li></ul><p>Für die Einreise muss nach § 2 Nummer 10 Coronavirus-Einreiseverordnung der Impfnachweis noch zusätzliche Anforderungen (bzgl. Sprachen und Impfschema) erfüllen.</p><p>Der Impfnachweis kann auf unterschiedliche Weise dokumentiert sein, eine Form ist das digitale <a href='#glossary_vaccination_certificate'>Impfzertifikat</a>.</p>"
+                    "description": "<p>Digitale Bestätigung, die durch das Einlesen von <a href='#glossary_vaccination_certificate' target='_blank'>Impfzertifikaten</a> in der App erstellt wird. Sie gibt Auskunft über den gebotenen Impfschutz. Der Impfnachweis dokumentiert einen Impfvorgang mit einem vom Paul-Ehrlich-Institut empfohlenen Impfstoff. Ein Impfnachweis muss mindestens folgende Attribute enthalten:</p> <ul><li>die personenbezogenen Daten des Geimpften (mindestens Name, Vorname und Geburtsdatum)</li><li>Datum der Schutzimpfung, Anzahl der Schutzimpfungen</li><li>Bezeichnung des Impfstoffes</li><li>Name der Krankheit, gegen die geimpft wurde sowie</li><li>Merkmale, die auf die für die Durchführung der Schutzimpfung oder die Ausstellung des <a href='#glossary_certificate' target='_blank'>Zertifikats</a> verantwortliche Person oder Institution schließen lassen, zum Beispiel ein offizielles Symbol oder der Name des Ausstellers.</li></ul><p>Für die Einreise muss nach § 2 Nummer 10 Coronavirus-Einreiseverordnung der Impfnachweis noch zusätzliche Anforderungen (bzgl. Sprachen und Impfschema) erfüllen.</p><p>Der Impfnachweis kann auf unterschiedliche Weise dokumentiert sein, eine Form ist das digitale <a href='#glossary_vaccination_certificate' target='_blank'>Impfzertifikat</a>.</p>"
                 },
                 {
                     "term": "Impfzertifikat",
                     "anchor": "vaccination_certificate",
-                    "description": "<p>Bestätigung über eine durchgeführte Impfung. Das digitale Impfzertifikat wird durch das Scannen von QR-Codes auf den vom jeweiligen medizinischen Personal erhaltenen Dokumenten erstellt. Jedes Impfzertifikat dokumentiert genau einen Impfvorgang (eine Dosis).</p><p>Das Impfzertifikat stellt eine digitale Form für einen <a href='#glossary_vaccination_proof'>Impfnachweis</a> dar.</p>"
+                    "description": "<p>Bestätigung über eine durchgeführte Impfung. Das digitale Impfzertifikat wird durch das Scannen von QR-Codes auf den vom jeweiligen medizinischen Personal erhaltenen Dokumenten erstellt. Jedes Impfzertifikat dokumentiert genau einen Impfvorgang (eine Dosis).</p><p>Das Impfzertifikat stellt eine digitale Form für einen <a href='#glossary_vaccination_proof' target='_blank'>Impfnachweis</a> dar.</p>"
                 },
                 {
                     "term": "Impfstatus",
@@ -3270,11 +3270,11 @@
                 {
                     "term": "iOS",
                     "anchor": "ios",
-                    "description": "iOS ist ein von Apple entwickeltes mobiles Betriebssystem für das iPhone, iPod touch und ehemalig auch iPad. Neben <a href='#glossary_android'>Android</a> ist es eines der beiden Betriebssysteme, auf denen die Corona-Warn-App angeboten wird."
+                    "description": "iOS ist ein von Apple entwickeltes mobiles Betriebssystem für das iPhone, iPod touch und ehemalig auch iPad. Neben <a href='#glossary_android' target='_blank'>Android</a> ist es eines der beiden Betriebssysteme, auf denen die Corona-Warn-App angeboten wird."
                 },{
                     "term": "Isolation",
                     "anchor": "isolation",
-                    "description": "Eine Isolierung ist eine behördlich angeordnete Maßnahme für Personen, bei denen eine SARS-CoV-2-Infektion durch einen PCR-Test bestätigt wurde. Die Isolierung kann zu Hause erfolgen oder bei schwerem Krankheitsverlauf im Krankenhaus. Die Entlassung aus der Isolierung erfolgt nach festgelegten <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Entlassmanagement.html?nn=13490888'> Kriterien.</a> Zum Zeitpunkt der Entlassung ist davon auszugehen, dass die Person nicht mehr ansteckend ist. Siehe auch <a href='#glossary_quarantine'>Quarantäne</a>."
+                    "description": "Eine Isolierung ist eine behördlich angeordnete Maßnahme für Personen, bei denen eine SARS-CoV-2-Infektion durch einen PCR-Test bestätigt wurde. Die Isolierung kann zu Hause erfolgen oder bei schwerem Krankheitsverlauf im Krankenhaus. Die Entlassung aus der Isolierung erfolgt nach festgelegten <a href='https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Entlassmanagement.html?nn=13490888' target='_blank'> Kriterien.</a> Zum Zeitpunkt der Entlassung ist davon auszugehen, dass die Person nicht mehr ansteckend ist. Siehe auch <a href='#glossary_quarantine' target='_blank'>Quarantäne</a>."
 
                 }
             ],
@@ -3294,7 +3294,7 @@
                 {
                     "term": "Molekularbiologischer Test",
                     "anchor": "molecular_biological_test",
-                    "description": "Siehe <a href='#glossary_pcr_test'>PCR-Test</a>"
+                    "description": "Siehe <a href='#glossary_pcr_test' target='_blank'>PCR-Test</a>"
                 }
             ],
             "O": [
@@ -3308,22 +3308,22 @@
                 {
                     "term": "PCR-Schnelltest",
                     "anchor": "rapid_pcr_test",
-                    "description": "PCR-Schnelltests, die oft auch als \"PoC-NAT-Tests\" bezeichnet werden, basieren auf derselben Technik wie reguläre <a href='#glossary_pcr_test'>PCR Tests</a>, lassen sich allerdings schnell und vor Ort auswerten und sind demnach besonders gut in Situationen geeignet, in denen ein relativ sicheres Testergebnis innerhalb kurzer Zeit benötigt wird. Im Gegensatz zu normalen PCR Tests sind sie in der Anwendung nicht auf ein medizinisches Labor beschränkt. Zum momentanen Zeitpunkt ist es nicht möglich ein PCR-Schnelltest Ergebnis in der Corona-Warn-App zu erhalten, die technischen Vorkehrungen wurden allerdings bereits in Version 2.19 implementiert."
+                    "description": "PCR-Schnelltests, die oft auch als \"PoC-NAT-Tests\" bezeichnet werden, basieren auf derselben Technik wie reguläre <a href='#glossary_pcr_test' target='_blank'>PCR Tests</a>, lassen sich allerdings schnell und vor Ort auswerten und sind demnach besonders gut in Situationen geeignet, in denen ein relativ sicheres Testergebnis innerhalb kurzer Zeit benötigt wird. Im Gegensatz zu normalen PCR Tests sind sie in der Anwendung nicht auf ein medizinisches Labor beschränkt. Zum momentanen Zeitpunkt ist es nicht möglich ein PCR-Schnelltest Ergebnis in der Corona-Warn-App zu erhalten, die technischen Vorkehrungen wurden allerdings bereits in Version 2.19 implementiert."
                 },
                 {
                     "term": "PCR-Test",
                     "anchor": "pcr_test",
-                    "description": "Unter den PCR-Tests gilt es zwischen dem laborbasierten PCR-Test und dem <a href='#glossary_rapid_pcr_test'>PCR-Schnelltest</a> zu differenzieren. Da unter dem Begriff \"PCR-Test\" in der Regel vom laborbasierten PCR-Test die Rede ist, wird in diesem Eintrag auf diesen eingegangen. Laborbasierte PCR-Tests gelten als die aussagekräftigsten Corona-Tests. Bei dieser Art des Tests entnimmt medizinisches Personal die Probe und lässt sie durch ein Labor auswerten. Anders als bei dem <a href='#glossary_rapid_pcr_test'>PCR-Schnelltest</a> lässt sich das Ergebnis eines PCR-Tests in der Corona-Warn-App empfangen."
+                    "description": "Unter den PCR-Tests gilt es zwischen dem laborbasierten PCR-Test und dem <a href='#glossary_rapid_pcr_test' target='_blank'>PCR-Schnelltest</a> zu differenzieren. Da unter dem Begriff \"PCR-Test\" in der Regel vom laborbasierten PCR-Test die Rede ist, wird in diesem Eintrag auf diesen eingegangen. Laborbasierte PCR-Tests gelten als die aussagekräftigsten Corona-Tests. Bei dieser Art des Tests entnimmt medizinisches Personal die Probe und lässt sie durch ein Labor auswerten. Anders als bei dem <a href='#glossary_rapid_pcr_test' target='_blank'>PCR-Schnelltest</a> lässt sich das Ergebnis eines PCR-Tests in der Corona-Warn-App empfangen."
                 },
                 {
                     "term": "Privacy-Preserving-Analytics (PPA)",
                     "anchor": "ppa",
-                    "description": "Mithilfe des Verfahrens, welches Privacy-Preserving-Analytics oder auch verkürzt PPA genannt wird, ist es möglich, dass Nutzende der Corona-Warn-App auf ihrem Smartphone anfallende Daten einer auswertenden Instanz zur Verfügung stellen, ohne dabei ihre Identität preiszugeben. Über diesen Weg werden seit dem 5. März 2021 täglich operationale Daten anonym, aber authentisiert von Corona-Warn-App-Nutzenden gespendet. Es erfolgt eine Überprüfung des spendenden Endgerätes, um sicherzustellen, dass nur eine genuine Corona-Warn-App von einem genuinen Endgerät Daten übermittelt (für eine ausführliche Dokumentation siehe <a href='https://github.com/corona-warn-app/cwa-ppa-server' target='_blank' rel='noopener noreferrer'>GitHub repository: cwa-ppa-server</a>). Siehe außerdem <a href='#glossary_data_donation'>Datenspende</a>."
+                    "description": "Mithilfe des Verfahrens, welches Privacy-Preserving-Analytics oder auch verkürzt PPA genannt wird, ist es möglich, dass Nutzende der Corona-Warn-App auf ihrem Smartphone anfallende Daten einer auswertenden Instanz zur Verfügung stellen, ohne dabei ihre Identität preiszugeben. Über diesen Weg werden seit dem 5. März 2021 täglich operationale Daten anonym, aber authentisiert von Corona-Warn-App-Nutzenden gespendet. Es erfolgt eine Überprüfung des spendenden Endgerätes, um sicherzustellen, dass nur eine genuine Corona-Warn-App von einem genuinen Endgerät Daten übermittelt (für eine ausführliche Dokumentation siehe <a href='https://github.com/corona-warn-app/cwa-ppa-server' target='_blank' rel='noopener noreferrer'>GitHub repository: cwa-ppa-server</a>). Siehe außerdem <a href='#glossary_data_donation' target='_blank'>Datenspende</a>."
                 },
                 {
                     "term": "Prüf-App / Prüfen eines Zertifikats / Verifizieren eines Zertifikats",
                     "anchor": "verify",
-                    "description": "<p>Die reine Existenz eines (digitalen) Dokuments hat keine Nachweis-/Beweiskraft. Vielmehr <b>muss</b> jedes Dokument/Zertifikat auch auf die <a href='#glossary_validity'>Gültigkeit und Validität</a> überprüft werden.</p><p>Diese Prüfung erledigt eine spezielle App (in Deutschland die <a href='#glossary_covpasscheck'>CovPassCheck-App</a>), die Prüf-App.</p><p>Die einzelnen Länder haben möglicherweise unterschiedliche Implementierungen der Prüf-App. Aber alle Prüf-Apps nutzen dieselben – auf einem europäischen Gateway konsolidierten – Schlüssel der teilnehmenden Länder sowie die hinterlegten <a href='#glossary_business_rules'>Business Rules</a>. Daher können alle Prüf-Apps künftig auch alle EU-Zertifikate validieren, sofern sie der Spezifikation des europäischen eHealth Network folgen.</p>"
+                    "description": "<p>Die reine Existenz eines (digitalen) Dokuments hat keine Nachweis-/Beweiskraft. Vielmehr <b>muss</b> jedes Dokument/Zertifikat auch auf die <a href='#glossary_validity' target='_blank'>Gültigkeit und Validität</a> überprüft werden.</p><p>Diese Prüfung erledigt eine spezielle App (in Deutschland die <a href='#glossary_covpasscheck' target='_blank'>CovPassCheck-App</a>), die Prüf-App.</p><p>Die einzelnen Länder haben möglicherweise unterschiedliche Implementierungen der Prüf-App. Aber alle Prüf-Apps nutzen dieselben – auf einem europäischen Gateway konsolidierten – Schlüssel der teilnehmenden Länder sowie die hinterlegten <a href='#glossary_business_rules' target='_blank'>Business Rules</a>. Daher können alle Prüf-Apps künftig auch alle EU-Zertifikate validieren, sofern sie der Spezifikation des europäischen eHealth Network folgen.</p>"
                 },
                 {
                     "term": "Pseudonymität",
@@ -3335,14 +3335,14 @@
                 {
                     "term": "Quarantäne",
                     "anchor": "quarantine",
-                    "description": "Eine Schutzmaßnahme, die dazu beiträgt, die Verbreitung ansteckender Krankheiten mithilfe von menschlicher Isolation einzudämmen.  Siehe auch <a href='#glossary_isolation'>Isolation</a>."
+                    "description": "Eine Schutzmaßnahme, die dazu beiträgt, die Verbreitung ansteckender Krankheiten mithilfe von menschlicher Isolation einzudämmen.  Siehe auch <a href='#glossary_isolation' target='_blank'>Isolation</a>."
                 }
             ],
             "R": [
                 {
                     "term": "RAT",
                     "anchor": "rat",
-                    "description": "Abkürzung für Antigen-Schnelltest (Rapid Antigen Test). Siehe <a href='#glossary_rapid_antigen_test'>Antigen-Schnelltest</a>."
+                    "description": "Abkürzung für Antigen-Schnelltest (Rapid Antigen Test). Siehe <a href='#glossary_rapid_antigen_test' target='_blank'>Antigen-Schnelltest</a>."
                 },
                 {
                     "term": "Release",
@@ -3367,24 +3367,24 @@
                 {
                     "term": "Rolling Proximity Identifier (RPI)",
                     "anchor": "rpi",
-                    "description": "IDs, die den Datenschutz sicherstellen und sich regelmäßig in kurzen Abständen ändern und so eine Nachverfolgung des Geräts verhindern. Diese IDs können lediglich mit ebenfalls <a href='#glossary_pseudonymity'>pseudonymen</a> <a href='#glossary_diagnosis_key'>Diagnoseschlüsseln</a> ('Positivkennungen') verknüpft werden, um die Begegnungserkennung durchzuführen. Da sich diese IDs alle 10 bis 20 Minuten ändern, könnte z.&nbsp;B. eine Person, die jeden Tag im Bus neben Ihnen sitzt, Sie selbst nicht mit einer ID in Verbindung bringen, wenn die Liste der verfügbaren RPIs einsehbar wäre."
+                    "description": "IDs, die den Datenschutz sicherstellen und sich regelmäßig in kurzen Abständen ändern und so eine Nachverfolgung des Geräts verhindern. Diese IDs können lediglich mit ebenfalls <a href='#glossary_pseudonymity' target='_blank'>pseudonymen</a> <a href='#glossary_diagnosis_key' target='_blank'>Diagnoseschlüsseln</a> ('Positivkennungen') verknüpft werden, um die Begegnungserkennung durchzuführen. Da sich diese IDs alle 10 bis 20 Minuten ändern, könnte z.&nbsp;B. eine Person, die jeden Tag im Bus neben Ihnen sitzt, Sie selbst nicht mit einer ID in Verbindung bringen, wenn die Liste der verfügbaren RPIs einsehbar wäre."
                 }
             ],
             "S": [
                 {
                     "term": "SARS-CoV-2",
                     "anchor": "sars_cov_2",
-                    "description": "Siehe <a href='#glossary_corona_virus'>Corona-Virus</a>"
+                    "description": "Siehe <a href='#glossary_corona_virus' target='_blank'>Corona-Virus</a>"
                 },
                 {
                     "term": "Science-Blog",
                     "anchor": "science_blog",
-                    "description": "Im Science-Blog der Corona-Warn-App werden verschiedene wissenschaftliche Themen zur Corona-Warn-App wie beispielsweise die Wirksamkeit, den Nutzen sowie Ergebnisse wissenschaftlicher Evaluationen des Robert Koch-Instituts behandelt. Siehe <a href='../../science'>Science-Blog</a>."
+                    "description": "Im Science-Blog der Corona-Warn-App werden verschiedene wissenschaftliche Themen zur Corona-Warn-App wie beispielsweise die Wirksamkeit, den Nutzen sowie Ergebnisse wissenschaftlicher Evaluationen des Robert Koch-Instituts behandelt. Siehe <a href='../../science' target='_blank'>Science-Blog</a>."
                 },
                 {
                     "term": "Schnelltest",
                     "anchor": "rapid_test",
-                    "description": "Siehe <a href='#glossary_rapid_antigen_test'>Antigen-Schnelltest</a> oder <a href='#glossary_rapid_pcr_test'>PCR-Schnelltests</a>"
+                    "description": "Siehe <a href='#glossary_rapid_antigen_test' target='_blank'>Antigen-Schnelltest</a> oder <a href='#glossary_rapid_pcr_test' target='_blank'>PCR-Schnelltests</a>"
                 },
                 {
                     "term": "Schnelltest-Profil",
@@ -3394,7 +3394,7 @@
                 {
                     "term": "Selbsttest",
                     "anchor": "selftest",
-                    "description": "Selbsttests sind freiverkäuflich und können auch von ungeschulten Personen sicher angewendet werden. Für die Auswertung eines Selbsttests, welche innerhalb von 15 bis 30 Minuten erfolgt, braucht es auch kein Labor. Sie müssen sich also nicht eigens zu einer Ärztin beziehungsweise einem Arzt, dem Gesundheitsamt oder einer Teststation begeben, sondern können sich bequem zuhause selbst testen. Ein Selbsttest ist jedoch erst dann zuverlässig, wenn er korrekt durchgeführt wurde. Da dies schwer nachweisbar ist, reichen Selbsttestergebnisse weder für das \"freitesten\" aus einer verordneten Quarantäne noch für die Bestätigung einer Infektion aus. In beiden Fällen ist ein zertifizierter <a href='#glossary_rapid_antigen_test'>Antigen-Schnelltest</a> notwendig."
+                    "description": "Selbsttests sind freiverkäuflich und können auch von ungeschulten Personen sicher angewendet werden. Für die Auswertung eines Selbsttests, welche innerhalb von 15 bis 30 Minuten erfolgt, braucht es auch kein Labor. Sie müssen sich also nicht eigens zu einer Ärztin beziehungsweise einem Arzt, dem Gesundheitsamt oder einer Teststation begeben, sondern können sich bequem zuhause selbst testen. Ein Selbsttest ist jedoch erst dann zuverlässig, wenn er korrekt durchgeführt wurde. Da dies schwer nachweisbar ist, reichen Selbsttestergebnisse weder für das \"freitesten\" aus einer verordneten Quarantäne noch für die Bestätigung einer Infektion aus. In beiden Fällen ist ein zertifizierter <a href='#glossary_rapid_antigen_test' target='_blank'>Antigen-Schnelltest</a> notwendig."
                 },
                 {
                     "term": "Signatur (Signierung eines Zertifikats)",
@@ -3416,7 +3416,7 @@
                 {
                     "term": "Technische Gültigkeit",
                     "anchor": "technical_validity",
-                    "description": "Das <a href='#glossary_certificate'>Zertifikat</a> als Dokument hat ein Ausstellungsdatum und ein technisches Ablaufdatum, so wie auch Ihr Reisepass oder Personalausweis beispielsweise. Für alle <a href='#glossary_certificate'>Zertifikate</a> gilt, dass das Ablaufdatum vom Herausgeber des <a href='#glossary_certificate'>Zertifikats</a> gesetzt wird. Derzeit werden in Deutschland die digitalen <a href='#glossary_vaccination_certificate'>Impf-</a>, <a href='#glossary_test_certificate'>Test-</a> und <a href='#glossary_recovery_certificate'>Genesenenzertifikate</a> der EU in der Regel mit einer technischen Gültigkeit von einem Jahr ab Ausstellungsdatum ausgestellt. Seit Version 2.23 kann man das aktuell verwendete <a href='#glossary_dcc'>DCC</a> in der App neu ausstellen lassen."
+                    "description": "Das <a href='#glossary_certificate' target='_blank'>Zertifikat</a> als Dokument hat ein Ausstellungsdatum und ein technisches Ablaufdatum, so wie auch Ihr Reisepass oder Personalausweis beispielsweise. Für alle <a href='#glossary_certificate' target='_blank'>Zertifikate</a> gilt, dass das Ablaufdatum vom Herausgeber des <a href='#glossary_certificate' target='_blank'>Zertifikats</a> gesetzt wird. Derzeit werden in Deutschland die digitalen <a href='#glossary_vaccination_certificate' target='_blank'>Impf-</a>, <a href='#glossary_test_certificate' target='_blank'>Test-</a> und <a href='#glossary_recovery_certificate' target='_blank'>Genesenenzertifikate</a> der EU in der Regel mit einer technischen Gültigkeit von einem Jahr ab Ausstellungsdatum ausgestellt. Seit Version 2.23 kann man das aktuell verwendete <a href='#glossary_dcc' target='_blank'>DCC</a> in der App neu ausstellen lassen."
                 },
                 {
                     "term": "Temporary Exposure Keys",
@@ -3426,14 +3426,14 @@
                 {
                     "term": "Testzertifikat",
                     "anchor": "test_certificate",
-                    "description": "Das Testzertifikat ist ein <a href='#glossary_digital_certificate'>digitales Zertifikat</a>, das einer Person ausgestellt wird, die einen COVID-19-Test mit einem negativen Ergebnis abgeschlossen hat."
+                    "description": "Das Testzertifikat ist ein <a href='#glossary_digital_certificate' target='_blank'>digitales Zertifikat</a>, das einer Person ausgestellt wird, die einen COVID-19-Test mit einem negativen Ergebnis abgeschlossen hat."
                 }
             ],
             "Z": [
                 {
                     "term": "Zertifikat",
                     "anchor": "certificate",
-                    "description": "Siehe <a href='#glossary_digital_certificate'>Digitales Zertifikat</a>"
+                    "description": "Siehe <a href='#glossary_digital_certificate' target='_blank'>Digitales Zertifikat</a>"
                 }
             ]
         },


### PR DESCRIPTION
Resolves #2981 

With this PR, any link in the FAQ opens up in a new tab. The changes are quite hard to represent in screenshots since there were many changes in this, however I'd like to explain my method of solving this.

Using the regular expression `<a href='[^']*'>`, any links that **only** contain the `href` attribute were highlighted. The attribute `target='_blank'` was added to all matching results, as suggested in the issue and preceding pull request (#3009).

---
Internal Tracking ID: [EXPOSUREAPP-13506)](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13506)