### PR TITLE
Update README.md: Include Rosetta requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This repository contains the source files of the official website for the Corona
 
 You need the Node.js 18 (Active LTS) version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website.
 
+In case you use a Mac computer with Apple Silicon, make sure that [Rosetta](https://support.apple.com/en-us/HT211861) is installed. 
+
 ### Getting started
 
 Clone the repository and ensure you have the requirements (from above) installed. To build and display the website in a web browser, switch to the `cwa-website` base directory and execute the commands:


### PR DESCRIPTION
As discovered in #3202, Rosetta is required to be installed in order to build this project on Apple Silicon Mac computers. With this PR, the requirements for development in the [README.md](https://github.com/corona-warn-app/cwa-website/blob/master/README.md) have been extended accordingly. 

---
Internal Tracking ID: [EXPOSUREAPP-14298](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14298)