### PR TITLE
Update reference to Node.js 16 (Maintenance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the source files of the official website for the Corona
 
 ### Requirements
 
-You need the Node.js 16 Active LTS version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website.
+You need the Node.js 16 (Maintenance) LTS version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website. Download from [latest node v16 version](https://nodejs.org/download/release/latest-v16.x/).  
 
 ### Getting started
 


### PR DESCRIPTION
This PR updates the reference to Node.js 16 in the [README.md: Requirements](https://github.com/corona-warn-app/cwa-website/blob/master/README.md#requirements) file section.

According to https://github.com/nodejs/release#release-schedule Node.js 16 is now in Maintenance status instead of the previous Active status. The download link for v16 is no longer on the main page, so the appropriate link to the download page for the latest node v16 version is added.

Node.js 18.x now becomes the Active LTS version (see https://nodejs.org/en/blog/release/v18.12.0/ from Oct 25, 2022).

Note that the GitHub Ubuntu runners, including [`ubuntu-latest` or `ubuntu-20.04`](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md) are currently still using node 16 (16.18.0) at this time. Node.js 18.x may become relevant for the cwa-website at a later date. (Node 18 requires an update of [webpack](https://www.npmjs.com/package/webpack) to v5.)
