### PR TITLE
Correct sitemap priority calculation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -485,7 +485,7 @@ function build_sitemap() {
       siteUrl: "https://coronawarn.app",
       priority: function (siteUrl, loc, entry) {
         // Reduce priority by 0.2 per level
-        return 1.0 - (entry.file.split('/').length - 1) * 0.2
+        return (10 - (entry.file.split('/').length - 1) * 2) / 10
       }
     }))
     .pipe(gulp.dest(PATHS.dist))


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3043 "sitemap.xml includes unrounded priority 0.3999999999999999" by changing the priority calculation to avoid unintended precision inaccuracies.

The priority calculation is first carried out using whole numbers then divided by 10:

`return (10 - (entry.file.split('/').length - 1) * 2) / 10`

## Verification

Execute `npm run build`

Examine the file `public/sitemap.xml` in the local cwa-website repository
Check that there are no longer any entries with priority `0.3999999999999999`
Check that the entry for https://coronawarn.app/de/faq/results/ shows priority `0.4`
Check that only priorities `1`, `0.8`, `0.6`, `0.4`, `0.2` and `0` are used