### PR TITLE
Bump current Android app version

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -518,7 +518,7 @@ function replaceVersionNumbers() {
     .pipe(replace('[ios.current-app-version]', '2.28.0'))
     .pipe(replace('[android.latest-os-version]', '13'))
     .pipe(replace('[android.minimum-required-os-version]', '6'))
-    .pipe(replace('[android.current-app-version]', '2.28.2'))
+    .pipe(replace('[android.current-app-version]', '2.28.3'))
     .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist));
 }


### PR DESCRIPTION
This PR bumps the current Android app version from 2.28.2 to 2.28.3.

---

GitHub release: https://github.com/corona-warn-app/cwa-app-android/releases/tag/v2.28.3