### PR TITLE
Correct STIKO name to "Standing Committee on Vaccination" (EN)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -786,7 +786,7 @@
                                 "active": false,
                                 "textblock": [
                                     "The Conference of Health Ministers has now passed a regulation on COVID-19 booster vaccinations. An additional booster vaccination is designed to help raise neutralizing antibody titers again, which may decline over time after basic immunization. This becomes particularly important if a weak/muted vaccine response is assumed or recognized after basic immunization in certain groups of vulnerable people.",
-                                    "The Corona-Warn-App (CWA) will notify the user to consider a booster vaccination if certain conditions are met. These conditions are based on the recommendations of the Paul Ehrlich Institute and the Permanent Vaccination Commission (STIKO) of the Robert Koch Institute (RKI).",
+                                    "The Corona-Warn-App (CWA) will notify the user to consider a booster vaccination if certain conditions are met. These conditions are based on the recommendations of the Paul Ehrlich Institute and the Standing Committee on Vaccination (STIKO) of the Robert Koch Institute (RKI).",
                                     "How long someone is effectively protected by a COVID-19 vaccination (basic immunization) depends on several factors and can therefore not be answered in general terms according to current knowledge."
                                 ]
                             },


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3081 "FAQ Wrong STIKO translation into English".

It changes the name of STIKO in https://www.coronawarn.app/en/faq/results/#vac_cert_booster_info "How do I become aware of booster vaccinations in the context of Corona?" to "Standing Committee on Vaccination".

Reference: [RKI: Standing Committee on Vaccination (STIKO)](https://www.rki.de/EN/Content/infections/Vaccination/Vaccination_node.html).