### PR TITLE
Correct Cypress message formatting for softAssert in headless mode

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -81,9 +81,9 @@ function itCallback ( func ) {
                 msg = 'Failed soft assertions... check log above ↑';
             } else {
                 _.each( errors, error => {
-                    msg += 'n' + error;
+                    msg += '\n' + error;
                 });
-                msg = msg.replace(/^/gm, 't');
+                msg = msg.replace(/^/gm, '\t');
             }
             throw new Error(msg);
         }


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3200 "Bad formatting in Cypress soft assertions headless error messages"

It corrects the tab and new line formatting characters in [cypress/support/e2e.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/support/e2e.js) used in headless mode.

## Verification

Temporarily edit `src/data/faq.json` and introduce several errors such as removing `target='_blank'` from two links.

In one terminal execute
`npm start`

Once the localhost website is shown in a browser open a second terminal and execute
`npx cypress run -s 'cypress/e2e/faq_link_attr.cy.js'`

Check that the error message looks correctly formatted with each error starting on a separate line such as:

```
  1 failing

  1) Check attributes of FAQ links
       Check links are using _blank to open in new frame
         Test links for _blank presence:
     Error:
        AssertionError: http://localhost:8000/en/faq/results/#risk_encounter_no_warning in /en/faq/results/: expected '<a>' to have attribute 'target'
        AssertionError: http://localhost:8000/en/faq/results/#risk_encounter_different_devices in /en/faq/results/: expected '<a>' to have attribute 'target'
      at Context.eval (webpack:///./cypress/support/e2e.js:88:18)

```

---
Internal Tracking ID: [EXPOSUREAPP-14291](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14291)