### PR TITLE
Update Cypress check for #vac_cert_booster redirection

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -41,7 +41,7 @@
         "#vac_booster",
         "#vac_cert",
         "#vac_cert_booster",
-        "#vac_cert",
+        "#vac_booster_basics",
         "#val_service_no_valid_dcc",
         "#val_service_basics",
         "#val_service_result",


### PR DESCRIPTION
This PR resolves https://github.com/corona-warn-app/cwa-website/issues/3146 "Cypress test fails redirect check" by making changes to the source of data-driven testing in [cypress/fixtures/appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json).

In the `faqRedirect` section, the anchor `#vac_cert_booster` entry is changed to test for redirection to `#vac_booster_basics`.

## Verification

Execute
`npm run test:open`
select `app_to_web.js`

The test should run successfully.

After merging and waiting for the daily run of [.github/workflows/cypress-test-prod.yml](https://github.com/corona-warn-app/cwa-website/blob/master/.github/workflows/cypress-test-prod.yml), check also the status of the Action [actions/workflows/cypress-test-prod.yml](https://github.com/corona-warn-app/cwa-website/actions/workflows/cypress-test-prod.yml). Alternatively run the action manually.

---
Internal Tracking ID: [EXPOSUREAPP-14156](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14156)
