### PR TITLE
Update Dashboard: Change order on statistics

### DIFF
--- a/src/assets/js/analyse/chart/config.js
+++ b/src/assets/js/analyse/chart/config.js
@@ -416,12 +416,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "qr_not_redeemed_cumulated"
-					},
-					{
 						color: "#3BA8CE",
 						data: "qr_redeemed_cumulated"
+					},
+					{
+						color: "#57DAFF",
+						data: "qr_not_redeemed_cumulated"
 					}
 					
 				],
@@ -436,12 +436,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "teletan_not_redeemed_cumulated"
-					},
-					{
 						color: "#3BA8CE",
 						data: "teletan_redeemed_cumulated"
+					},
+					{
+						color: "#57DAFF",
+						data: "teletan_not_redeemed_cumulated"
 					}
 					
 				],
@@ -477,13 +477,13 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "qr_not_redeemed_daily"
-					},
-					{
 						color: "#3BA8CE",
 						data: "qr_redeemed_daily"
 					},
+					{
+						color: "#57DAFF",
+						data: "qr_not_redeemed_daily"
+					}
 				],
 				"stacked": true,
 				"type":"bar"
@@ -496,12 +496,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "teletan_not_redeemed_daily"
-					},
-					{
 						color: "#3BA8CE",
 						data: "teletan_redeemed_daily"
+					},
+					{
+						color: "#57DAFF",
+						data: "teletan_not_redeemed_daily"
 					}
 				],
 				"stacked": true,
@@ -536,12 +536,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "qr_not_redeemed_7days_sum"
-					},
-					{
 						color: "#3BA8CE",
 						data: "qr_redeemed_7days_sum"
+					},
+					{
+						color: "#57DAFF",
+						data: "qr_not_redeemed_7days_sum"
 					}
 					
 				],
@@ -556,12 +556,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "teletan_not_redeemed_7days_sum"
-					},
-					{
 						color: "#3BA8CE",
 						data: "teletan_redeemed_7days_sum"
+					},
+					{
+						color: "#57DAFF",
+						data: "teletan_not_redeemed_7days_sum"
 					}
 					
 				],
@@ -606,12 +606,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "qr_not_redeemed_7days_avg"
-					},
-					{
 						color: "#3BA8CE",
 						data: "qr_redeemed_7days_avg"
+					},
+					{
+						color: "#57DAFF",
+						data: "qr_not_redeemed_7days_avg"
 					},
 					{
 						ghost: true,
@@ -619,12 +619,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "qr_not_redeemed_daily"
-					},
-					{
 						color: "#3BA8CE",
 						data: "qr_redeemed_daily"
+					},
+					{
+						color: "#57DAFF",
+						data: "qr_not_redeemed_daily"
 					}
 				]
 			},
@@ -636,12 +636,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "teletan_not_redeemed_7days_avg"
-					},
-					{
 						color: "#3BA8CE",
 						data: "teletan_redeemed_7days_avg"
+					},
+					{
+						color: "#57DAFF",
+						data: "teletan_not_redeemed_7days_avg"
 					},
 					{
 						ghost: true,
@@ -649,12 +649,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#57DAFF",
-						data: "teletan_not_redeemed_daily"
-					},
-					{
 						color: "#3BA8CE",
 						data: "teletan_redeemed_daily"
+					},
+					{
+						color: "#57DAFF",
+						data: "teletan_not_redeemed_daily"
 					}
 				]
 			}

--- a/src/assets/js/analyse/chart/config.js
+++ b/src/assets/js/analyse/chart/config.js
@@ -477,13 +477,13 @@ export default {
 						name: "total"
 					},
 					{
+						color: "#57DAFF",
+						data: "qr_not_redeemed_daily"
+					},
+					{
 						color: "#3BA8CE",
 						data: "qr_redeemed_daily"
 					},
-					{
-						color: "#57DAFF",
-						data: "qr_not_redeemed_daily"
-					}
 				],
 				"stacked": true,
 				"type":"bar"
@@ -496,12 +496,12 @@ export default {
 						name: "total"
 					},
 					{
-						color: "#3BA8CE",
-						data: "teletan_redeemed_daily"
-					},
-					{
 						color: "#57DAFF",
 						data: "teletan_not_redeemed_daily"
+					},
+					{
+						color: "#3BA8CE",
+						data: "teletan_redeemed_daily"
 					}
 				],
 				"stacked": true,


### PR DESCRIPTION
When looking at the "Sharing behaviour" tile, specifically the "QR codes" and "teleTANs" section, the order of "Shared" and "Not Shared" differs between "Daily" and any other option. While "Shared" is at the bottom of each bar in the "Daily" view, it is at the top of the bar in any other view.

![image](https://user-images.githubusercontent.com/88365935/196111025-fd019773-3d99-4a63-95f8-fa66215015e1.png)
![image](https://user-images.githubusercontent.com/88365935/196111154-5d0f865d-10db-4407-ab66-13ed98213620.png)

To fix this, we have changed the order of all other views to align with the daily view.

![chrome_KcHo40S8E3](https://user-images.githubusercontent.com/88365935/196129785-5d07282c-6f6a-4738-843d-6267e0f719bb.png)
![chrome_dIj1xH8RaM](https://user-images.githubusercontent.com/88365935/196129793-32df7622-fd04-4fc3-88c9-5a4ed84dc531.png)


---
Internal Tracking ID: [EXPOSUREAPP-14142](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14142)