### PR TITLE
Update screenshots: Add 2.26 archive

### DIFF
--- a/src/data/screenshots-archive-2-26.json
+++ b/src/data/screenshots-archive-2-26.json
@@ -1,0 +1,615 @@
+{
+    "meta": {
+        "title": "Screenshots",
+        "description": ""
+    },
+    "section-main": {
+        "headline": {
+            "title": "Take a Look (Version 2.26)"
+        },
+        "content": {
+            "textblock": [
+                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 2.26 (available since August 31st, 2022). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
+                "This update corrects bugs in the app. It does not contain any new features.",
+                "The images provided on this page are available for free use."
+            ]
+        },
+        "navigation": {
+            "description": "You can switch between Android and iOS screenshots"
+        },
+        "side-menu": {
+            "description": "Side menu for navigation"
+        }
+    },
+    "android-screenshots": {
+        "tab-title": "Android Screenshots",
+        "sections": [
+            {
+                "title": "Onboarding",
+                "anchor": "android_onboarding",
+                "description": "In this section you will find screenshots of the information that can be seen when you install the app. We first show how you can use your smartphone to break infection chains faster by informing you about the features of the Corona-Warn-App. This is followed by our privacy policy, where you will learn, among other things, how your data is processed and what data protection rights you have as a user of the Corona-Warn-App. Next, we will explain how you can activate risk detection using Bluetooth. You will then be asked to alert others via the app in case of a positive test, and to adjust your notification settings to be informed about your risk status or the validity of your certificates, among other things. Lastly, you will have the opportunity to decide whether you want to participate in the data donation process. Your voluntarily provided data will allow the RKI to better evaluate the effectiveness of the app and improve both its features and user experience.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/OnboardingFragment", "alt": "Onboarding image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/OnboardingPrivacyFragment", "alt": "Onboarding image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/OnboardingTracingFragment", "alt": "Onboarding image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/OnboardingTestFragment", "alt": "Onboarding image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/OnboardingNotificationsFragment", "alt": "Onboarding image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/OnboardingAnalyticsFragment", "alt": "Onboarding image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Risk Cards",
+                "anchor": "android_cards",
+                "description": "In this section you will find screenshots of the different risk cards. In each case, we show the risk tile on the status page and the corresponding detail view, which you can get to by tapping the tile in the app. First we show the low risk green tile with no encounters, then the low risk green tile with encounters, and finally the high risk red tile. You can reach the hygiene rules and minimize risk of infection by tapping on the 'i' in each case in the detailed view of the red tile in the app. Clicking on the respective text will take you to a screenshot that shows everything in one image.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_low_risk_no_encounters", "alt": "Risk Cards image 1 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_low_risk_with_no_encounters_1", "alt": "Risk Cards image 2 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_low_risk_with_no_encounters_2", "alt": "Risk Cards image 3 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_low_risk_with_no_encounters_3_edited", "alt": "Risk Cards image 4 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_test_negative", "alt": "Risk Cards image 5 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_low_risk_with_one_encounters_1", "alt": "Risk Cards image 6 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_low_risk_with_one_encounters_2", "alt": "Risk Cards image 7 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_low_risk_with_one_encounters_3", "alt": "Risk Cards image 8 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_low_risk_with_one_encounters_4_edited", "alt": "Risk Cards image 9 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_increased_risk", "alt": "Risk Cards image 10 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_increased_1", "alt": "Risk Cards image 11 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_increased_2", "alt": "Risk Cards image 12 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_increased_3", "alt": "Risk Cards image 13 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TracingDetailsFragment_tracing_increased_4", "alt": "Risk Cards image 14 of 16" },
+                    { "filename": "/assets/img/faq/hr_en", "alt": "Risk Cards image 15 of 16" },
+                    { "filename": "/assets/img/faq/minimizerisk_en", "alt": "Risk Cards image 16 of 16" }
+                ]
+            },
+            {
+                "title": "Contact Journal",
+                "anchor": "android_journal",
+                "description": "In this section you will find screenshots of the contact journal. We show the respective day for the past two weeks. If you press on one of these days, a new window appears and you have the possibility to add people and places. To add a person the name, email and phone number of a person is needed. For the location, the description, email and phone number are required. If you then press on the added person or place, you have the possibility to set the duration of the meeting. If you press on the three dots in the upper right corner, you can edit the added places and persons or remove them completely. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/ContactDiaryOnboardingFragment", "alt": "Contact Journal image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/ContactDiaryOverviewFragment_2", "alt": "Contact Journal image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/ContactDiaryDayFragment_persons_data", "alt": "Contact Journal image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/ContactDiaryDayFragment_locations_data", "alt": "Contact Journal image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/ContactDiaryEditPersonsFragment", "alt": "Contact Journal image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/ContactDiaryEditLocationsFragment", "alt": "Contact Journal image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Check In - Scan QR Code",
+                "anchor": "android_check_in",
+                "description": "In this section you will find screenshots of the check-in process by scanning QR codes. After tapping on the \"Check-in\" tab, you will be presented with information about the check-in process when you first open it, which you must agree to in order to proceed. You will then see a list of your check-ins. If there are no entries in this list, it will explain how to create an entry in this list by scanning a QR code. Once you have scanned a check-in QR code, you will have the choice of whether you want to record this entry in the contact diary and/or adjust the typical length of stay specified by the creator. After successful check-in, the entry is visible in your check-in list and you can check out early if needed. After check-out, the event is still in your check-in list and you have the option to adjust the length of stay.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/checkinscan1", "alt": "Check In - Scan QR Code image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkinscan2", "alt": "Check In - Scan QR Code image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkinscan3", "alt": "Check In - Scan QR Code image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkinscan4", "alt": "Check In - Scan QR Code image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkinscan5", "alt": "Check In - Scan QR Code image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkinscan6", "alt": "Check In - Scan QR Code image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Check In - Create QR Code",
+                "anchor": "android_check_in_create_event",
+                "description": "In this section you will find screenshots on how to create QR codes. Within the \"Status\" tab, tap \"Create QR Code\" in the \"Planning an event?\" tile. Then tap on the button in the lower right corner. Now select for which location or event you want to create a QR code, enter a name and an address, and adjust the typical length of stay if necessary. Afterwards, the event you created will appear in your QR code list. From there, you can check in to the event you created yourself, or use the three-dot menu to duplicate the event, display the print version, or delete the event.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/checkin1", "alt": "Check In - Create QR Code image 1 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkin2", "alt": "Check In - Create QR Code image 2 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkin3", "alt": "Check In - Create QR Code image 3 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkin4", "alt": "Check In - Create QR Code image 4 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkin5", "alt": "Check In - Create QR Code image 5 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkin6", "alt": "Check In - Create QR Code image 6 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkin7", "alt": "Check In - Create QR Code image 7 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/android/checkin8", "alt": "Check In - Create QR Code image 8 of 8" }
+                ]
+            },
+            {
+                "title": "Statistics",
+                "anchor": "android_stats",
+                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doses administered.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_0", "alt": "Statistics image 1 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_1", "alt": "Statistics image 2 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_2", "alt": "Statistics image 3 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_3", "alt": "Statistics image 4 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_4", "alt": "Statistics image 5 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_5", "alt": "Statistics image 6 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_6", "alt": "Statistics image 7 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_7", "alt": "Statistics image 8 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_8", "alt": "Statistics image 9 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_statistics_card_9", "alt": "Statistics image 10 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/android/StatisticsExplanationFragment", "alt": "Statistics image 11 of 11" }
+                ]
+            },
+            {
+                "title": "Test Registration & Key Sharing",
+                "anchor": "android_registertest",
+                "description": "In this section you will find screenshots of test registration and key sharing. If you press \"Continue\" on the \"Status\" page at \"You are getting tested\" you will get to the test administration. Here you have the possibility to register your PCR test or a PCR test of a family member. Press \"Enter TAN for PCR test\" so that a window appears where you can enter your 10-digit TAN. Once you have done this, you still need to give your consent. Then your test result can have three different statuses. These are \"Your result is not yet available\" \"SARS-CoV-2 negative,\" and \"SARS-CoV-2 positive.\" With the latter, you still have the option to record the onset and type of symptoms.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionDispatcherFragment", "alt": "Test registration & Key sharing image 1 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionTanFragment", "alt": "Test registration & Key sharing image 2 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionConsentFragment", "alt": "Test registration & Key sharing image 3 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/FamilyTestConsentFragment_with_data", "alt": "Test registration & Key sharing image 4 of 12"},
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionTestResultAvailableFragment__consent", "alt": "Test registration & Key sharing image 5 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionTestResultPendingFragment", "alt": "Test registration & Key sharing image 6 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionTestResultNegativeFragment", "alt": "Test registration & Key sharing image 7 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionTestResultConsentGivenFragment", "alt": "Test registration & Key sharing image 8 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionSymptomIntroductionFragment", "alt": "Test registration & Key sharing image 9 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionSymptomCalendarFragment", "alt": "Test registration & Key sharing image 10 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_submission_done", "alt": "Test registration & Key sharing image 11 of 12" },
+                    { "filename": "/assets/screenshots/2-25/en/android/FamilyTestListFragment_1", "alt": "Test registration & Key sharing image 11 of 12"}
+                ]
+            },
+            {
+                "title": "Warn for Others",
+                "anchor": "android_warn_for_others",
+                "description": "In this section you will find screenshots of \"Warn for Others\". If you press the three dots in the upper right corner of the \"My QR Codes\" page, you have the option to select \"Warn for Others\". If you have done so, a new window will appear where you can select an event for which you can warn others on behalf of an infected person. If you press \"Continue\", you can set the start/arrival and the duration of the stay. Finally, you just have to enter your 10-digit TAN. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/TraceLocationsFragment__menu", "alt": "Warn for others image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TraceLocationWarnInfoFragment", "alt": "Warn for others image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TraceLocationSelectionFragment", "alt": "Warn for others image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TraceLocationWarnDurationFragment", "alt": "Warn for others image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TraceLocationWarnTanFragment", "alt": "Warn for others image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TraceLocationOrganizerThanksFragment", "alt": "Warn for others image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Test Result",
+                "anchor": "android_results",
+                "description": "In this section you will find screenshots of \"Test Result\". If you have registered a PCR test, you have the option to retrieve the test result on the status page. There are 5 possibilities. The result is not available yet, negative, positive, no longer valid and your PCR test was invalid.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_test_pending", "alt": "Test result home image 1 of 5" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_test_negative", "alt": "Test result home image 2 of 5" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_test_positive", "alt": "Test result home image 3 of 5" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_test_invalid", "alt": "Test result home image 4 of 5" },
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_test_error", "alt": "Test result home image 5 of 5" }
+                ]
+            },
+            {
+                "title": "Rapid Antigen Test",
+                "anchor": "android_rat",
+                "description": "In this section you will find screenshots of \"Rapid Antigen Test\". Within the \"Register your Test\" tile, tap on \"Next Steps\" to register a test either by QR code or by TAN. In the same tile you will be informed about the current status of your test. Accordingly, as soon as a test result is available, you can retrieve your test result and will find different information depending on your test result. If your test is positive, you will be informed about the next steps and other users will be warned via the app.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_1", "alt": "Rapid antigen test image 1 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_2", "alt": "Rapid antigen test image 2 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_3", "alt": "Rapid antigen test image 3 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_4", "alt": "Rapid antigen test image 4 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_5", "alt": "Rapid antigen test image 5 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_6", "alt": "Rapid antigen test image 6 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_7", "alt": "Rapid antigen test image 7 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_8", "alt": "Rapid antigen test image 8 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_9", "alt": "Rapid antigen test image 9 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/android/rat_10", "alt": "Rapid antigen test image 10 of 10" }
+                ]
+            },
+            {
+                "title": "Rapid Test Profiles",
+                "anchor": "android_rat_profiles",
+                "description": "In this section you will find screenshots of rapid test profiles. Within the \"Manage your tests\" tile, tap on \"Rapid Test Profile\". If you're accessing this for the first time, you will first be informed about the advantages of creating a rapid test profile and the related data security and protection hints. If applicable, tap on \"Continue\" to proceed. On the \"Rapid Test Profiles\" overview page, tap on the button located at the bottom to create a new rapid test profile. Once you filled in all the data, tap on \"Save\" at the bottom of the page. Now you can see the created rapid test profile in the overview.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Rapid Test Profiles image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/SubmissionDispatcherFragment_2", "alt": "Rapid Test Profiles image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RATProfileOnboardingFragment", "alt": "Rapid Test Profiles image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RATProfilesList_Empty", "alt": "Rapid Test Profiles image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RATProfileCreateFragment", "alt": "Rapid Test Profiles image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RATProfilesList_one", "alt": "Rapid Test Profiles image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Certificates",
+                "anchor": "android_certificates",
+                "description": "In this section you will find screenshots of \"Certificates\". When you visit the \"Certificates\" page for the first time, you will get an info window. Press \"Continue\" and you will have the option to add your certificate. If you have done so, your certificate will be visible on the \"Certificates\" page. It is possible to add multiple certificates.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/CovidCertificateOnboardingFragment", "alt": "Certificates image 1 of 9"},
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonOverviewFragment_empty", "alt": "Certificates image 2 of 9"},
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonOverviewFragment_one_person", "alt": "Certificates image 3 of 9"},
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonOverviewFragment_many_persons", "alt": "Certificates image 4 of 9"},
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonOverviewFragment_two_g_plus_with_badge", "alt": "Certificates image 5 of 9"},
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonDetailsFragment_cwa", "alt": "Certificates image 6 of 9"},
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonDetailsFragment_cwa_2", "alt": "Certificates image 7 of 9"},
+                    { "filename": "/assets/screenshots/2-25/en/android/checkcertificate1", "alt": "Certificates image 8 of 9"},
+                    { "filename": "/assets/screenshots/2-25/en/android/checkcertificate2", "alt": "Certificates image 9 of 9"}
+                ]
+            },
+            {
+                "title": "Certificate Reissuance",
+                "anchor": "android_certificate_reissuance",
+                "description": "In this section you will find screenshots for renewing your certificates. You will be informed about the certificates to be renewed and asked to agree to renew them. At the end, you will be notified that your certificates have been successfully renewed and can be found in the Certificates tab.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonDetailsFragment_cwa", "alt": "Certificate Reissuance image 1 of 5"},
+                    { "filename": "/assets/screenshots/2-25/en/android/DccReissuanceConsentFragment_1", "alt": "Certificate Reissuance image 2 of 5"},
+                    { "filename": "/assets/screenshots/2-25/en/android/DccReissuanceConsentFragment_2", "alt": "Certificate Reissuance image 3 of 5"},
+                    { "filename": "/assets/screenshots/2-25/en/android/DccReissuanceConsentFragment_3", "alt": "Certificate Reissuance image 4 of 5"},
+                    { "filename": "/assets/screenshots/2-25/en/android/DccReissuanceSuccessFragment", "alt": " Certificate Reissuance image 5 of 5"}
+                ]
+            },
+            {
+                "title": "Test Certificate",
+                "anchor": "android_test_certificate",
+                "description": "In this section you will find screenshots of \"Test Certificate\". If you press \"Continue\" at \"Manage Your Tests\" on the start page and then \"Request Test Certificate”, after that you have the option to scan a QR code and thus request a COVID test certificate. You still need to set your date of birth for your own safety, if the date is wrong, the test result will not be delivered. Lastly, on the \"Certificates\" page, you can view your test result and by pressing \"Check Validity for Travel\", you can check the travel validity and also get detailed information about your test result. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Test certificate image 1 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RequestCovidCertificateFragment_pcr", "alt": "Test certificate image 2 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RequestCovidCertificateFragment_date_picker", "alt": "Test certificate image 3 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RequestCovidCertificateFragment_rat", "alt": "Test certificate image 4 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonDetailsFragment_cwa", "alt": "Test certificate image 5 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TestCertificateDetailsFragment_expired", "alt": "Test certificate image 6 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/TestCertificateDetailsFragment__2", "alt": "Test certificate image 7 of 7" }
+                ]
+            },
+            {
+                "title": "Vaccination Certificate",
+                "anchor": "android_vaccination_certificate",
+                "description": "In this section you can find screenshots about \"Vaccination Certificate\". You can view your vaccination certificate on the \"Certificates\" page and by pressing \"Check Validity for Travel\", you can check the travel validity and also the other detailed information about your vaccination certificate.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonDetailsFragment_booster", "alt": "Vaccination certificate image 1 of 3" },
+                    { "filename": "/assets/screenshots/2-25/en/android/VaccinationDetailsFragment_immune", "alt": "Vaccination certificate image 2 of 3" },
+                    { "filename": "/assets/screenshots/2-25/en/android/VaccinationDetailsFragment_immune_2", "alt": "Vaccination certificate image 3 of 3" }
+                ]
+             },
+              {
+                  "title": "Recovery Certificate",
+                  "anchor": "android_recovery_certificate",
+                  "description": "In this section you can find screenshots of \"Recovery Certificate\". You can view your recovery certificate on the \"Certificates\" page and by pressing \"Check Validity for Travel, you can check the travel validity and also the other detailed information about your recovery certificate.",
+                  "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/RecoveryCertificateDetailsFragment_recovered", "alt": "Recovery certificate image 1 of 2" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RecoveryCertificateDetailsFragment_recovered_2", "alt": "Recovery certificate image 2 of 2" }
+                        ]
+              },
+             {
+                "title": "Recycle Bin",
+                "anchor": "android_recycle_bin",
+                "description": "In this section you will find screenshots of \"Recycle Bin\". If you scroll all the way down on the home page and press \"Recycle Bin\", you will then see your personal recycle bin. This is where deleted certificates and tests are kept. You have the option to restore them.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/RecyclerBin_from_menu", "alt": "Recycle bin image 1 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RecyclerBinOverviewFragment_empty", "alt": "Recycle bin image 2 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RecyclerBinOverviewFragment_full", "alt": "Recycle bin image 3 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/android/RecyclerBinOverviewFragment_full_2", "alt": "Recycle bin image 4 of 4" }
+                ]
+            },
+             {
+                "title": "Print Certificates",
+                "anchor": "android_print_certificate",
+                "description": "In this section you will find screenshots of \"Print Certificate\". Press on your vaccination certificate in the \"Certificates\" page and scroll all the way down and select the vaccination you want to have as a printable version. Tap on the three-dot menu on the top right and then on \"Display Print Version\". Alternatively, in the overview of all your certificates, you can tap the \"Export arrow\" in the upper right corner to export all certificates into one document. An info window will appear for \"Generating the EU Printout\". After carefully reading through and confirming with \"Continue\", your printable certificate(s) will appear.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/PrintVaccinationFragment", "alt": "Print certificates image 1 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/PrintVaccinationFragment_2", "alt": "Print certificates image 2 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/PersonOverviewFragment_many_persons", "alt": "Print certificates image 3 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/export_all1", "alt": "Print certificates image 4 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/export_all2", "alt": "Print certificates image 5 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/PrintVaccinationFragment_3", "alt": "Print certificates image 6 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/android/PrintVaccinationFragment_4", "alt": "Print certificates image 7 of 7" }
+                ]
+             },
+              {
+                  "title": "Check Certificates for Validity Before a Trip",
+                  "anchor": "android_check_validity_certificate",
+                  "description": "In this section you will find screenshots of \"Check Certificates for Validity Before a trip\". Press \"Check Validity for Travel\" on the \"Certificates\" page under your vaccination certificate. A window will appear where you have the option to set the country, date and time for the check. Then press \"Check\" to complete the process.",
+                  "images": [
+                      { "filename": "/assets/screenshots/2-25/en/android/check_validity1", "alt": "Check Certificates for Validity Before a Trip image 1 of 6" },
+                      { "filename": "/assets/screenshots/2-25/en/android/check_validity2", "alt": "Check Certificates for Validity Before a Trip image 2 of 6" },
+                      { "filename": "/assets/screenshots/2-25/en/android/check_validity3", "alt": "Check Certificates for Validity Before a Trip image 3 of 6" },
+                      { "filename": "/assets/screenshots/2-25/en/android/check_validity4", "alt": "Check Certificates for Validity Before a Trip image 4 of 6" },
+                      { "filename": "/assets/screenshots/2-25/en/android/check_validity5", "alt": "Check Certificates for Validity Before a Trip image 5 of 6" },
+                      { "filename": "/assets/screenshots/2-25/en/android/check_validity6", "alt": "Check Certificates for Validity Before a Trip image 6 of 6" }
+                  ]
+              },
+              {
+                  "title": "Invalid Certificates",
+                  "anchor": "android_invalid_certificate",
+                  "description": "In this section you can find screenshots of \"Invalid Certificates\". Here, sample certificates are shown, by which you can recognize the invalidity. For example, a feature of an invalid certificate is the exclamation mark in the black triangle, which would not appear on a valid certificate.",
+                  "images": [
+                      { "filename": "/assets/screenshots/2-25/en/android/VaccinationDetailsFragment_invalid", "alt": "Invalid certificate image 1 of 2" },
+                      { "filename": "/assets/screenshots/2-25/en/android/VaccinationDetailsFragment_expired", "alt": "Invalid certificate image 2 of 2" }
+                  ]
+              },
+            {
+                "title": "Security note",
+                "anchor": "android_security_note",
+                "description": "In this section you will find a screenshot for “Security note”. This alerts you that signs of administrator privileges have been found on your device and therefore there is an increased risk that other applications on your smartphone can access data from the Corona-Warn-App. You can suppress this message until the next update of the Corona-Warn-App.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/LauncherActivity_launcher_root", "alt": "Security note image 1 of 1"}
+                ]
+            },
+            {
+                "title": "Note on Booster Vaccination",
+                "anchor": "android_booster_note",
+                "description": "In this section you will find screenshots of \"Note on Booster Vaccination\". Based on your saved certificates, you may receive a notice for a booster vaccination. This can be found below the QR code of a vaccination certificate. If you tap on the notice, you will receive detailed information about the notice.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/android/booster_note", "alt": "Note on Booster Vaccination image 1 of 3"},
+                    { "filename": "/assets/screenshots/2-25/en/android/booster_note_detail", "alt": "Note on Booster Vaccination image 2 of 3"},
+                    { "filename": "/assets/screenshots/2-25/en/android/booster_note_detail2", "alt": "Note on Booster Vaccination image 3 of 3"}
+                ]
+            }
+        ]
+    },
+    "ios-screenshots": {
+        "tab-title": "iOS Screenshots",
+        "sections": [
+            {
+                "title": "Onboarding",
+                "anchor": "ios_onboarding",
+                "description": "In this section you will find screenshots of the information that can be seen when you install the app. We first show how you can use your smartphone to break infection chains faster by informing you about the features of the Corona-Warn-App. This is followed by our privacy policy, where you will learn, among other things, how your data is processed and what data protection rights you have as a user of the Corona-Warn-App. Next, we will explain how you can activate risk detection using Bluetooth. You will then be asked to alert others via the app in case of a positive test, and to adjust your notification settings to be informed about your risk status or the validity of your certificates, among other things. Lastly, you will have the opportunity to decide whether you want to participate in the data donation process. Your voluntarily provided data will allow the RKI to better evaluate the effectiveness of the app and improve both its features and user experience.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-AppStore_0001", "alt": "Onboarding image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-OnboardingFlow_EnablePermission_0002", "alt": "Onboarding image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-OnboardingFlow_EnablePermission_0003", "alt": "Onboarding image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-OnboardingFlow_EnablePermission_0004", "alt": "Onboarding image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-OnboardingFlow_EnablePermission_0005", "alt": "Onboarding image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-OnboardingFlow_EnablePermission_0006", "alt": "Onboarding image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Risk Cards",
+                "anchor": "ios_cards",
+                "description": "In this section you will find screenshots of the different risk cards. In each case, we show the risk tile on the status page and the corresponding detail view, which you can get to by tapping the tile in the app. First we show the low risk green tile with no encounters, then the low risk green tile with encounters, and finally the high risk red tile. You can reach the hygiene rules and minimize risk of infection by tapping on the 'i' in each case in the detailed view of the red tile in the app. Clicking on the respective text will take you to a screenshot that shows everything in one image.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-AppStore_0002", "alt": "Risk Cards image 1 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/no1en", "alt": "Risk Cards image 2 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/no2en", "alt": "Risk Cards image 3 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/no3en", "alt": "Risk Cards image 4 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-homescreenrisk_level_low_risk_one_day_0001", "alt": "Risk Cards image 5 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/low1en", "alt": "Risk Cards image 6 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/low2en", "alt": "Risk Cards image 7 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/low3en", "alt": "Risk Cards image 8 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/low4en", "alt": "Risk Cards image 9 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/high0en", "alt": "Risk Cards image 10 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/high1en", "alt": "Risk Cards image 11 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/high2en", "alt": "Risk Cards image 12 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/high3en", "alt": "Risk Cards image 13 of 16" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/high4en", "alt": "Risk Cards image 14 of 16" },
+                    { "filename": "/assets/img/faq/hr_en", "alt": "Risk Cards image 15 of 16" },
+                    { "filename": "/assets/img/faq/minimizerisk_en", "alt": "Risk Cards image 16 of 16" }
+                ]
+            },
+            {
+                "title": "Contact Journal",
+                "anchor": "ios_journal",
+                "description": "In this section you will find screenshots of the contact journal. We show the respective day for the past two weeks. If you press on one of these days, a new window appears and you have the possibility to add people and places. To add a person the name, email and phone number of a person is needed. For the location, the description, email and phone number are required. If you then press on the added person or place, you have the possibility to set the duration of the meeting. If you press on the three dots in the upper right corner, you can edit the added places and persons or remove them completely. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-contact_journal_information_screen_0001", "alt": "Contact Journal image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-contact_journal_listing1_0001", "alt": "Contact Journal image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-contact_journal_listing_add_persons", "alt": "Contact Journal image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-contact_journal_listing_add_locations", "alt": "Contact Journal image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-contact_journal_listing_edit_persons", "alt": "Contact Journal image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-contact_journal_listing_edit_locations", "alt": "Contact Journal image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Check In - Scan QR Code",
+                "anchor": "ios_check_in",
+                "description": "In this section you will find screenshots of check in - scan QR code. On the check-in page you have the option to press scan QR code. This will bring up a new window where your device's camera will be used and you can scan your QR code. Once you have done this, a confirmation window will appear again with information about your QR code, which you can confirm by clicking \"Check in\". ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-event_checkin_004_mycheckins_emptyList", "alt": "Check In image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-event_checkin_005_mycheckins_checkin", "alt": "Check In image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-event_checkin_005_checkinDetails", "alt": "Check In image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-event_checkin_007_checkinDetailsTime", "alt": "Check In image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-event_checkin_006_mycheckins", "alt": "Check In image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-event_checkin_008_checkinList", "alt": "Check In image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Check In - Create QR Code",
+                "anchor": "ios_check_in_create_event",
+                "description" : "In this section you will find screenshots for check in - creating QR codes. As soon as you press “Create QR Code”, a window will appear where you can select the location or event. After that you still need to enter the name and address for the selected place/event. You will also need to select the typical length of stay. Once you have completed these steps, the QR code is successfully created. Finally, you still have the option to press \"Check yourself in\". If you do this, then a confirmation window will appear with information about your QR code, which you confirm by clicking \"Check in\".",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-traceLocation_004_emptyList", "alt": "Check In image 1 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-traceLocation_005_categories", "alt": "Check In image 2 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-traceLocation_006_createQRCodeInputScreen", "alt": "Check In image 3 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-traceLocation_007_traceLocationOverview", "alt": "Check In image 4 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-traceLocation_010_checkinScreen", "alt": "Check In image 5 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-traceLocation_011_myQRCodes", "alt": "Check In image 6 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-traceLocation_008_traceLocationDetailScreen", "alt": "Check In image 7 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-traceLocation_009_traceLocationPdfScreen", "alt": "Check In image 8 of 8" }
+                ]
+            },
+            {
+                "title": "Statistics",
+                "anchor": "ios_stats",
+                "description": "In this section you will find screenshots of the statistics. If you scroll down on the \"Status\" page, you will see \"Add local 7-day incidence\". Now swipe to the right to read the current numbers. The numbers available are the 7-day incidence, COVID-19 Patients in Intensive Care Units, confirmed new infections, warnings by app users, 7-day R-value, people who have received at least one vaccine dose, people who have basic immunization, people who have received a booster vaccination and the vaccine doses administered.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_add_local_statistics", "alt": "Statistics image 1 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_local_7day_values", "alt": "Statistics image 2 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_7day_combined_incidences", "alt": "Statistics image 3 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_intensive_care", "alt": "Statistics image 4 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_confirmed_new_infections", "alt": "Statistics image 5 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_key_submissions", "alt": "Statistics image 6 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_7Day_rvalue", "alt": "Statistics image 7 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_at_least_one_vaccination", "alt": "Statistics image 8 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_fully_vaccinated", "alt": "Statistics image 9 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_booster_vaccination", "alt": "Statistics image 10 of 13"},
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_doses", "alt": "Statistics image 11 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_info_screen_0001", "alt": "Statistics image 12 of 13" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-statistics_info_screen_0002", "alt": "Statistics image 13 of 13" }
+                ]
+            },
+            {
+                "title": "Test Registration & Key Sharing",
+                "anchor": "ios_registertest",
+                "description": "In this section you will find screenshots of test registration and key sharing. If you press \"Continue\" on the \"Status\" page at \"You are getting tested\" you will get to the test administration. Here you have the possibility to register your PCR test or the PCR test of a family member. Press \"Enter TAN for PCR test\" so that a window appears where you can enter your 10-digit TAN. Once you have done this, you still need to give your consent. Then your test result can have three different statuses. These are \"Your result is not yet available\" \"SARS-CoV-2 negative,\" and \"SARS-CoV-2 positive.\" With the latter, you still have the option to record the onset and type of symptoms.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-tan_submissionflow_qr_0001", "alt": "Test registration & Key sharing image 1 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_family_member_tests_selection", "alt": "Test registration & Key sharing image 2 of 11"},
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-tan_submissionflow_qr_0002", "alt": "Test registration & Key sharing image 3 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_family_member_tests_consent_1", "alt": "Test registration & Key sharing image 4 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-submissionflow_screenshot_test_result_available", "alt": "Test registration & Key sharing image 5 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-submissionflow_screenshot_test_result_pending", "alt": "Test registration & Key sharing image 6 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_test_certificate_button_test_result_negative", "alt": "Test registration & Key sharing image 7 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-submissionflow_screenshot_test_result_positive_constent_given", "alt": "Test registration & Key sharing image 8 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-tan_submissionflow_tan_0001", "alt": "Test registration & Key sharing image 9 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-tan_submissionflow_symptoms_selection0001", "alt": "Test registration & Key sharing image 10 of 11" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-submissionflow_screenshot_symptoms_onset_date_option", "alt": "Test registration & Key sharing image 11 of 11" }
+                ]
+            },
+            {
+                "title": "Warn for Others",
+                "anchor": "ios_warn_for_others",
+                "description": "In this section you will find screenshots of \"Warn for Others\". If you press the three dots in the upper right corner of the \"My QR Codes\" page, you have the option to select \"Warn for Others\". If you have done so, a new window will appear where you can select an event for which you can warn others on behalf of an infected person. If you press \"Continue\", you can set the start/arrival and the duration of the stay. Finally, you just have to enter your 10-digit TAN.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-onbehalfwarning_info", "alt": "Warn for others image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-onbehalfwarning_info_0002", "alt": "Warn for others image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-onbehalfwarning_location_selection", "alt": "Warn for others image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-onbehalfwarning_date_time_selection", "alt": "Warn for others image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-onbehalfwarning_tan_v2", "alt": "Warn for others image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-onbehalfwarning_thank_you", "alt": "Warn for others image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Test Result",
+                "anchor": "ios_results",
+                "description": "In this section you will find screenshots of \"Test Result\". Directly below the risk info you can see the status of the tests registered on your device. There are 4 different possibilities. The result of the PCR test is not yet available, the PCR test is negative, the PCR test is positive and the PCR test is invalid.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-homescreenrisk_show_pending_test_result_0001", "alt": "Test result home image 1 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-homescreenrisk_show_negative_test_result_0001", "alt": "Test result home image 2 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-homescreenrisk_show_positive_test_result_0001", "alt": "Test result home image 3 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-homescreenrisk_show_invalid_test_result_0001", "alt": "Test result home image 4 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_family_member_tests_home_2", "alt": "Test result home image 5 of 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_family_member_tests_family_list_1", "alt": "Test result home image 6 of 6" }
+                ]
+            },
+            {
+                "title": "Rapid Antigen Test",
+                "anchor": "ios_rat",
+                "description": "In this section you will find screenshots of \"Rapid Antigen Test\". Within the \"Register your Test\" tile, tap on \"Next Steps\" to register a test either by QR code or by TAN. In the same tile you will be informed about the current status of your test. Accordingly, as soon as a test result is available, you can retrieve your test result and will find different information depending on your test result. If your test is positive, you will be informed about the next steps and other users will be warned via the app.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_1", "alt": "Rapid antigen test image 1 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_2", "alt": "Rapid antigen test image 2 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_3", "alt": "Rapid antigen test image 3 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_4", "alt": "Rapid antigen test image 4 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_5", "alt": "Rapid antigen test image 5 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_6", "alt": "Rapid antigen test image 6 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_7", "alt": "Rapid antigen test image 7 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_8", "alt": "Rapid antigen test image 8 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_9", "alt": "Rapid antigen test image 9 of 10" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/rat_10", "alt": "Rapid antigen test image 10 of 10" }
+                ]
+            },
+            {
+                "title": "Rapid Test Profiles",
+                "anchor": "ios_rat_profiles",
+                "description": "In this section you will find screenshots of rapid test profiles. Within the \"Manage your tests\" tile, tap on \"Rapid Test Profiles\". If you're accessing this for the first time, you will first be informed about the advantages of creating a rapid test profile and the related data security and protection hints. If applicable, tap on \"Continue\" to proceed. On the \"Rapid Test Profiles\" overview page, tap on the button located at the top to create a new rapid test profile. Once you filled in all the data, tap on \"Save\" at the bottom of the page. Now you can see the created rapid test profile in the overview.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-AppStore_0002", "alt": "Rapid Test Profiles Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/RATProfiles", "alt": "Rapid Test Profiles Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/RATProfileOnboarding", "alt": "Rapid Test Profiles Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/RATProfileListEmpty", "alt": "Rapid Test Profiles Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/RATProfileCreate", "alt": "Rapid Test Profiles Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/RATProfileList", "alt": "Rapid Test Profiles Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Certificates",
+                "anchor": "ios_certificates",
+                "description": "In this section you will find screenshots of \"Certificates\". When you visit the \"Certificates\" page for the first time, you will get an info window. Press \"Continue\" and you will have the option to add your certificate. If you have done so, your certificate will be visible on the \"Certificates\" page. It is possible to add multiple certificates.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_health_certificate_consent_screen", "alt": "Certificates image 1 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_health_certificate_empty_screen", "alt": "Certificates image 2 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_certificate_family_certificate-cert-1", "alt": "Certificates image 3 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_certificate_family_certificate-cert-2", "alt": "Certificates image 4 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_health_certificate_reissuance_refresh_certificate", "alt": "Certificates image 5 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_health_certificate_reissuance_consentScreen", "alt": "Certificates image 6 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_health_certificate_reissuance_success", "alt": "Certificates image 7 of 8" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/checkcertificate", "alt": "Certificates image 8 of 8" }
+                ]
+            },
+            {
+                "title": "Certificate Reissuance",
+                "anchor": "ios_certificate_reissuance",
+                "description": "In this section you will find screenshots for renewing your certificates. You will be informed about the certificates to be renewed and asked to agree to renew them. At the end, you will be notified that your certificates have been successfully renewed and can be found in the Certificates tab.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/reissuance0", "alt": "Certificate Reissuance image 1 of 6"},
+                    { "filename": "/assets/screenshots/2-25/en/ios/reissuance1", "alt": "Certificate Reissuance image 1 of 6"},
+                    { "filename": "/assets/screenshots/2-25/en/ios/reissuance2", "alt": "Certificate Reissuance image 2 of 6"},
+                    { "filename": "/assets/screenshots/2-25/en/ios/reissuance3", "alt": "Certificate Reissuance image 3 of 6"},
+                    { "filename": "/assets/screenshots/2-25/en/ios/reissuance4", "alt": " Certificate Reissuance image 4 of 6"},
+                    { "filename": "/assets/screenshots/2-25/en/ios/reissuance5", "alt": "Certificate Reissuance image 5 of 6"}
+                ]
+            },
+            {
+                "title": "Test Certificate",
+                "anchor": "ios_test_certificate",
+                "description": "In this section you will find screenshots of \"Test Certificate\". If you press \"Continue\" at \"Manage Your Tests\" on the start page and then \"Request Test Certificate”, after that you have the option to scan a QR code and thus request a COVID test certificate. You still need to set your date of birth for your own safety, if the date is wrong, the test result will not be delivered. Lastly, on the \"Certificates\" page, you can view your test result and by pressing \"Check Validity for Travel\", you can check the travel validity and also get detailed information about your test result. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-homescreenrisk_level_low_installation_14days_0001", "alt": "Test certificate image 1 of 5" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-submissionflow_screenshot_test_certificate_entered_birthday", "alt": "Test certificate image 2 of 5" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_test_certificate_valid_overview_part1", "alt": "Test certificate image 3 of 5" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_test_certificate_valid_details_part1", "alt": "Test certificate image 4 of 5" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_test_certificate_valid_details_part2", "alt": "Test certificate image 5 of 5" }
+                ]
+            },
+            {
+                "title": "Vaccination Certificate",
+                "anchor": "ios_vaccination_certificate",
+                "description": "In this section you can find screenshots about \"Vaccination Certificate\". You can view your vaccination certificate on the \"Certificates\" page and by pressing \"Check Validity for Travel\", you can check the travel validity and also the other detailed information about your vaccination certificate.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_vaccination_certificate_valid_details_part1", "alt": "Vaccination certificate image 1 of 3" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_vaccination_certificate_valid_details_part3", "alt": "Vaccination certificate image 2 of 3" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_second_vaccination_certificate_details_part2", "alt": "Vaccination certificate image 3 of 3" }
+                ]
+            },
+            {
+                "title": "Recovery Certificate",
+                "anchor": "ios_recovery_certificate",
+                "description": "In this section you can find screenshots of \"Recovery Certificate\". You can view your recovery certificate on the \"Certificates\" page and by pressing \"Check Validity for Travel, you can check the travel validity and also the other detailed information about your recovery certificate.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_recovery_certificate_valid_overview_part1", "alt": "Recovery certificate image 1 of 3" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_recovery_certificate_valid_details_part1", "alt": "Recovery certificate image 2 of 3" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_recovery_certificate_valid_details_part2", "alt": "Recovery certificate image 3 of 3" }
+                ]
+            },
+            {
+                "title": "Recycle Bin",
+                "anchor": "ios_recycle_bin",
+                "description": "In this section you will find screenshots of \"Recycle Bin\". If you scroll all the way down on the home page and press \"Recycle Bin\", you will then see your personal recycle bin. This is where deleted certificates and tests are kept. You have the option to restore them.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/ios-bin-0", "alt": "Recycle bin image 1 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/ios-bin-1", "alt": "Recycle bin image 2 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/ios-bin-2", "alt": "Recycle bin image 3 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/ios-bin-3", "alt": "Recycle bin image 4 of 4" }
+                ]
+            },
+            {
+                "title": "Print Certificates",
+                "anchor": "ios_print_certificate",
+                "description": "In this section you will find screenshots of \"Print Certificate\". Press on your vaccination certificate in the \"Certificates\" page and scroll all the way down and select the vaccination you want to have as a printable version. Then select \"More\" and \"Display Print Version\". Alternatively, in the overview of all your certificates, you can tap the \"Export arrow\" in the upper right corner to export all certificates into one document. An info window will appear for \"Generating the EU Printout\". After carefully reading through and confirming with \"Continue\", your printable certificate(s) will appear.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_vaccination_certificate_valid_details_part3", "alt": "Print certificates image 1 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_vaccination_certificate_print_pdf_actionsheet", "alt": "Print certificates image 2 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/export_all1", "alt": "Print certificates image 3 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/export_all2", "alt": "Print certificates image 4 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_vaccination_certificate_print_pdf_infoscreen", "alt": "Print certificates image 5 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_vaccination_certificate_print_pdf_pdfscreen", "alt": "Print certificates image 6 of 7" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/print_share", "alt": "Print certificates image 7 of 7" }
+                ]
+            },
+            {
+                "title": "Check Certificates for Validity Before a Trip",
+                "anchor": "ios_check_validity_certificate",
+                "description": "In this section you will find screenshots of \"Check Certificates for Validity Before a trip\". Press \"Check Validity\" on the \"Certificates\" page under your vaccination certificate. A window will appear where you have the option to set the country, date and time for the check. Then press \"Check\" to complete the process.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_vaccination_certificate_valid_details_part3", "alt": "Certificate check image 1 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_certificate_validation_date_selection", "alt": "Certificate check image 2 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_certificate_validation_country_selection", "alt": "Certificate check image 3 of 4" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_certificate_validation", "alt": "Certificate check image 4 of 4" }
+                ]
+            },
+            {
+                "title": "Invalid Certificates",
+                "anchor": "ios_invalid_certificate",
+                "description": "In this section you can find screenshots of \"Invalid Certificates\". Here, sample certificates are shown, by which you can recognize the invalidity. For example, a feature of an invalid certificate is the exclamation mark in the black triangle, which would not appear on a valid certificate.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_recovery_certificate_overview_part1", "alt": "Invalid certificate image 1 of 3" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_recovery_certificate_expired_details_part1", "alt": "Invalid certificate image 2 of 3" },
+                    { "filename": "/assets/screenshots/2-25/en/ios/iPhone 13-screenshot_recovery_certificate_expired_details_part2", "alt": "Invalid certificate image 3 of 3" }
+                ]
+            },
+            {
+                "title": "Note on Booster Vaccination",
+                "anchor": "ios_booster_note",
+                "description": "In this section you will find screenshots of \"Note on Booster Vaccination\". Based on your saved certificates, you may receive a notice for a booster vaccination. This can be found below the QR code of a vaccination certificate. If you tap on the notice, you will receive detailed information about the notice.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/en/ios/booster_note", "alt": "Note on Booster Vaccination image 1 of 2"},
+                    { "filename": "/assets/screenshots/2-25/en/ios/booster_note_detail", "alt": "Note on Booster Vaccination image 2 of 2"}
+                ]
+            }
+        ]
+    }
+}

