### PR TITLE
Refactor faqRedirect test

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -36,16 +36,26 @@
         "#test_cert"
     ],
     "faqRedirect": [
-        "#hc_prefix_invalid",
-        "#eu_dcc",
-        "#vac_booster",
-        "#vac_cert",
-        "#vac_cert_booster",
-        "#vac_booster_basics",
-        "#val_service_no_valid_dcc",
-        "#val_service_basics",
-        "#val_service_result",
-        "#val_service_basics"
+        [
+            "#hc_prefix_invalid",
+            "#eu_dcc"
+        ],
+        [
+            "#vac_booster",
+            "#vac_cert"
+        ],
+        [
+            "#vac_cert_booster",
+            "#vac_booster_basics"
+        ],
+        [
+            "#val_service_no_valid_dcc",
+            "#val_service_basics"
+        ],
+        [
+            "#val_service_result",
+            "#val_service_basics"
+        ]
     ],
     "blogEntry": [
         "2021-08-05-statistictiles",

--- a/cypress/integration/app_to_web.js
+++ b/cypress/integration/app_to_web.js
@@ -40,10 +40,11 @@ describe("Test cwa-webserver links used by Corona-Warn-App", () => {
     it("Test FAQ redirected links", () => {
         var redirectFAQs = links.faqRedirect;
         languages.forEach(lang => {
-            var i;
-            for (i = 0; i < redirectFAQs.length; i = i + 2) {
-                cy.testFaqRedirect(lang, redirectFAQs[i], redirectFAQs[i + 1]);
-            }
+            redirectFAQs.forEach(redirect => {
+                var redirectSource = redirect[0];
+                var redirectDestination = redirect[1];
+                cy.testFaqRedirect(lang, redirectSource, redirectDestination);
+            });
         });
     });
 


### PR DESCRIPTION
This PR refactors the Cypress test [cypress/integration/app_to_web.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/integration/app_to_web.js) section which checks FAQ redirects. The source data of the redirect source and destination anchors stored in [appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json) is restructured for readability.

In the original submission of this data the relationship between redirect source and destination was displayed by keeping the data pair on one line. Unfortunately if the json file is reformatted using standard editor tools, then this relationship is lost. This affects readability only, not functionality.

To make sure that the redirect data is still readable after editor reformatting, the `faqRedirect` section in [appToWebLinks.json](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/fixtures/appToWebLinks.json) is converted to an array of arrays and the Cypress test code is changed accordingly. Now the relationship is clear again, for instance in the example below, the test checks that `#hc_prefix_invalid` redirects to `#eu_dcc`. Source and destination are grouped together in one array with source followed by destination anchor. The brackets `[ ]` around this pair separate it from other pairs.
```
        [
            "#hc_prefix_invalid",
            "#eu_dcc"
        ],
```