### PR TITLE
Add Cypress check for FAQ #mask_rules

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -1,6 +1,6 @@
 {
     "appVersionFirst": "2.23",
-    "appVersionLast": "2.26",
+    "appVersionLast": "2.27",
     "faqEntry": [
         "#admission_policy",
         "#android_location",

--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -20,6 +20,7 @@
         "#hc_already_registered",
         "#hc_signature_invalid",
         "#interoperability_countries",
+        "#mask_rules",
         "#notification_settings",
         "#part_incompat",
         "#quarantine_measures",


### PR DESCRIPTION
- This PR adds the anchor FAQ `#mask_rules` to be checked by the Cypress test spec [cypress/integration/app_to_web.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/app_to_web.js)

- The new anchor is planned to be added with [CCL 3.3](https://github.com/corona-warn-app/cwa-app-ccl/milestone/6). See also response from @mlenkeit in https://github.com/corona-warn-app/cwa-app-ccl/pull/102#issuecomment-1243757234.

- Since the FAQ article `#mask_rules` has not yet been created in this repository, this PR is submitted in Draft state. Also, since there is as yet no branch release/2.27.x, the PR targets the `master` branch. 