### PR TITLE
Correct soft assertions message format

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -62,7 +62,7 @@ chai.Assertion.prototype.assert = function (...args) {
 const origLog = Cypress.log;
 Cypress.log = function ( data ) {
     if ( data && data.error && /soft assertions/i.test(data.error.message) ) {
-        data.error.message = 'nnt' + data.error.message + 'nn';
+        data.error.message = '\n\n\t' + data.error.message + '\n\n';
         throw data.error;
     }
     return origLog.call(Cypress, ...arguments);


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3040 "Error in Cypress softAssert error message format".

The formatting characters in the error message are correctly escaped with the backslash character "\":

`data.error.message = '\n\n\t' + data.error.message + '\n\n';`

## Verification

1. Introduce a temporary error, e.g. in /data/index.json Line 18 change `#howto` to `#how`
2. Execute `npm run test:open`
3. Select `check_anchor_links.js`
4. Check for correctly formatted error message with two blank links before and after the text and a tab before the text `Failed soft assertions... check log above ↑`

![Failed soft assertions - right format](https://user-images.githubusercontent.com/66998419/180146142-0128c410-3fd3-4c8e-b99d-ad5bb118948b.jpg)

