### PR TITLE
Uninstall unneeded gulp plugins (gulp-load-plugins and gulp-uglify)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "gulp-if": "^3.0.0",
         "gulp-imagemin": "^8.0.0",
         "gulp-json-transform": "^0.4.8",
-        "gulp-load-plugins": "^2.0.8",
         "gulp-postcss": "^9.0.1",
         "gulp-rename": "^2.0.0",
         "gulp-sass": "^5.1.0",
@@ -6101,20 +6100,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/findup-sync": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
-      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
-      "dependencies": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.4",
-        "resolve-dir": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/fined": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
@@ -7500,64 +7485,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/gulp-load-plugins": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-2.0.8.tgz",
-      "integrity": "sha512-BS0aRx67WnWPt8stEDvwt+biD2gQ1NwDMgxuUhX5+AQSujqlcSecbdL+U6g0zu2S3YjOuY+eGmnXjT2J3hRMIg==",
-      "dependencies": {
-        "array-unique": "^0.3.2",
-        "fancy-log": "^2.0.0",
-        "findup-sync": "^5.0.0",
-        "gulplog": "^2.0.0",
-        "has-gulplog": "^1.0.0",
-        "micromatch": "^4.0.2",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gulp-load-plugins/node_modules/fancy-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-2.0.0.tgz",
-      "integrity": "sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==",
-      "dependencies": {
-        "color-support": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gulp-load-plugins/node_modules/glogg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-2.0.0.tgz",
-      "integrity": "sha512-YDtL/QX54MN8+GorvS9tnKI5HtqWrFW9bv5yPRmFBeofi5neWzqQN8X/0HmM5zMkDbB8OYvC3/Pj8UEJUZFeqA==",
-      "dependencies": {
-        "sparkles": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/gulp-load-plugins/node_modules/gulplog": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-2.0.1.tgz",
-      "integrity": "sha512-11IFA5ZwhFUjXPNYxrk9Z5FWGQIzJzxrBCE4qZC2elFkwt6oamM1ESwZVrhFMLl5IVlhnMwleFEWxiEyuMndIg==",
-      "dependencies": {
-        "glogg": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/gulp-load-plugins/node_modules/sparkles": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-2.0.0.tgz",
-      "integrity": "sha512-rqUsosNTLY8KIT6qhuJlXzIUjYJNHTDoHmPnJwfnD7bEvSSvhUOMKuPMCsmLR3vDhyTGi0oAqAbLjgiIXnL2wQ==",
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/gulp-match": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.1.0.tgz",
@@ -7763,25 +7690,6 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/has-gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-1.0.0.tgz",
-      "integrity": "sha512-3bRkTBls3EdDU9Aw9VyMjSeIfPTGZO9C/eDEr7wdnu9fP0I2Mli8eQlo+oN57Oog8rpByXFZeNXNs+pQwJF6ow==",
-      "dependencies": {
-        "sparkles": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/has-gulplog/node_modules/sparkles": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-2.0.0.tgz",
-      "integrity": "sha512-rqUsosNTLY8KIT6qhuJlXzIUjYJNHTDoHmPnJwfnD7bEvSSvhUOMKuPMCsmLR3vDhyTGi0oAqAbLjgiIXnL2wQ==",
-      "engines": {
-        "node": ">= 10.13.0"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -20079,17 +19987,6 @@
         "semver-regex": "^2.0.0"
       }
     },
-    "findup-sync": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
-      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
-      "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.4",
-        "resolve-dir": "^1.0.1"
-      }
-    },
     "fined": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
@@ -21159,51 +21056,6 @@
         }
       }
     },
-    "gulp-load-plugins": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-2.0.8.tgz",
-      "integrity": "sha512-BS0aRx67WnWPt8stEDvwt+biD2gQ1NwDMgxuUhX5+AQSujqlcSecbdL+U6g0zu2S3YjOuY+eGmnXjT2J3hRMIg==",
-      "requires": {
-        "array-unique": "^0.3.2",
-        "fancy-log": "^2.0.0",
-        "findup-sync": "^5.0.0",
-        "gulplog": "^2.0.0",
-        "has-gulplog": "^1.0.0",
-        "micromatch": "^4.0.2",
-        "resolve": "^1.17.0"
-      },
-      "dependencies": {
-        "fancy-log": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-2.0.0.tgz",
-          "integrity": "sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==",
-          "requires": {
-            "color-support": "^1.1.3"
-          }
-        },
-        "glogg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glogg/-/glogg-2.0.0.tgz",
-          "integrity": "sha512-YDtL/QX54MN8+GorvS9tnKI5HtqWrFW9bv5yPRmFBeofi5neWzqQN8X/0HmM5zMkDbB8OYvC3/Pj8UEJUZFeqA==",
-          "requires": {
-            "sparkles": "^2.0.0"
-          }
-        },
-        "gulplog": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-2.0.1.tgz",
-          "integrity": "sha512-11IFA5ZwhFUjXPNYxrk9Z5FWGQIzJzxrBCE4qZC2elFkwt6oamM1ESwZVrhFMLl5IVlhnMwleFEWxiEyuMndIg==",
-          "requires": {
-            "glogg": "^2.0.0"
-          }
-        },
-        "sparkles": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-2.0.0.tgz",
-          "integrity": "sha512-rqUsosNTLY8KIT6qhuJlXzIUjYJNHTDoHmPnJwfnD7bEvSSvhUOMKuPMCsmLR3vDhyTGi0oAqAbLjgiIXnL2wQ=="
-        }
-      }
-    },
     "gulp-match": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.1.0.tgz",
