### PR TITLE
Fix the hrefs breaking on faq search

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -396,7 +396,8 @@ $(document).ready(function(){
                         }
                         else {
                             let canContinue = true;
-                            const itemsToAvoid = [];
+                            // Avoid href
+                            const itemsToAvoid = $(p).find("a");
                             $(p).children().each((index, child) => {
                                 if($(child).is("a") || $(child).is("img")) {
                                     itemsToAvoid.push($(child))


### PR DESCRIPTION
Adds the <a> tag to avoided/ignored items when highlighting items on the search faq page