### PR TITLE
update gulpfile.js android.latest-os-version to 13

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -509,7 +509,7 @@ function replaceVersionNumbers() {
     .src([PATHS.dist + '/**/*.html', PATHS.dist + '/**/*.json'])
     .pipe(replace('[ios.minimum-required-os-version]', '12.5'))
     .pipe(replace('[ios.current-app-version]', '2.27.0'))
-    .pipe(replace('[android.latest-os-version]', '12'))
+    .pipe(replace('[android.latest-os-version]', '13'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.current-app-version]', '2.27.2'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))


### PR DESCRIPTION
The current android release is 13. This PR updates the gulpfile to replace "android.latest-os-version" with 13 instead of 12.
Seemingly, that replacement is currently unused.

---
Internal Tracking ID: [EXPOSUREAPP-14104](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14104)