--- a/src/data/screenshots-archive-2-26_de.json
+++ b/src/data/screenshots-archive-2-26_de.json
@@ -1,0 +1,616 @@
+{
+    "meta": {
+        "title": "Screenshots",
+        "description": ""
+    },
+    "section-main": {
+        "headline": {
+            "title": "Machen Sie sich selbst ein Bild (Version 2.26)"
+        },
+        "content": {
+            "textblock": [
+                "Verschaffen Sie sich mithilfe von Screenshots einen Überblick über die Funktionen, die die Corona-Warn-App mit Version 2.26 (verfügbar seit 31. August 2022) bietet. Bitte beachten Sie, dass die Screenshots für Android und iOS designbedingt leicht voneinander abweichen können.",
+                "Mit diesem Update beheben wir Fehler in der App. Es enthält keine neuen Funktionen.",
+                "Die auf dieser Seite zur Verfügung gestellten Bilder stehen zur freien Nutzung bereit."
+            ]
+        },
+        "navigation": {
+            "description": "Sie können zwischen der Android und iOS Version wechseln"
+        },
+        "side-menu": {
+            "description": "Seitenmenü für die Navigation"
+        }
+    },
+    "android-screenshots": {
+        "tab-title": "Android Screenshots",
+        "sections": [
+            {
+                "title": "Einführung",
+                "anchor": "android_onboarding",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu den Informationen, die bei einer Neuinstallation der App zu sehen sind. Wir zeigen zunächst auf inwiefern Sie mit Ihrem Smartphone daran teilhaben können Infektionsketten schneller zu durchbrechen, indem wir Sie über die Funktionen der Corona-Warn-App in Kenntnis setzen. Im Anschluss folgt unsere Datenschutzerklärung, in welcher Sie unter anderem erfahren, wie Ihre Daten verarbeitet werden, und welche Datenschutzrechte Sie als Nutzer der Corona-Warn-App haben. Als nächstes wird erklärt, wie Sie mithilfe von Bluetooth die Risiko-Ermittlung aktivieren können. Daraufhin werden Sie darum gebeten im Falle eines positiven Tests andere über die App zu warnen, und Ihre Mitteilungseinstellungen anzupassen, um unter anderem über Ihren Risikostatus oder die Gültigkeit Ihrer Zertifikate informiert zu werden. Zuletzt haben Sie die Möglichkeit zu entscheiden, ob Sie an der Datenspende teilnehmen wollen. Durch Ihre freiwillig bereitgestellten Daten kann das RKI die Wirksamkeit der App besser bewerten und sowohl die Funktionen als auch die Nutzerfreundlichkeit der App verbessern.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/OnboardingFragment", "alt": "Einführung Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/OnboardingPrivacyFragment", "alt": "Einführung Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/OnboardingTracingFragment", "alt": "Einführung Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/OnboardingTestFragment", "alt": "Einführung Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/OnboardingNotificationsFragment", "alt": "Einführung Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/OnboardingAnalyticsFragment", "alt": "Einführung Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Risiko-Karten",
+                "anchor": "android_cards",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu den verschiedenen Risiko-Karten. Wir zeigen jeweils die Risiko-Karte auf der Status-Seite und die dazugehörige Detailansicht, zu der Sie durch das Antippen der Karte in der App gelangen. Als erstes zeigen wir die grüne Kachel mit niedrigem Risiko ohne Begegnungen, danach die grüne Kachel mit niedrigem Risiko mit Begegnungen, und schließlich die rote Kachel mit hohem Risiko. Die Hygieneregeln und Ansteckungsrisiko minimieren erreichen Sie, indem Sie jeweils auf das 'i' in der Detailansicht der roten Karte in der App tippen. Mit einem Klick auf den jeweiligen Text gelangen Sie zu einem Screenshot, der alles in einem Bild darstellt.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_low_risk_no_encounters", "alt": "Risiko-Karten Bild 1 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_low_risk_with_no_encounters_1", "alt": "Risiko-Karten Bild 2 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_low_risk_with_no_encounters_2", "alt": "Risiko-Karten Bild 3 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_low_risk_with_no_encounters_3", "alt": "Risiko-Karten Bild 4 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_test_negative", "alt": "Risiko-Karten Bild 5 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_low_risk_with_one_encounters_1_edited", "alt": "Risiko-Karten Bild 6 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_low_risk_with_one_encounters_2_edited", "alt": "Risiko-Karten Bild 7 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_low_risk_with_one_encounters_3", "alt": "Risiko-Karten Bild 8 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_low_risk_with_one_encounters_4_edited", "alt": "Risiko-Karten Bild 9 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_increased_risk", "alt": "Risiko-Karten Bild 10 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_increased_1", "alt": "Risiko-Karten Bild 11 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_increased_2_edited", "alt": "Risiko-Karten Bild 12 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_increased_3", "alt": "Risiko-Karten Bild 13 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_increased_4", "alt": "Risiko-Karten Bild 14 von 17" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TracingDetailsFragment_tracing_increased_5_edited", "alt": "Risiko-Karten Bild 15 von 17" },
+                    { "filename": "/assets/img/faq/hr_de", "alt": "Risiko-Karten Bild 16 von 17" },
+                    { "filename": "/assets/img/faq/minimizerisk_de", "alt": "Risiko-Karten Bild 17 von 17" }
+
+                ]
+            },
+            {
+                "title": "Kontakt-Tagebuch",
+                "anchor": "android_journal",
+                "description": "In diesem Abschnitt finden Sie Screenshots zum Kontakt-Tagebuch. Wir zeigen den jeweiligen Tag für die vergangenen zwei Wochen. Drückt man auf einen dieser Tag, erscheint ein neues Fenster und man hat die Möglichkeit, Personen und Orte hinzuzufügen. Um eine Person hinzuzufügen wird der Name, die E-Mail und die Telefonnummer einer Person benötigt. Für den Ort gilt die Beschreibung, die E-Mail und Telefonnummer. Drückt man anschließend auf die hinzugefügte Person oder Ort hat man die Möglichkeit die Dauer der Begegnung, bzw. des Aufenthaltes einzustellen. Drückt man oben rechts auf die drei Punkte, kann man hinzugefügte Orte und Personen bearbeiten oder gänzlich entfernen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/ContactDiaryOnboardingFragment", "alt": "Kontakt-Tagebuch Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/ContactDiaryOverviewFragment_2", "alt": "Kontakt-Tagebuch Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/ContactDiaryDayFragment_persons_data", "alt": "Kontakt-Tagebuch Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/ContactDiaryDayFragment_locations_data", "alt": "Kontakt-Tagebuch Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/ContactDiaryEditPersonsFragment", "alt": "Kontakt-Tagebuch Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/ContactDiaryEditLocationsFragment", "alt": "Kontakt-Tagebuch Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Check-in - QR-Code scannen",
+                "anchor": "android_check_in",
+                "description": "In diesem Abschnitt finden Sie Screenshots zum Check-in durch das Scannen von QR-Codes. Nach dem Tippen auf die \"Check-in\"-Registerkarte werden Ihnen beim ersten Öffnen Informationen zum Check-in Prozess präsentiert, mit welchen Sie einverstanden sein müssen um fortzufahren. Anschließend sehen Sie eine Liste Ihrer Check-ins. Falls keine Einträge in dieser Liste vorhanden sind, wird Ihnen dort erläutert, wie Sie einen Eintrag in dieser Liste durch das Scannen eines QR-Codes anlegen. Sobald Sie einen Check-in QR-Code gescannt haben, haben Sie die Wahl ob Sie diesen Eintrag im Kontakt-Tagebuch vermerken wollen und/oder die vom Ersteller angegebene typische Aufenthaltsdauer anpassen möchten. Nach dem erfolgreichen Check-in ist der Eintrag in Ihrer Check-in Liste sichtbar und Sie können bei Bedarf frühzeitig auschecken. Nach dem Auschecken ist das Event weiterhin in Ihrer Check-in Liste und Sie haben die Möglichkeit die Aufenthaltsdauer anzupassen.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/checkinscan1", "alt": "Check In - QR-Code scannen Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkinscan2", "alt": "Check In - QR-Code scannen Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkinscan3", "alt": "Check In - QR-Code scannen Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkinscan4", "alt": "Check In - QR-Code scannen Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkinscan5", "alt": "Check In - QR-Code scannen Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkinscan6", "alt": "Check In - QR-Code scannen Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Check-in - QR-Code erstellen",
+                "anchor": "android_check_in_create_event",
+                "description": "In diesem Abschnitt finden Sie Screenshots zum Erstellen von QR-Codes. Tippen Sie innerhalb der \"Status\"-Registerkarte auf \"QR-Code erstellen\" in der \"Sie planen eine Veranstaltung?\" Kachel. Anschließend tippen Sie auf den Button in der unteren rechten Ecke. Wählen Sie dann aus für welchen Ort bzw. für welches Event Sie einen QR-Code erstellen wollen, geben Sie eine Bezeichnung und eine Adresse an, und passen Sie gegebenenfalls die typische Aufenthaltsdauer an. Im Anschluss erscheint das von Ihnen erstellte Event in Ihrer QR-Code Liste. Von dort können Sie selbst in das von Ihnen erstellte Event einchecken, oder über das Drei-Punkte-Menu das Event duplizieren, die Druckversion anzeigen, oder das Event löschen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/checkin1", "alt": "Check In - QR-Code erstellen Bild 1 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkin2", "alt": "Check In - QR-Code erstellen Bild 2 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkin3", "alt": "Check In - QR-Code erstellen Bild 3 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkin4", "alt": "Check In - QR-Code erstellen Bild 4 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkin5", "alt": "Check In - QR-Code erstellen Bild 5 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkin6", "alt": "Check In - QR-Code erstellen Bild 6 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkin7", "alt": "Check In - QR-Code erstellen Bild 7 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/android/checkin8", "alt": "Check In - QR-Code erstellen Bild 8 von 8" }
+                ]
+            },
+            {
+                "title": "Aktuelle Zahlen",
+                "anchor": "android_stats",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Aktuelle Zahlen“. Wenn Sie auf der „Status“ Seite, nach unten scrollen, dann sehen Sie „Lokale 7-Tage-Inzidenz hinzufügen“. Wischen Sie nun nach rechts, um die aktuellen Zahlen zu lesen. Die verfügbaren Zahlen sind die 7-Tage-Inzidenz, die COVID-19-Erkrankten auf Intensivstationen, die bestätigten Neuinfektionen, warnende Personen, der 7-Tage-R-Wert, mindestens einmal geimpfte Personen, vollständig geimpfte Personen und die verabreichten Impfdosen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_0", "alt": "Aktuelle Zahlen Bild 1 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_1", "alt": "Aktuelle Zahlen Bild 2 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_2", "alt": "Aktuelle Zahlen Bild 3 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_3", "alt": "Aktuelle Zahlen Bild 4 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_4", "alt": "Aktuelle Zahlen Bild 5 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_5", "alt": "Aktuelle Zahlen Bild 6 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_6", "alt": "Aktuelle Zahlen Bild 7 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_7", "alt": "Aktuelle Zahlen Bild 8 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_8", "alt": "Aktuelle Zahlen Bild 9 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_statistics_card_9", "alt": "Aktuelle Zahlen Bild 10 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/StatisticsExplanationFragment", "alt": "Aktuelle Zahlen Bild 11 von 11" }
+                ]
+            },
+            {
+                "title": "Test registrieren & andere warnen",
+                "anchor": "android_registertest",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Test registrieren & andere warnen“. Wenn Sie auf der „Status“ Seite bei „Sie lassen sich testen“ auf „Weiter“ drücken kommen Sie zur Testverwaltung. Hier haben Sie die Möglichkeit Ihren PCR-Test, oder den eines Familienmitglieds, zu registrieren. Drücken Sie auf „TAN für PCR-Test eingeben“, damit ein Fenster erscheint, wo Sie Ihren 10-stelligen TAN eingeben können. Sobald Sie dies getan haben, müssen Sie noch Ihr Einverständnis geben. Dann kann Ihr Testergebnis drei verschiedene Status haben. Diese sind „Ergebnis liegt noch nicht vor“, „Sars-CoV-2 negativ“ und „Sars-CoV-2 positiv“. Beim letzteren haben Sie noch die Möglichkeit den Beginn und die Art der Symptome zu erfassen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionDispatcherFragment", "alt": "Test registrieren & andere warnen Bild 1 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionConsentFragment", "alt": "Test registrieren & andere warnen Bild 2 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/FamilyTestConsentFragment_with_data", "alt": "Test registrieren & andere warnen Bild 3 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionTestResultAvailableFragment__consent", "alt": "Test registrieren & andere warnen Bild 4 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionTestResultPendingFragment", "alt": "Test registrieren & andere warnen Bild 5 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionTestResultNegativeFragment", "alt": "Test registrieren & andere warnen Bild 6 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionTestResultConsentGivenFragment", "alt": "Test registrieren & andere warnen Bild 7 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionTanFragment", "alt": "Test registrieren & andere warnen Bild 8 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionSymptomIntroductionFragment", "alt": "Test registrieren & andere warnen Bild 9 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionSymptomCalendarFragment", "alt": "Test registrieren & andere warnen Bild 10 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_submission_done", "alt": "Test registrieren & andere warnen Bild 11 von 11" }
+                ]
+            },
+            {
+                "title": "In Vertretung warnen",
+                "anchor": "android_warn_for_others",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „In Vertretung warnen“. Wenn Sie auf der „Meine QR-Codes\" Seite auf die drei Punkte oben rechts drücken, haben Sie die Möglichkeit „In Vertretung warnen” auszuwählen. Falls Sie dies getan haben, erscheint ein neues Fenster, in dem Sie ein Event wählen können, für welches Sie in Vertretung einer infizierten Person andere warnen können. Wenn Sie “Weiter“ drücken, können Sie Beginn/Ankunft und die Dauer des Aufenthaltes einstellen. Zuletzt müssen Sie nur noch ihren 10-stelligen TAN eingeben. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/TraceLocationsFragment__menu", "alt": "In Vertretung warnen Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TraceLocationWarnInfoFragment", "alt": "In Vertretung warnen Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TraceLocationSelectionFragment", "alt": "In Vertretung warnen Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TraceLocationWarnDurationFragment", "alt": "In Vertretung warnen Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TraceLocationWarnTanFragment", "alt": "In Vertretung warnen Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/TraceLocationOrganizerThanksFragment", "alt": "In Vertretung warnen Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Testergebnis",
+                "anchor": "android_results",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu “Testergebnis”. Sofern Sie einen PCR-Test registriert haben, haben Sie die Möglichkeit das Testergebnis auf der Status-Seite abzurufen. Es gibt 5 Möglichkeiten. Das Ergebnis liegt noch nicht vor, Negativ, Positiv, nicht mehr gültig und Ihr PCR-Test war fehlerhaft.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_test_pending", "alt": "Testergebnis abrufen Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_test_negative", "alt": "Testergebnis abrufen Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_test_positive", "alt": "Testergebnis abrufen Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_test_invalid", "alt": "Testergebnis abrufen Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_test_error", "alt": "Testergebnis abrufen Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/FamilyTestListFragment_1", "alt": "Testergebnis abrufen Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Schnelltest",
+                "anchor": "android_rat",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Schnelltest“. Tippen Sie innerhalb der „Test registrieren“-Kachel auf „Nächste Schritte“ um einen Test entweder per QR-Code oder per TAN zu registrieren. In der gleichen Kachel werden Sie über den aktuellen Stand Ihres Tests informiert. Demnach können Sie, sobald ein Testergebnis vorliegt, Ihr Testergebnis abrufen und werden abhängig von Ihrem Testergebnis unterschiedliche Informationen finden. Sollte Ihr Test positiv gewesen sein werden Sie über das weitere Vorgehen aufgeklärt und Ihre Mitmenschen werden über die App gewarnt.  ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_1", "alt": "Schnelltest Bild 1 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_2", "alt": "Schnelltest Bild 2 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_3", "alt": "Schnelltest Bild 3 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_4", "alt": "Schnelltest Bild 4 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_5", "alt": "Schnelltest Bild 5 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_6", "alt": "Schnelltest Bild 6 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_7", "alt": "Schnelltest Bild 7 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_8", "alt": "Schnelltest Bild 8 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_9", "alt": "Schnelltest Bild 9 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/android/rat_10", "alt": "Schnelltest Bild 10 von 10" }
+                ]
+            },
+            {
+                "title": "Schnelltest-Profile",
+                "anchor": "android_rat_profiles",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu Schnelltest-Profilen. Tippen Sie in der Kachel \"Sie lassen sich testen?\" auf \"Schnelltest-Profil\". Wenn Sie zum ersten Mal darauf zugreifen, werden Sie zunächst über die Vorteile der Erstellung eines Schnelltestprofils und die damit verbundenen Hinweise zu Datensicherheit und Datenschutz informiert. Tippen Sie gegebenenfalls auf \"Weiter\", um fortzufahren. Tippen Sie auf der Übersichtsseite \"Schnelltest-Profile\" auf die Schaltfläche am unteren Rand, um ein neues Schnelltest-Profil anzulegen. Sobald Sie alle Daten eingegeben haben, tippen Sie auf \"Speichern\" am unteren Rand der Seite. Nun können Sie das erstellte Schnelltestprofil in der Übersicht sehen.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Schnelltest-Profile Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/SubmissionDispatcherFragment_2", "alt": "Schnelltest-Profile Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/RATProfileOnboardingFragment", "alt": "Schnelltest-Profile Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/RATProfilesList_Empty", "alt": "Schnelltest-Profile Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/RATProfileCreateFragment", "alt": "Schnelltest-Profile Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/android/RATProfilesList_one", "alt": "Schnelltest-Profile Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Zertifikate",
+                "anchor": "android_certificates",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Zertifikate“. Wenn Sie die „Zertifikate“-Seite zum ersten Mal besuchen, erhalten Sie ein Infofenster. Drücken Sie auf „Weiter“ und Sie werden die Möglichkeit haben, Ihr Zertifikat hinzuzufügen. Sofern Sie dies getan haben, wird Ihr Zertifikat auf der „Zertifikate“-Seite zu sehen sein. Es ist möglich mehrere Zertifikate hinzuzufügen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/CovidCertificateOnboardingFragment", "alt": "Zertifikate Bild 1 von 9"},
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonOverviewFragment_empty", "alt": "Zertifikate Bild 2 von 9"},
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonOverviewFragment_one_person", "alt": "Zertifikate Bild 3 von 9"},
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonOverviewFragment_many_persons", "alt": "Zertifikate Bild 4 von 9"},
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonOverviewFragment_two_g_plus_with_badge", "alt": "Zertifikate Bild 5 von 9"},
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonDetailsFragment_cwa", "alt": "Zertifikate Bild 6 von 9"},
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonDetailsFragment_cwa_2", "alt": "Zertifikate Bild 7 von 9"},
+                    { "filename": "/assets/screenshots/2-25/de/android/checkcertificate1", "alt": "Zertifikate Bild 8 von 9"},
+                    { "filename": "/assets/screenshots/2-25/de/android/checkcertificate2", "alt": "Zertifikate Bild 9 von 9"}
+                ]
+            },
+            {
+                "title": "Zertifikate erneuern",
+                "anchor": "android_certificate_reissuance",
+                "description": "In diesem Abschnitt finden Sie Screenshots zum Erneuern Ihrer Zertifikate. Sie werden über die zu erneuernden Zertifikate informiert und um eine Einverständnis gebeten, um diese zu erneuern. Am Ende werden Sie darüber in Kenntnis gesetzt, dass Ihre Zertifikate erfolgreich erneuert wurden und in der Zertifikate-Registerkarte zu finden sind.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonDetailsFragment_cwa", "alt": "Zertifikate erneuern Bild 1 von 5"},
+                    { "filename": "/assets/screenshots/2-25/de/android/DccReissuanceConsentFragment_1", "alt": "Zertifikate erneuern Bild 2 von 5"},
+                    { "filename": "/assets/screenshots/2-25/de/android/DccReissuanceConsentFragment_2", "alt": "Zertifikate erneuern Bild 3 von 5"},
+                    { "filename": "/assets/screenshots/2-25/de/android/DccReissuanceConsentFragment_3", "alt": "Zertifikate erneuern Bild 4 von 5"},
+                    { "filename": "/assets/screenshots/2-25/de/android/DccReissuanceSuccessFragment", "alt": "Zertifikate erneuern Bild 5 von 5"}
+                ]
+            },
+            {
+                "title": "Testzertifikat",
+                "anchor": "android_test_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Testzertifikat“. Wenn Sie auf der Startseite bei „Sie lassen sich testen?“ auf „Weiter“ drücken und anschließend auf QR-Code scannen, dann haben Sie die Möglichkeit einen QR-Code zu scannen und so ein COVID-Testzertifikat anzufordern. Sie müssen noch Ihr Geburtsdatum zu Ihrer eigenen Sicherheit einstellen, bei einem falschen Datum wird das Testergebnis nicht zugestellt. Zuletzt können Sie auf der „Zertifikate“-Seite Ihr Testergebnis ansehen und durch Drücken von „Reisegültigkeit prüfen“, einmal die Reisegültigkeit prüfen und zu den anderen detaillierten Informationen zu Ihrem Testergebnis bekommen. ",
+                "images": [
+                   { "filename": "/assets/screenshots/2-25/de/android/HomeFragment_low_risk_no_encounters_without_install_time", "alt": "Testzertifikat Bild 1 von 7" },
+                   { "filename": "/assets/screenshots/2-25/de/android/RequestCovidCertificateFragment_pcr", "alt": "Testzertifikat Bild 2 von 7" },
+                   { "filename": "/assets/screenshots/2-25/de/android/RequestCovidCertificateFragment_date_picker", "alt": "Testzertifikat Bild 3 von 7" },
+                   { "filename": "/assets/screenshots/2-25/de/android/RequestCovidCertificateFragment_rat", "alt": "Testzertifikat Bild 4 von 7" },
+                   { "filename": "/assets/screenshots/2-25/de/android/PersonDetailsFragment_cwa", "alt": "Testzertifikat Bild 5 von 7" },
+                   { "filename": "/assets/screenshots/2-25/de/android/TestCertificateDetailsFragment_expired", "alt": "Testzertifikat Bild 6 von 7" },
+                   { "filename": "/assets/screenshots/2-25/de/android/TestCertificateDetailsFragment__2", "alt": "Testzertifikat Bild 7 von 7" }
+                ]
+            },
+            {
+                "title": "Impfzertifikat",
+                "anchor": "android_vaccination_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Impfzertifikat“. Sie können auf der „Zertifikate“-Seite Ihr Impfzertifikat ansehen und durch Drücken von „Reisegültigkeit prüfen“, einmal die Reisegültigkeit prüfen und zu den anderen detaillierten Informationen zu Ihrem Impfzertifikat bekommen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonDetailsFragment_booster", "alt": "Impfzertifikat Bild 1 von 3" },
+                    { "filename": "/assets/screenshots/2-25/de/android/VaccinationDetailsFragment_immune", "alt": "Impfzertifikat Bild 2 von 3" },
+                    { "filename": "/assets/screenshots/2-25/de/android/VaccinationDetailsFragment_immune_2", "alt": "Impfzertifikat Bild 3 von 3" }
+                ]
+            },
+            {
+                "title": "Genesenen&shy;zertifikat",
+                "anchor": "android_recovery_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Genesenenzertifikat“. Sie können auf der „Zertifikate“-Seite Ihr Genesenenzertifikat ansehen und durch Drücken von „Reisegültigkeit prüfen“, einmal die Reisegültigkeit prüfen und zu den anderen detaillierten Informationen zu Ihrem Genesenenzertifikat bekommen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/RecoveryCertificateDetailsFragment_recovered", "alt": "Genesenenzertifikat Bild 1 von 2" },
+                    { "filename": "/assets/screenshots/2-25/de/android/RecoveryCertificateDetailsFragment_recovered_2", "alt": "Genesenenzertifikat Bild 2 von 2" }
+                ]
+            },
+            {
+                "title": "Papierkorb",
+                "anchor": "android_recycle_bin",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Papierkorb“. Wenn Sie auf der Startseite ganz nach unten scrollen und auf „Papierkorb“ drücken, wird Ihnen anschließend Ihr persönlicher Papierkorb angezeigt. Hier werden gelöschte Zertifikate und Tests aufbewahrt. Sie haben die Möglichkeit, diese wiederherzustellen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/RecyclerBin_from_menu", "alt": "Papierkorb Bild 1 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/android/RecyclerBinOverviewFragment_empty", "alt": "Papierkorb Bild 2 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/android/RecyclerBinOverviewFragment_full", "alt": "Papierkorb Bild 3 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/android/RecyclerBinOverviewFragment_full_2", "alt": "Papierkorb Bild 4 von 4" }
+                ]
+            },
+            {
+                "title": "Zertifikate drucken",
+                "anchor": "android_print_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Zertifikate drucken“. Drücken Sie auf Ihr Impfzertifikat in der „Zertifikate“-Seite und scrollen ganz nach unten und wählen die gewünschte Impfung, die sie als Druckversion haben wollen. Tippen Sie oben rechts auf das Drei-Punkte-Menü und im Anschluss auf „Druckversion anzeigen“. Alternativ können Sie in der Übersicht all Ihrer Zertifikate oben rechts auf den „Export-Pfeil“ tippen, um alle Zertifikate in ein Dokument zu exportieren. Es erscheint ein Infofenster für die „Erstellung des EU-Ausdrucks“. Nach sorgfältigem durchlesen und der Bestätigung mit „Weiter“, erscheint Ihr druckbares Zertifikat bzw. Ihre druckbaren Zertifikate. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/PrintVaccinationFragment", "alt": "Zertifikate drucken Bild 1 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/android/PrintVaccinationFragment_2", "alt": "Zertifikate drucken Bild 2 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/android/PersonOverviewFragment_many_persons", "alt": "Zertifikate drucken Bild 3 of 7" },
+                    { "filename": "/assets/screenshots/2-25/de/android/export_all1", "alt": "Zertifikate drucken Bild 4 of 7" },
+                    { "filename": "/assets/screenshots/2-25/de/android/export_all2", "alt": "Zertifikate drucken Bild 5 of 7" },
+                    { "filename": "/assets/screenshots/2-25/de/android/PrintVaccinationFragment_3", "alt": "Zertifikate drucken Bild 6 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/android/PrintVaccinationFragment_4", "alt": "Zertifikate drucken Bild 7 von 7" }
+                ]
+            },
+            {
+                  "title": "Zertifikate vor einer Reise auf Gültigkeit prüfen",
+                  "anchor": "android_check_validity_certificate",
+                  "description": "In diesem Abschnitt finden Sie Screenshots zu „Zertifikate vor einer Reise auf Gültigkeit prüfen“. Drücken Sie auf „Reisegültigkeit prüfen“ auf der „Zertifikate“-Seite unter Ihrem Impfzertifikat. Es erscheint ein Fenster, in welchem Sie die Möglichkeit haben, das Land, Datum und Uhrzeit für die Prüfung festzulegen. Drücken Sie anschließend noch auf „Prüfen“, um den Prozess abzuschließen. ",
+                  "images": [
+                      { "filename": "/assets/screenshots/2-25/de/android/check_validity1", "alt": "Zertifikate auf Gültigkeit prüfen Bild 1 von 6" },
+                      { "filename": "/assets/screenshots/2-25/de/android/check_validity2", "alt": "Zertifikate auf Gültigkeit prüfen Bild 2 von 6" },
+                      { "filename": "/assets/screenshots/2-25/de/android/check_validity3", "alt": "Zertifikate auf Gültigkeit prüfen Bild 3 von 6" },
+                      { "filename": "/assets/screenshots/2-25/de/android/check_validity4", "alt": "Zertifikate auf Gültigkeit prüfen Bild 4 von 6" },
+                      { "filename": "/assets/screenshots/2-25/de/android/check_validity5", "alt": "Zertifikate auf Gültigkeit prüfen Bild 5 von 6" },
+                      { "filename": "/assets/screenshots/2-25/de/android/check_validity6", "alt": "Zertifikate auf Gültigkeit prüfen Bild 6 von 6" }
+                  ]
+            },
+            {
+                  "title": "Ungültige Zertifikate",
+                  "anchor": "android_invalid_certificate",
+                  "description": "In diesem Abschnitt finden Sie Screenshots zu „Ungültige Zertifikate“. Hier werden Beispielzertifikate gezeigt, an welchen man die Ungültigkeit erkennen kann. Ein Merkmal eines ungültigen Zertifikats ist beispielsweise das Ausrufezeichen im schwarzen Dreieck, welches bei einem gültigen Zertifikat nicht erscheinen würde.",
+                  "images": [
+                      { "filename": "/assets/screenshots/2-25/de/android/VaccinationDetailsFragment_invalid", "alt": "Ungültige Zertifikate Bild 1 von 2" },
+                      { "filename": "/assets/screenshots/2-25/de/android/VaccinationDetailsFragment_expired", "alt": "Ungültige Zertifikate Bild 2 von 2" }
+                  ]
+            },
+            {
+                "title": "Sicherheitshinweis",
+                "anchor": "android_security_note",
+                "description": "In diesem Abschnitt finden Sie einen Screenshot für den Sicherheitshinweis. Dieser weist Sie darauf hin, dass auf Ihrem Gerät Anzeichen für Administrator-Berechtigungen gefunden wurden und daher ein erhöhtes Risiko besteht, dass andere Anwendungen auf Ihrem Smartphone auf Daten der Corona-Warn-App zugreifen können. Diese Meldung können Sie bis zum nächsten Update der Corona-Warn-App unterdrücken.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/LauncherActivity_launcher_root", "alt": "Sicherheitshinweis Bild 1 von 1"}
+                ]
+            },
+            {
+                "title": "Hinweis zur Auffrischimpfung",
+                "anchor": "android_booster_note",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Hinweis zur Auffrischimpfung“. Auf Grundlage Ihrer gespeicherten Zertifikate kann es dazu kommen, dass Sie einen Hinweis für eine Auffrischimpfung erhalten. Diese ist unterhalb des QR-Codes eines Impfzertifikats zu finden. Wenn Sie auf den Hinweis tippen, erhalten Sie detaillierte Informationen zu dem Hinweis.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/android/booster_note_de", "alt": "Hinweis zur Auffrischimpfung Bild 1 von 3"},
+                    { "filename": "/assets/screenshots/2-25/de/android/booster_note_detail_de", "alt": "Hinweis zur Auffrischimpfung Bild 2 von 3"},
+                    { "filename": "/assets/screenshots/2-25/de/android/booster_note_detail2_de", "alt": "Hinweis zur Auffrischimpfung Bild 3 von 3"}
+                ]
+            }
+        ]
+    },
+    "ios-screenshots": {
+        "tab-title": "iOS Screenshots",
+        "sections": [
+            {
+                "title": "Einführung",
+                "anchor": "ios_onboarding",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu den Informationen, die bei einer Neuinstallation der App zu sehen sind. Wir zeigen zunächst auf inwiefern Sie mit Ihrem Smartphone daran teilhaben können Infektionsketten schneller zu durchbrechen, indem wir Sie über die Funktionen der Corona-Warn-App in Kenntnis setzen. Im Anschluss folgt unsere Datenschutzerklärung, in welcher Sie unter anderem erfahren, wie Ihre Daten verarbeitet werden, und welche Datenschutzrechte Sie als Nutzer der Corona-Warn-App haben. Als nächstes wird erklärt, wie Sie mithilfe von Bluetooth die Risiko-Ermittlung aktivieren können. Daraufhin werden Sie darum gebeten im Falle eines positiven Tests andere über die App zu warnen, und Ihre Mitteilungseinstellungen anzupassen, um unter anderem über Ihren Risikostatus oder die Gültigkeit Ihrer Zertifikate informiert zu werden. Zuletzt haben Sie die Möglichkeit zu entscheiden, ob Sie an der Datenspende teilnehmen wollen. Durch Ihre freiwillig bereitgestellten Daten kann das RKI die Wirksamkeit der App besser bewerten und sowohl die Funktionen als auch die Nutzerfreundlichkeit der App verbessern.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-AppStore_0001", "alt": "Einführung Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-OnboardingFlow_EnablePermission_0002", "alt": "Einführung Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-OnboardingFlow_EnablePermission_0003", "alt": "Einführung Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-OnboardingFlow_EnablePermission_0004", "alt": "Einführung Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-OnboardingFlow_EnablePermission_0005", "alt": "Einführung Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-OnboardingFlow_EnablePermission_0006", "alt": "Einführung Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Risiko-Karten",
+                "anchor": "ios_cards",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu den verschiedenen Risiko-Karten. Wir zeigen jeweils die Risiko-Karte auf der Status-Seite und die dazugehörige Detailansicht, zu der Sie durch das Antippen der Karte in der App gelangen. Als erstes zeigen wir die grüne Kachel mit niedrigem Risiko ohne Begegnungen, danach die grüne Kachel mit niedrigem Risiko mit Begegnungen, und schließlich die rote Kachel mit hohem Risiko. Die Hygieneregeln und Ansteckungsrisiko minimieren erreichen Sie, indem Sie jeweils auf das 'i' in der Detailansicht der roten Karte in der App tippen. Mit einem Klick auf den jeweiligen Text gelangen Sie zu einem Screenshot, der alles in einem Bild darstellt.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-AppStore_0002", "alt": "Risiko-Karten Bild 1 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/no1de", "alt": "Risiko-Karten Bild 2 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/no2de", "alt": "Risiko-Karten Bild 3 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/no3de", "alt": "Risiko-Karten Bild 4 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-homescreenrisk_level_low_risk_one_day_0001", "alt": "Risiko-Karten Bild 5 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/low1de", "alt": "Risiko-Karten Bild 6 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/low2de", "alt": "Risiko-Karten Bild 7 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/low3de", "alt": "Risiko-Karten Bild 8 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/low4de", "alt": "Risiko-Karten Bild 9 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/high0de", "alt": "Risiko-Karten Bild 10 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/high1de", "alt": "Risiko-Karten Bild 11 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/high2de", "alt": "Risiko-Karten Bild 12 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/high3de", "alt": "Risiko-Karten Bild 13 von 16" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/high4de", "alt": "Risiko-Karten Bild 14 von 16" },
+                    { "filename": "/assets/img/faq/hr_de", "alt": "Risiko-Karten Bild 15 von 16" },
+                    { "filename": "/assets/img/faq/minimizerisk_de", "alt": "Risiko-Karten Bild 16 von 16" }
+                ]
+            },
+            {
+                "title": "Kontakt-Tagebuch",
+                "anchor": "ios_journal",
+                "description": "In diesem Abschnitt finden Sie Screenshots zum Kontakt-Tagebuch. Wir zeigen den jeweiligen Tag für die vergangenen zwei Wochen. Drückt man auf einen dieser Tag, erscheint ein neues Fenster und man hat die Möglichkeit, Personen und Orte hinzuzufügen. Um eine Person hinzuzufügen wird der Name, die E-Mail und die Telefonnummer einer Person benötigt. Für den Ort gilt die Beschreibung, die E-Mail und Telefonnummer. Drückt man anschließend auf die hinzugefügte Person oder Ort hat man die Möglichkeit die Dauer der Begegnung, bzw. des Aufenthaltes einzustellen. Drückt man oben rechts auf die drei Punkte, kann man hinzugefügte Orte und Personen bearbeiten oder gänzlich entfernen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-contact_journal_information_screen_0001", "alt": "Kontakt-Tagebuch Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-contact_journal_listing1_0001", "alt": "Kontakt-Tagebuch Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-contact_journal_listing_add_persons", "alt": "Kontakt-Tagebuch Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-contact_journal_listing_add_locations", "alt": "Kontakt-Tagebuch Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-contact_journal_listing_edit_persons", "alt": "Kontakt-Tagebuch Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-contact_journal_listing_edit_locations", "alt": "Kontakt-Tagebuch Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Check-in - QR-Code scannen",
+                "anchor": "ios_check_in",
+                "description": "In diesem Abschnitt finden Sie Screenshots zum Check-in QR-Code scannen. Auf der Check-in-Seite haben Sie die Möglichkeit auf QR-Code scannen zu drücken. Daraufhin wird ein neues Fenster erscheinen, in welchem die Kamera Ihres Gerätes benutzt wird und Sie Ihren QR-Code scannen können. Wenn Sie dies getan haben, erscheint nochmal ein Bestätigungsfenster mit Informationen zu Ihrem QR-Code, das Sie mit „Einchecken“ bestätigen können. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-event_checkin_004_mycheckins_emptyList", "alt": "Check In Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-event_checkin_005_mycheckins_checkin", "alt": "Check In Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-event_checkin_005_checkinDetails", "alt": "Check In Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-event_checkin_007_checkinDetailsTime", "alt": "Check In Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-event_checkin_006_mycheckins", "alt": "Check In Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-event_checkin_008_checkinList", "alt": "Check In Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Check-in - QR-Code erstellen",
+                "anchor": "ios_check_in_create_event",
+                "description": "In diesem Abschnitt finden Sie Screenshots zum Erstellen von QR-Codes. Sobald Sie auf QR-Code erstellen drücken, erscheint ein Fenster, in welchem Sie den Ort bzw. Event wählen können. Daraufhin müssen Sie noch die Bezeichnung und die Adresse für den ausgewählten Ort/Event eingeben. Außerdem müssen Sie die typische Aufenthaltsdauer auswählen. Sobald Sie diese Schritte absolviert haben, ist der QR-Code erfolgreich erstellt. Zum Schluss haben Sie noch die Möglichkeit auf „Selbst einchecken“ zu drücken. Wenn Sie dies tun, dann erscheint ein Bestätigungsfenster mit Informationen zu Ihrem QR-Code, das Sie mit „Einchecken“ bestätigen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-traceLocation_004_emptyList", "alt": "Check In Bild 1 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-traceLocation_005_categories", "alt": "Check In Bild 2 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-traceLocation_006_createQRCodeInputScreen-DE", "alt": "Check In Bild 3 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-traceLocation_007_traceLocationOverview", "alt": "Check In Bild 4 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-traceLocation_010_checkinScreen", "alt": "Check In Bild 5 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-traceLocation_011_myQRCodes", "alt": "Check In Bild 6 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-traceLocation_008_traceLocationDetailScreen", "alt": "Check In Bild 7 von 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-traceLocation_009_traceLocationPdfScreen", "alt": "Check In Bild 8 von 8" }
+                ]
+            },
+            {
+                "title": "Aktuelle Zahlen",
+                "anchor": "ios_stats",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Aktuelle Zahlen“. Wenn Sie auf der „Status“ Seite, nach unten scrollen, dann sehen Sie „Lokale 7-Tage-Inzidenz hinzufügen“. Wischen Sie nun nach rechts, um die aktuellen Zahlen zu lesen. Die verfügbaren Zahlen sind die 7-Tage-Inzidenz, die COVID-19-Erkrankten auf Intensivstationen, die bestätigten Neuinfektionen, warnende Personen, der 7-Tage-R-Wert, mindestens einmal geimpfte Personen, vollständig geimpfte Personen und die verabreichten Impfdosen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_add_local_statistics", "alt": "Aktuelle Zahlen Bild 1 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_local_7day_values", "alt": "Aktuelle Zahlen Bild 2 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_7day_combined_incidences", "alt": "Aktuelle Zahlen Bild 3 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_intensive_care", "alt": "Aktuelle Zahlen Bild 4 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_confirmed_new_infections", "alt": "Aktuelle Zahlen Bild 5 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_key_submissions", "alt": "Aktuelle Zahlen Bild 6 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_7Day_rvalue", "alt": "Aktuelle Zahlen Bild 7 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_at_least_one_vaccination", "alt": "Aktuelle Zahlen Bild 8 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_fully_vaccinated", "alt": "Aktuelle Zahlen Bild 9 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_booster_vaccination", "alt": "Aktuelle Zahlen Bild 10 von 13"},
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_doses", "alt": "Aktuelle Zahlen Bild 11 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_info_screen_0001", "alt": "Aktuelle Zahlen Bild 12 von 13" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-statistics_info_screen_0002", "alt": "Aktuelle Zahlen Bild 13 von 13" }
+                ]
+            },
+            {
+                "title": "Test registrieren & andere warnen",
+                "anchor": "ios_registertest",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Test registrieren & andere warnen“. Wenn Sie auf der „Status“ Seite bei „Sie lassen sich testen“ auf „Weiter“ drücken kommen Sie zur Testverwaltung. Hier haben Sie die Möglichkeit Ihren PCR-Test, oder den eines Familienmitglieds, zu registrieren. Drücken Sie auf „TAN für PCR-Test eingeben“, damit ein Fenster erscheint, wo Sie Ihren 10-stelligen TAN eingeben können. Sobald Sie dies getan haben, müssen Sie noch Ihr Einverständnis geben. Dann kann Ihr Testergebnis drei verschiedene Status haben. Diese sind „Ergebnis liegt noch nicht vor“, „Sars-CoV-2 negativ“ und „Sars-CoV-2 positiv“. Beim letzteren haben Sie noch die Möglichkeit den Beginn und die Art der Symptome zu erfassen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-tan_submissionflow_qr_0001", "alt": "Test registrieren & andere warnen Bild 1 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_family_member_tests_selection", "alt": "Test registrieren & andere warnen Bild 2 von 11"},
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-tan_submissionflow_qr_0002", "alt": "Test registrieren & andere warnen Bild 3 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_family_member_tests_consent_1", "alt": "Test registrieren & andere warnen Bild 4 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-submissionflow_screenshot_test_result_available", "alt": "Test registrieren & andere warnen Bild 5 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-submissionflow_screenshot_test_result_pending", "alt": "Test registrieren & andere warnen Bild 6 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_test_certificate_button_test_result_negative", "alt": "Test registrieren & andere warnen Bild 7 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-submissionflow_screenshot_test_result_positive_constent_given", "alt": "Test registrieren & andere warnen Bild 8 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-tan_submissionflow_tan_0001", "alt": "Test registrieren & andere warnen Bild 9 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-tan_submissionflow_symptoms_selection0001", "alt": "Test registrieren & andere warnen Bild 10 von 11" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-submissionflow_screenshot_symptoms_onset_date_option", "alt": "Test registrieren & andere warnen Bild 11 von 11" }
+                ]
+            },
+            {
+                "title": "In Vertretung warnen",
+                "anchor": "ios_warn_for_others",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „In Vertretung warnen“. Wenn Sie auf der „Meine QR-Codes\" Seite auf die drei Punkte oben rechts drücken, haben Sie die Möglichkeit „In Vertretung warnen” auszuwählen. Falls Sie dies getan haben, erscheint ein neues Fenster, in dem Sie ein Event wählen können, für welches Sie in Vertretung einer infizierten Person andere warnen können. Wenn Sie “Weiter“ drücken, können Sie Beginn/Ankunft und die Dauer des Aufenthaltes einstellen. Zuletzt müssen Sie nur noch ihren 10-stelligen TAN eingeben. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-onbehalfwarning_info", "alt": "In Vertretung warnen Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-onbehalfwarning_info_0002", "alt": "In Vertretung warnen Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-onbehalfwarning_location_selection", "alt": "In Vertretung warnen Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-onbehalfwarning_date_time_selection", "alt": "In Vertretung warnen Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-onbehalfwarning_tan", "alt": "In Vertretung warnen Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-onbehalfwarning_thank_you", "alt": "In Vertretung warnen Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Testergebnis",
+                "anchor": "ios_results",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Testergebnis“. Direkt unter der Risiko-Info können Sie den Status der in Ihrem Gerät registrierten Tests sehen. Es gibt 4 verschiedene Möglichkeiten. Das Ergebnis des PCR-Tests liegt noch nicht vor, der PCR-Test ist negativ, der PCR-Test ist positiv und der PCR-Test ist fehlerhaft. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-homescreenrisk_show_pending_test_result_0001", "alt": "Testergebnis abrufen Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-homescreenrisk_show_negative_test_result_0001", "alt": "Testergebnis abrufen Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-homescreenrisk_show_positive_test_result_0001", "alt": "Testergebnis abrufen Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-homescreenrisk_show_invalid_test_result_0001", "alt": "Testergebnis abrufen Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_family_member_tests_home_2", "alt": "Testergebnis abrufen Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_family_member_tests_family_list_1", "alt": "Testergebnis abrufen Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Schnelltest",
+                "anchor": "ios_rat",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Schnelltest“. Tippen Sie innerhalb der „Test registrieren“-Kachel auf „Nächste Schritte“ um einen Test entweder per QR-Code oder per TAN zu registrieren. In der gleichen Kachel werden Sie über den aktuellen Stand Ihres Tests informiert. Demnach können Sie, sobald ein Testergebnis vorliegt, Ihr Testergebnis abrufen und werden abhängig von Ihrem Testergebnis unterschiedliche Informationen finden. Sollte Ihr Test positiv gewesen sein werden Sie über das weitere Vorgehen aufgeklärt und Ihre Mitmenschen werden über die App gewarnt. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_1", "alt": "Schnelltest Bild 1 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_2", "alt": "Schnelltest Bild 2 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_3", "alt": "Schnelltest Bild 3 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_4", "alt": "Schnelltest Bild 4 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_5", "alt": "Schnelltest Bild 5 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_6", "alt": "Schnelltest Bild 6 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_7", "alt": "Schnelltest Bild 7 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_8", "alt": "Schnelltest Bild 8 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_9", "alt": "Schnelltest Bild 9 von 10" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/rat_10", "alt": "Schnelltest Bild 10 von 10" }
+                ]
+            },
+            {
+                "title": "Schnelltest-Profile",
+                "anchor": "ios_rat_profiles",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu Schnelltest-Profilen. Tippen Sie in der Kachel \"Sie lassen sich testen?\" auf \"Schnelltest-Profile\". Wenn Sie zum ersten Mal darauf zugreifen, werden Sie zunächst über die Vorteile der Erstellung eines Schnelltestprofils und die damit verbundenen Hinweise zu Datensicherheit und Datenschutz informiert. Tippen Sie gegebenenfalls auf \"Weiter\", um fortzufahren. Tippen Sie auf der Übersichtsseite \"Schnelltest-Profile\" auf die Schaltfläche am oberen Rand, um ein neues Schnelltest-Profil anzulegen. Sobald Sie alle Daten eingegeben haben, tippen Sie auf \"Speichern\" am unteren Rand der Seite. Nun können Sie das erstellte Schnelltestprofil in der Übersicht sehen.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-AppStore_0002", "alt": "Schnelltest-Profile Bild 1 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/RATProfilesDE", "alt": "Schnelltest-Profile Bild 2 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/RATProfileOnboardingDE", "alt": "Schnelltest-Profile Bild 3 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/RATProfileListEmptyDE", "alt": "Schnelltest-Profile Bild 4 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/RATProfileCreateDE", "alt": "Schnelltest-Profile Bild 5 von 6" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/RATProfileListDE", "alt": "Schnelltest-Profile Bild 6 von 6" }
+                ]
+            },
+            {
+                "title": "Zertifikate",
+                "anchor": "ios_certificates",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Zertifikate“. Wenn Sie die „Zertifikate“-Seite zum ersten Mal besuchen, erhalten Sie ein Infofenster. Drücken Sie auf „Weiter“ und Sie werden die Möglichkeit haben, Ihr Zertifikat hinzuzufügen. Sofern Sie dies getan haben, wird Ihr Zertifikat auf der „Zertifikate“-Seite zu sehen sein. Es ist möglich mehrere Zertifikate hinzuzufügen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_health_certificate_consent_screen", "alt": "Zertifikate Bild 1 of 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_health_certificate_empty_screen", "alt": "Zertifikate Bild 2 of 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_certificate_family_certificate-cert-1", "alt": "Zertifikate Bild 3 of 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_certificate_family_certificate-cert-2", "alt": "Zertifikate Bild 4 of 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_health_certificate_reissuance_refresh_certificate", "alt": "Zertifikate Bild 5 of 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_health_certificate_reissuance_consentScreen", "alt": "Zertifikate Bild 6 of 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_health_certificate_reissuance_success", "alt": "Zertifikate Bild 7 of 8" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/checkcertificate", "alt": "Zertifikate Bild 8 of 8" }
+                ]
+            },
+            {
+                "title": "Zertifikate erneuern",
+                "anchor": "ios_certificate_reissuance",
+                "description": "In diesem Abschnitt finden Sie Screenshots zum Erneuern Ihrer Zertifikate. Sie werden über die zu erneuernden Zertifikate informiert und um eine Einverständnis gebeten, um diese zu erneuern. Am Ende werden Sie darüber in Kenntnis gesetzt, dass Ihre Zertifikate erfolgreich erneuert wurden und in der Zertifikate-Registerkarte zu finden sind.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-23/de/ios/reissuance0", "alt": "Zertifikate erneuern Bild 1 von 6"},
+                    { "filename": "/assets/screenshots/2-25/de/ios/reissuance1", "alt": "Zertifikate erneuern Bild 1 von 6"},
+                    { "filename": "/assets/screenshots/2-25/de/ios/reissuance2", "alt": "Zertifikate erneuern Bild 2 von 6"},
+                    { "filename": "/assets/screenshots/2-25/de/ios/reissuance3", "alt": "Zertifikate erneuern Bild 3 von 6"},
+                    { "filename": "/assets/screenshots/2-25/de/ios/reissuance4", "alt": "Zertifikate erneuern Bild 4 von 6"},
+                    { "filename": "/assets/screenshots/2-25/de/ios/reissuance5", "alt": "Zertifikate erneuern Bild 5 von 6"}
+                ]
+            },
+            {
+                "title": "Testzertifikat",
+                "anchor": "ios_test_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Testzertifikat“. Wenn Sie auf der Startseite bei „Sie lassen sich testen?“ auf „Weiter“ drücken und anschließend auf QR-Code scannen, dann haben Sie die Möglichkeit einen QR-Code zu scannen und so ein COVID-Testzertifikat anzufordern. Sie müssen noch Ihr Geburtsdatum zu Ihrer eigenen Sicherheit einstellen, bei einem falschen Datum wird das Testergebnis nicht zugestellt. Zuletzt können Sie auf der „Zertifikate“-Seite Ihr Testergebnis ansehen und durch Drücken von „Reisegültigkeit prüfen“, einmal die Reisegültigkeit prüfen und zu den anderen detaillierten Informationen zu Ihrem Testergebnis bekommen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-homescreenrisk_level_low_installation_14days_0001", "alt": "Testzertifikat Bild 1 von 5" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-submissionflow_screenshot_test_certificate_entered_birthday", "alt": "Testzertifikat Bild 2 von 5" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_test_certificate_valid_overview_part1", "alt": "Testzertifikat Bild 3 von 5" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_test_certificate_valid_details_part1", "alt": "Testzertifikat Bild 4 von 5" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_test_certificate_valid_details_part2", "alt": "Testzertifikat Bild 5 von 5" }
+                ]
+            },
+            {
+                "title": "Impfzertifikat",
+                "anchor": "ios_vaccination_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Impfzertifikat“. Sie können auf der „Zertifikate“-Seite Ihr Impfzertifikat ansehen und durch Drücken von „Reisegültigkeit prüfen“, einmal die Reisegültigkeit prüfen und zu den anderen detaillierten Informationen zu Ihrem Impfzertifikat bekommen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_vaccination_certificate_valid_details_part1", "alt": "Impfzertifikat Bild 1 von 3" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_vaccination_certificate_valid_details_part3", "alt": "Impfzertifikat Bild 2 von 3" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_second_vaccination_certificate_details_part2", "alt": "Impfzertifikat Bild 3 von 3" }
+                ]
+            },
+            {
+                "title": "Genesenen&shy;zertifikat",
+                "anchor": "ios_recovery_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Genesenenzertifikat“. Sie können auf der „Zertifikate“-Seite Ihr Genesenenzertifikat ansehen und durch Drücken von „Reisegültigkeit prüfen“, einmal die Reisegültigkeit prüfen und zu den anderen detaillierten Informationen zu Ihrem Genesenenzertifikat bekommen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_recovery_certificate_valid_details_part1", "alt": "Genesenenzertifikat Bild 1 von 2" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_recovery_certificate_valid_details_part2", "alt": "Genesenenzertifikat Bild 2 von 2" }
+                ]
+            },
+            {
+                "title": "Papierkorb",
+                "anchor": "ios_recycle_bin",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Papierkorb“. Wenn Sie auf der Startseite ganz nach unten scrollen und auf „Papierkorb“ drücken, wird Ihnen anschließend Ihr persönlicher Papierkorb angezeigt. Hier werden gelöschte Zertifikate und Tests aufbewahrt. Sie haben die Möglichkeit, diese wiederherzustellen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/ios-bin-0", "alt": "Papierkorb Bild 1 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/ios-bin-1", "alt": "Papierkorb Bild 2 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/ios-bin-2", "alt": "Papierkorb Bild 3 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/ios-bin-3", "alt": "Papierkorb Bild 4 von 4" }
+                ]
+            },
+            {
+                "title": "Zertifikate drucken",
+                "anchor": "ios_print_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Zertifikate drucken“. Drücken Sie auf Ihr Impfzertifikat in der „Zertifikate“-Seite und scrollen ganz nach unten und wählen die gewünschte Impfung, die sie als Druckversion haben wollen. Wählen Sie anschließend „Mehr“ und „Druckversion anzeigen“. Alternativ können Sie in der Übersicht all Ihrer Zertifikate oben rechts auf den „Export-Pfeil“ tippen, um alle Zertifikate in ein Dokument zu exportieren. Es erscheint ein Infofenster für die „Erstellung des EU-Ausdrucks“. Nach sorgfältigem durchlesen und der Bestätigung mit „Weiter“, erscheint Ihr druckbares Zertifikat bzw. Ihre druckbaren Zertifikate.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_vaccination_certificate_valid_details_part3", "alt": "Zertifikate drucken Bild 1 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_vaccination_certificate_print_pdf_actionsheet", "alt": "Zertifikate drucken Bild 2 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/export_all1", "alt": "Zertifikate drucken Bild 3 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/export_all2", "alt": "Zertifikate drucken Bild 4 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_vaccination_certificate_print_pdf_infoscreen", "alt": "Zertifikate drucken Bild 5 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_vaccination_certificate_print_pdf_pdfscreen", "alt": "Zertifikate drucken Bild 6 von 7" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/print_share", "alt": "Zertifikate drucken Bild 7 von 7" }
+                ]
+            },
+            {
+                "title": "Zertifikate vor einer Reise auf Gültigkeit prüfen",
+                "anchor": "ios_check_validity_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Zertifikate vor einer Reise auf Gültigkeit prüfen“. Drücken Sie auf „Reisegültigkeit prüfen“ auf der „Zertifikate“-Seite unter Ihrem Impfzertifikat. Es erscheint ein Fenster, in welchem Sie die Möglichkeit haben, das Land, Datum und Uhrzeit für die Prüfung festzulegen. Drücken Sie anschließend noch auf „Prüfen“, um den Prozess abzuschließen. ",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_vaccination_certificate_valid_details_part3", "alt": "Zertifikate auf Gültigkeit prüfen Bild 1 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_certificate_validation_date_selection", "alt": "Zertifikate auf Gültigkeit prüfen Bild 2 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_certificate_validation_country_selection", "alt": "Zertifikate auf Gültigkeit prüfen Bild 3 von 4" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_certificate_validation", "alt": "Zertifikate auf Gültigkeit prüfen Bild 4 von 4" }
+                ]
+            },
+            {
+                "title": "Ungültige Zertifikate",
+                "anchor": "ios_invalid_certificate",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Ungültige Zertifikate“. Hier werden Beispielzertifikate gezeigt, an welchen man die Ungültigkeit erkennen kann. Ein Merkmal eines ungültigen Zertifikats ist beispielsweise das Ausrufezeichen im schwarzen Dreieck, welches bei einem gültigen Zertifikat nicht erscheinen würde.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_recovery_certificate_overview_part1", "alt": "Ungültige Zertifikate Bild 1 von 3" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_recovery_certificate_expired_details_part1", "alt": "Ungültige Zertifikate Bild 2 von 3" },
+                    { "filename": "/assets/screenshots/2-25/de/ios/iPhone 13-screenshot_recovery_certificate_expired_details_part2", "alt": "Ungültige Zertifikate Bild 3 von 3" }
+                ]
+            },
+            {
+                "title": "Hinweis zur Auffrischimpfung",
+                "anchor": "ios_booster_note",
+                "description": "In diesem Abschnitt finden Sie Screenshots zu „Hinweis zur Auffrischimpfung“. Auf Grundlage Ihrer gespeicherten Zertifikate kann es dazu kommen, dass Sie einen Hinweis für eine Auffrischimpfung erhalten. Diese ist unterhalb des QR-Codes eines Impfzertifikats zu finden. Wenn Sie auf den Hinweis tippen, erhalten Sie detaillierte Informationen zu dem Hinweis.",
+                "images": [
+                    { "filename": "/assets/screenshots/2-25/de/ios/booster_note_de", "alt": "Hinweis zur Auffrischimpfung Bild 1 von 3"},
+                    { "filename": "/assets/screenshots/2-25/de/ios/booster_note_detail_de", "alt": "Hinweis zur Auffrischimpfung Bild 2 von 3"}
+                ]
+            }
+        ]
+    }
+}

