### PR TITLE
Fix experimental json import in gulpfile.mjs

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -32,7 +32,13 @@ const pluginSass = gulpSass(npmSass);
 
 import { processBlogFiles, getBlogEntries } from './src/services/blog-processor.js';
 import { processScienceBlogFiles } from './src/services/science-blog-processor.js';
-import analyseConfig from './src/data/analyse.json' assert {type: 'json'};
+
+// import assertions are still experimental, so do not use the following:
+// import analyseConfig from './src/data/analyse.json' assert {type: 'json'};
+// instead:
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const analyseConfig = require('./src/data/analyse.json');
 
 // Check for --develop or --dev flag
 const PRODUCTION = !(yargs.argv.develop || yargs.argv.dev);


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3194 "Experimental json import warning from build"

It changes the method used to import a `json` file in an ESM environment from using an experimental feature to using a supported `Node.js` feature.

Adding the lines:

```js
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
```

before the original code from the CommonJS environment:

```js
const analyseConfig = require('./src/data/analyse.json');
```

resolves the issue.

## Verification

`npm run build` should run successfully and it should not output the following message:
`(node:21804) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time`