@@ -21361,21 +21213,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-    },
-    "has-gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-1.0.0.tgz",
-      "integrity": "sha512-3bRkTBls3EdDU9Aw9VyMjSeIfPTGZO9C/eDEr7wdnu9fP0I2Mli8eQlo+oN57Oog8rpByXFZeNXNs+pQwJF6ow==",
-      "requires": {
-        "sparkles": "^2.0.0"
-      },
-      "dependencies": {
-        "sparkles": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-2.0.0.tgz",
-          "integrity": "sha512-rqUsosNTLY8KIT6qhuJlXzIUjYJNHTDoHmPnJwfnD7bEvSSvhUOMKuPMCsmLR3vDhyTGi0oAqAbLjgiIXnL2wQ=="
-        }
-      }
     },
     "has-property-descriptors": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "gulp-sass": "^5.1.0",
         "gulp-sitemap": "^8.0.0",
         "gulp-sourcemaps": "^3.0.0",
-        "gulp-uglify": "^3.0.2",
         "gulp-webp": "^4.0.1",
         "jquery": "^3.6.1",
         "js-yaml": "^3.14.1",
@@ -7672,43 +7671,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/gulp-uglify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",
-      "integrity": "sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==",
-      "dependencies": {
-        "array-each": "^1.0.1",
-        "extend-shallow": "^3.0.2",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "isobject": "^3.0.1",
-        "make-error-cause": "^1.1.1",
-        "safe-buffer": "^5.1.2",
-        "through2": "^2.0.0",
-        "uglify-js": "^3.0.5",
-        "vinyl-sourcemaps-apply": "^0.2.0"
-      }
-    },
-    "node_modules/gulp-uglify/node_modules/has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha512-+F4GzLjwHNNDEAJW2DC1xXfEoPkRDmUdJ7CBYw4MpqtDwOnqdImJl7GWlpqx+Wko6//J8uKTnIe4wZSv7yCqmw==",
-      "dependencies": {
-        "sparkles": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/gulp-uglify/node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
     "node_modules/gulp-webp": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gulp-webp/-/gulp-webp-4.0.1.tgz",
@@ -9990,19 +9952,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
-    "node_modules/make-error-cause": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
-      "integrity": "sha512-4TO2Y3HkBnis4c0dxhAgD/jprySYLACf7nwN6V0HAHDx59g12WlRpUmFy1bRHamjGUEEBrEvCq6SUpsEE2lhUg==",
-      "dependencies": {
-        "make-error": "^1.2.0"
       }
     },
     "node_modules/make-iterator": {
@@ -14706,6 +14655,7 @@
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -21348,42 +21298,6 @@
         }
       }
     },
-    "gulp-uglify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",
-      "integrity": "sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==",
-      "requires": {
-        "array-each": "^1.0.1",
-        "extend-shallow": "^3.0.2",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "isobject": "^3.0.1",
-        "make-error-cause": "^1.1.1",
-        "safe-buffer": "^5.1.2",
-        "through2": "^2.0.0",
-        "uglify-js": "^3.0.5",
-        "vinyl-sourcemaps-apply": "^0.2.0"
-      },
-      "dependencies": {
-        "has-gulplog": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-          "integrity": "sha512-+F4GzLjwHNNDEAJW2DC1xXfEoPkRDmUdJ7CBYw4MpqtDwOnqdImJl7GWlpqx+Wko6//J8uKTnIe4wZSv7yCqmw==",
-          "requires": {
-            "sparkles": "^1.0.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
-    },
     "gulp-webp": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gulp-webp/-/gulp-webp-4.0.1.tgz",
@@ -23074,19 +22988,6 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "requires": {
         "semver": "^6.0.0"
-      }
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
-    "make-error-cause": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
-      "integrity": "sha512-4TO2Y3HkBnis4c0dxhAgD/jprySYLACf7nwN6V0HAHDx59g12WlRpUmFy1bRHamjGUEEBrEvCq6SUpsEE2lhUg==",
-      "requires": {
-        "make-error": "^1.2.0"
       }
     },
     "make-iterator": {
@@ -26650,7 +26551,8 @@
     "uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g=="
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "optional": true
     },
     "uint8-to-base64": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "gulp-if": "^3.0.0",
     "gulp-imagemin": "^8.0.0",
     "gulp-json-transform": "^0.4.8",
-    "gulp-load-plugins": "^2.0.8",
     "gulp-postcss": "^9.0.1",
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "gulp-sass": "^5.1.0",
     "gulp-sitemap": "^8.0.0",
     "gulp-sourcemaps": "^3.0.0",
-    "gulp-uglify": "^3.0.2",
     "gulp-webp": "^4.0.1",
     "jquery": "^3.6.1",
     "js-yaml": "^3.14.1",


### PR DESCRIPTION
This PR uninstalls gulp plugins which are not used, as described in issues:

- https://github.com/corona-warn-app/cwa-website/issues/3192
- https://github.com/corona-warn-app/cwa-website/issues/3193

## Verification

After syncing the installed npm packages with `npm ci` then

`npm run build` and
`npm test`

should show no errors.

---
---
Internal Tracking ID: [EXPOSUREAPP-14268](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14268)
