### PR TITLE
Make faq test less senstive for statistics entry

### DIFF
--- a/cypress/fixtures/copy/stringDe.json
+++ b/cypress/fixtures/copy/stringDe.json
@@ -17,6 +17,6 @@
         "text":"Test",
         "topic": "Was tun, wenn?"
     },
-    "resultAssertion": "Wegen der hohen Dynamik der Pandemie"
+    "resultAssertion": "Statistiken"
   }
 }

--- a/cypress/fixtures/copy/stringEn.json
+++ b/cypress/fixtures/copy/stringEn.json
@@ -17,6 +17,6 @@
         "text":"Test",
         "topic": "What to do, if?"
     },
-    "resultAssertion": "Due to the high dynamics of the pandemic"
+    "resultAssertion": "statistics"
   }
 }


### PR DESCRIPTION
This PR changes the test data for [faq.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/faq.js) to make it less sensitive to the exact text in https://www.coronawarn.app/en/faq/results/#further_details.

Submitting first as draft until Cypress tests completed.

- This should also fix the issue in PR https://github.com/corona-warn-app/cwa-website/pull/3151

Internal Tracking ID: [EXPOSUREAPP-14167](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14167)

