### PR TITLE
Remove BReg Baukasten from blog archive

### DIFF
--- a/src/data/news_archive_combined.json
+++ b/src/data/news_archive_combined.json
@@ -246,22 +246,6 @@
         },
         {
             "image": {
-                "url": "/assets/img/news/cwa-wortbildmarke.jpg",
-                "url-webp": "/assets/img/news/cwa-wortbildmarke.webp"
-            },
-            "title": "Corona-Warn-App: Der Baukasten für Unterstützerinnen und Unterstützer",
-            "author": "Bundesregierung",
-            "date": "June 8, 2020",
-            "date_de": "08.06.2020",
-            "captionaddition": "[only available in German]",
-            "source": {
-                "title": "styleguide.bundesregierung.de",
-                "external": true,
-                "url": "https://styleguide.bundesregierung.de/sg-de/basiselemente/programmmarken/corona-warn-app-baukasten/corona-warn-app-der-baukasten-fuer-unterstuetzerinnen-und-unterstuetzer-1756534"
-            }
-        },
-        {
-            "image": {
                 "url": "/assets/img/news/ui-screens.png",
                 "url-webp": "/assets/img/news/ui-screens.webp"
             },


### PR DESCRIPTION
This PR resolves https://github.com/corona-warn-app/cwa-website/issues/3096 "404 error for BReg 'CWA: Der Baukasten für Unterstützerinnen und Unterstützer'".

The blog archive entry for [Corona-Warn-App: Der Baukasten für Unterstützerinnen und Unterstützer](https://styleguide.bundesregierung.de/sg-de/basiselemente/programmmarken/corona-warn-app-baukasten/corona-warn-app-der-baukasten-fuer-unterstuetzerinnen-und-unterstuetzer-1756534) is removed, since the corresponding target link no longer exists. (404-Meldung Die von Ihnen gewählte URL kann leider nicht aufgerufen werden.)

After merging this PR the Cypress test [cypress/integration/hybrid/check_links.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/hybrid/check_links.js) will no longer fail with a 404 error due to the missing asset from the Bundesregierung's website.