### PR TITLE
Migrate cwa-website to Node.js 18 (Active LTS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v3
     
-    - name: Setup Node.js environment (v16)
+    - name: Setup Node.js 18 environment
       uses: actions/setup-node@v3
       with:
-        node-version: 'lts/gallium'
+        node-version: 'lts/hydrogen'
 
     - name: Install root dependencies
       uses: bahmutov/npm-install@v1

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -27,10 +27,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      - name: Setup Node.js environment (v16)
+      - name: Setup Node.js 18 environment
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/gallium'
+          node-version: 'lts/hydrogen'
 
       - name: npm install
         run: npm install

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the source files of the official website for the Corona
 
 ### Requirements
 
-You need the Node.js 16 (Maintenance) LTS version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website. Download from [latest node v16 version](https://nodejs.org/download/release/latest-v16.x/).  
+You need the Node.js 18 (Active LTS) version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website.
 
 ### Getting started
 


### PR DESCRIPTION
- This PR replaces PR https://github.com/corona-warn-app/cwa-website/pull/3187
- It implements the suggestion from https://github.com/corona-warn-app/cwa-website/issues/3186.

The web builds on GitHub using Node.js 18. Locally the web can still be built without errors on Node.js 16, although users should preferably also migrate to using Node.js 18 locally to avoid future issues.

The following changes are made:

1. Workflow: change `node-version:` from `'lts/gallium'` to `'lts/hydrogen'`
2. Update [README: Requirements](https://github.com/corona-warn-app/cwa-website/blob/master/README.md#requirements) to refer to Node.js 18

---
Internal Tracking ID: [EXPOSUREAPP-14247](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14247)
