### PR TITLE
Add searchable_blogentries*.json to .gitignore

### DIFF
--- a/src/data/.gitignore
+++ b/src/data/.gitignore
@@ -1,3 +1,4 @@
 # generated assets
 blogentries*.json
 scienceblogentries*.json
+searchable_blogentries*.json


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3037 "searchable_blogentries missing in .gitignore".

It adds

`searchable_blogentries*.json`

to

https://github.com/corona-warn-app/cwa-website/blob/master/src/data/.gitignore

## Verification

1. Execute `npm run build`
2. Watch the folder /src/data in VS Code and note that the files
    - `searchable_blogentries_de.json` and 
    - `searchable_blogentries.json`
  are temporarily shown and are greyed out

---
Internal Tracking ID: [EXPOSUREAPP-13674](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13674)
