### PR TITLE
2.26 Screenshots: Fix incorrectly written date

### DIFF
--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -9,7 +9,7 @@
         },
         "content": {
             "textblock": [
-                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 2.26 (available since August 31th, 2022). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
+                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 2.26 (available since August 31st, 2022). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
                 "This update corrects bugs in the app. It does not contain any new features.",
                 "The images provided on this page are available for free use."
             ]


### PR DESCRIPTION
Fixes https://github.com/corona-warn-app/cwa-website/issues/3094#issuecomment-1272086287
> https://www.coronawarn.app/en/screenshots/ includes an incorrectly written date:
> 
> "August 31th, 2022"
> 
> Either
> 
> "August 31st, 2022" (see https://en.wikipedia.org/wiki/English_numerals#Ordinal_numbers) or
> "August 31, 2022"
> 
> would be correct.

---
Internal Tracking ID: [EXPOSUREAPP-14015](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14015) / [EXPOSUREAPP-14093](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14093)