### PR TITLE
Bump current iOS version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -510,7 +510,7 @@ function createFaqRedirects() {
 function replaceVersionNumbers() {
   return gulp
     .src([PATHS.dist + "/**/*.html", PATHS.dist + "/**/*.json"])
-    .pipe(replace('[ios.latest-os-version]', '15.6.1'))
+    .pipe(replace('[ios.latest-os-version]', '16.0.2'))
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.26.1'))
     .pipe(replace('[android.latest-os-version]', '12'))


### PR DESCRIPTION
This PR bumps the current iOS version from 15.6.1 to 16.0.2.

---

Apple release: https://developer.apple.com/news/releases/?id=09222022b