### PR TITLE
Modify .gitignore for Cypress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,14 +114,14 @@ public
 .pnp.*
 
 # cypress
+cypress/downloads/
 cypress/screenshots/
 cypress/videos/
+
 src/pages/de/science/**
 src/pages/en/science/**
 !src/pages/de/science/index.html
 !src/pages/en/science/index.html
-cypress/logs/broken_anchor_links_result.txt
-cypress/logs/broken_links_result.txt
 
 # analyse data backup
 src/data/analyse-backup.json


### PR DESCRIPTION
This PR cleans up `.gitignore` entries affected by Cypress and resolves issue https://github.com/corona-warn-app/cwa-website/issues/3166 "Cypress entries in .gitignore".

It makes the following changes to [.gitignore](https://github.com/corona-warn-app/cwa-website/blob/master/.gitignore):

- Add `cypress/downloads/` 
- Remove `cypress/logs/broken_anchor_links_result.txt` and `cypress/logs/broken_links_result.txt`

## Verification

Execute `npm test`

Execute `git status` and ensure that no new temporary files are marked.

View local repository with VS Code and check that the directories:

- `cypress/downloads`
- `cypress/logs`

are greyed out (to indicate that they are ignored by git)


---
Internal Tracking ID: [EXPOSUREAPP-14225](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14225)