--- a/src/pages/de/screenshots-archive/2-26.html
+++ b/src/pages/de/screenshots-archive/2-26.html
@@ -1,0 +1,9 @@
+---
+lang_de: true
+page-title: Open-Source-Projekt Corona-Warn-App – Screenshots
+page-description: Screenshots der Corona-Warn-App.
+page-name: 2-26
+lightbox: true
+screenshotsarchive: true
+---
+{{> page-screenshots page-contents=screenshots-archive-2-26_de}}

--- a/src/pages/en/screenshots-archive/2-26.html
+++ b/src/pages/en/screenshots-archive/2-26.html
@@ -1,0 +1,9 @@
+---
+lang_en: true
+page-title: Open-Source Project Corona-Warn-App – Screenshots
+page-description: Screenshots of the Corona-Warn-App.
+page-name: 2-26
+lightbox: true
+screenshotsarchive: true
+---
+{{> page-screenshots page-contents=screenshots-archive-2-26}}


### PR DESCRIPTION
With #3131, the screenshots for version 2.27 have been released. However, the screenshots for 2.26 were not archived and accessing https://www.coronawarn.app/de/screenshots-archive/2-26.html or https://www.coronawarn.app/en/screenshots-archive/2-26.html currently leads to a 404 error.

With this PR, this is fixed