### PR TITLE
Correct STIKO typo (Impfkommission)

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2404,7 +2404,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Informationen zu COVID-19 und Impfen finden Sie hier: <a href='https://www.rki.de/DE/Content/Infekt/Impfen/ImpfungenAZ/COVID-19/COVID-19.html' target='_blank' rel='noopener noreferrer'>RKI - Impfungen A - Z - COVID-19 und Impfen</a>",
-                                    "Informationen über die Ständige Impfkomission (STIKO) finden Sie hier: <a href='https://www.rki.de/DE/Content/Kommissionen/STIKO/stiko_node.html' target='_blank' rel='noopener noreferrer'>RKI - Ständige Impfkomission</a>",
+                                    "Informationen über die Ständige Impfkommission (STIKO) finden Sie hier: <a href='https://www.rki.de/DE/Content/Kommissionen/STIKO/stiko_node.html' target='_blank' rel='noopener noreferrer'>RKI - Ständige Impfkommission</a>",
                                     "Siehe auch FAQ: <a href='#vac_booster_notification' target='_blank'>Warum erhalte ich eine Benachrichtigung über eine Impfempfehlung der Ständigen Impfkommission (STIKO)?</a>"
                                 ]
                             }


### PR DESCRIPTION
This PR corrects the spelling of [Ständige Impfkommission (STIKO)](https://www.rki.de/DE/Content/Kommissionen/STIKO/stiko_node.html) in the German FAQ. There are two "m"s in [Kommission](https://www.duden.de/rechtschreibung/Kommission).