### PR TITLE
Update build workflow actions to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Setup Node.js environment (v16)
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 'lts/gallium'
 


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3160 "Build workflow shows deprecation notice" by updating 

[.github/workflows/build.yml](https://github.com/corona-warn-app/cwa-website/blob/master/.github/workflows/build.yml):

- `actions/checkout@v2` to `v3`
- `actions/setup-node@v2` to `v3`

--
Internal Tracking ID: [EXPOSUREAPP-14216](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14216)
