### PR TITLE
Update appToWebLinks.json for 2.28 release

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -1,8 +1,7 @@
 {
     "appVersionFirst": "2.23",
-    "appVersionLast": "2.27",
+    "appVersionLast": "2.28",
     "faqEntry": [
-        "#mask_rules",
         "#admission_policy",
         "#android_location",
         "#cause9002_recovery",
@@ -21,6 +20,7 @@
         "#hc_already_registered",
         "#hc_signature_invalid",
         "#interoperability_countries",
+        "#mask_rules",
         "#notification_settings",
         "#part_incompat",
         "#quarantine_measures",


### PR DESCRIPTION
This PR carries out housekeeping for the [appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json) data source for the Cypress test [cypress/integration/app_to_web.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/app_to_web.js).

1. The comment field `appVersionLast` is updated to 2.28 to show that the file has been prepared for the upcoming release
2. The `#mask_rules` entry, which was added for the 2.27 release, is moved into alphabetical order for better readability and maintenance

Note that although the use of the FAQ anchor `#quarantine_measures` is planned to be removed in the CWA 2.28 release, it stays in the [appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json) file because the Cypress test ensures that all anchors used by previous app versions from `"appVersionFirst": "2.23"` onwards continue to be available. This could only change if there were to be a decision to stop supporting earlier app versions.