### PR TITLE
Correct RKI EN name in newer blogs (no hyphen)

### DIFF
--- a/blog/2022-04-19-cwa-2-21/index.md
+++ b/blog/2022-04-19-cwa-2-21/index.md
@@ -7,7 +7,7 @@ author: CWA-Team, 10 am
 layout: blog
 ---
 
-The project team of the Robert Koch-Institute (RKI), Deutsche Telekom, and SAP have released version 2.21 of the Corona-Warn-App (CWA). The update allows users to **register tests for family members**. In addition, the project team has adjusted the texts about the user’s vaccination status in the certificate area. 
+The project team of the Robert Koch Institute (RKI), Deutsche Telekom, and SAP have released version 2.21 of the Corona-Warn-App (CWA). The update allows users to **register tests for family members**. In addition, the project team has adjusted the texts about the user’s vaccination status in the certificate area. 
 
 <!-- overview -->
 

--- a/blog/2022-05-04-cwa-2-22/index.md
+++ b/blog/2022-05-04-cwa-2-22/index.md
@@ -7,7 +7,7 @@ author: CWA-Team, 6 pm
 layout: blog
 ---
 
-The project team of the Robert Koch-Institute (RKI), Deutsche Telekom, and SAP have released version 2.22 of the Corona-Warn-App (CWA). With the update, users can **create rapid test profiles for family members**.
+The project team of the Robert Koch Institute (RKI), Deutsche Telekom, and SAP have released version 2.22 of the Corona-Warn-App (CWA). With the update, users can **create rapid test profiles for family members**.
 
 <!-- overview -->
 

--- a/blog/2022-06-01-cwa-2-23/index.md
+++ b/blog/2022-06-01-cwa-2-23/index.md
@@ -7,7 +7,7 @@ author: CWA-Team, 6 pm
 layout: blog
 ---
 
-The project team of the Robert Koch-Institute (RKI), Deutsche Telekom, and SAP have released version 2.23 of the Corona-Warn-App (CWA). With the update, users can **renew technically expired certificates via the CWA**. 
+The project team of the Robert Koch Institute (RKI), Deutsche Telekom, and SAP have released version 2.23 of the Corona-Warn-App (CWA). With the update, users can **renew technically expired certificates via the CWA**. 
 
 <!-- overview -->
 

--- a/blog/2022-06-29-cwa-2-24/index.md
+++ b/blog/2022-06-29-cwa-2-24/index.md
@@ -7,7 +7,7 @@ author: CWA-Team, 6 pm
 layout: blog
 ---
 
-The project team of the Robert Koch-Institute (RKI), Deutsche Telekom, and SAP have released **version 2.24 of the Corona-Warn-App (CWA)**. With the update, users can save all certificates available in their app in one PDF document in only one step.
+The project team of the Robert Koch Institute (RKI), Deutsche Telekom, and SAP have released **version 2.24 of the Corona-Warn-App (CWA)**. With the update, users can save all certificates available in their app in one PDF document in only one step.
 
 <!-- overview -->
 

--- a/blog/2022-07-27-cwa-2-25/index.md
+++ b/blog/2022-07-27-cwa-2-25/index.md
@@ -7,7 +7,7 @@ author: CWA-Team, 6 pm
 layout: blog
 ---
 
-The project team of the Robert Koch-Institute (RKI), Deutsche Telekom, and SAP have **released version 2.25 of the Corona-Warn-App (CWA).** The team has updated the **guidelines on what to do in case of a low or increased risk** (red as well as green tile) corresponding to the [recommendations of the RKI](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html) (German only). Among other things, this involves recommendations on contact restriction and wearing masks. In addition, the project team has made improvements and small adjustments. 
+The project team of the Robert Koch Institute (RKI), Deutsche Telekom, and SAP have **released version 2.25 of the Corona-Warn-App (CWA).** The team has updated the **guidelines on what to do in case of a low or increased risk** (red as well as green tile) corresponding to the [recommendations of the RKI](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Quarantaene/Absonderung.html) (German only). Among other things, this involves recommendations on contact restriction and wearing masks. In addition, the project team has made improvements and small adjustments. 
 
 Given the current pandemic situation, it is still useful and important to use the CWA and its functions, especially to warn others.  
 


### PR DESCRIPTION
This PR corrects the English language name of RKI in newer blogs. The official name is "Robert Koch Institute".
There is no hyphen (-) in the English name of RKI, only in the German name.

## References

- https://www.coronawarn.app/en/imprint/
- https://www.rki.de/EN/Service/Imprint/imprint_node.html