### PR TITLE
Fix img width attribute in 2.18 blog

### DIFF
--- a/blog/2022-02-23-cwa-2-18/index.md
+++ b/blog/2022-02-23-cwa-2-18/index.md
@@ -15,7 +15,7 @@ The project team consisting of the Robert Koch Institute, Deutsche Telekom and S
 
 <div class="right-float">
 <figure>
-<img src="./iPhone 13-screenshot_2g_plus_certificate_overview.png" alt="2G+ status display in the CWA" style="align: center" width=250px><figcaption aria-hidden="true"><em>Fig. 1: 2G+ status display in the CWA</em></figcaption>
+<img src="./iPhone 13-screenshot_2g_plus_certificate_overview.png" alt="2G+ status display in the CWA" style="align: center" width=250><figcaption aria-hidden="true"><em>Fig. 1: 2G+ status display in the CWA</em></figcaption>
 </figure>
 </div>
 
@@ -50,7 +50,7 @@ Questions about the current status are answered in our [FAQ](../../faq/#admissio
     <div class="row">
         <div class="col-md-6">
             <figure>
-                <img src="./booster_note.png" title="Note on Booster Vaccination" alt="Note on Booster Vaccination" style="align: center" width=250px>
+                <img src="./booster_note.png" title="Note on Booster Vaccination" alt="Note on Booster Vaccination" style="align: center" width=250>
                 <figcaption aria-hidden="true">
                     <em>Fig. 2: Note on Booster Vaccination</em>
                 </figcaption>
@@ -58,7 +58,7 @@ Questions about the current status are answered in our [FAQ](../../faq/#admissio
         </div>
         <div class="col-md-6">
             <figure>
-                <img src="./booster_note_detail.png" title="Note on Booster Vaccination detail view" alt="Note on Booster Vaccination detail view"style="align: center" width=250px>
+                <img src="./booster_note_detail.png" title="Note on Booster Vaccination detail view" alt="Note on Booster Vaccination detail view"style="align: center" width=250>
                 <figcaption aria-hidden="true">
                     <em>Fig. 3: Note on Booster Vaccination detail view</em>
                 </figcaption>

--- a/blog/2022-02-23-cwa-2-18/index_de.md
+++ b/blog/2022-02-23-cwa-2-18/index_de.md
@@ -15,7 +15,7 @@ Das Projektteam aus Robert Koch-Institut, Deutscher Telekom und SAP hat Version 
 
 <div class="right-float">
 <figure>
-<img src="./iPhone 13-screenshot_2g_plus_certificate_overview_de.png" alt="2G+-Status-Anzeige in der CWA" style="align: center" width=250px><figcaption aria-hidden="true"><em>Abb. 1: 2G+-Status-Anzeige in der CWA</em></figcaption>
+<img src="./iPhone 13-screenshot_2g_plus_certificate_overview_de.png" alt="2G+-Status-Anzeige in der CWA" style="align: center" width=250><figcaption aria-hidden="true"><em>Abb. 1: 2G+-Status-Anzeige in der CWA</em></figcaption>
 </figure>
 </div>
 
@@ -50,7 +50,7 @@ Fragen zum aktuellen Status beantworten wir in unseren [FAQ](../../faq/#admissio
     <div class="row">
         <div class="col-md-6">
             <figure>
-                <img src="./booster_note_de.png" title="Hinweis zur Auffrischimpfung" alt="Hinweis zur Auffrischimpfung" style="align: center" width=250px>
+                <img src="./booster_note_de.png" title="Hinweis zur Auffrischimpfung" alt="Hinweis zur Auffrischimpfung" style="align: center" width=250>
                 <figcaption aria-hidden="true">
                     <em>Abb. 2: Hinweis zur Auffrischimpfung</em>
                 </figcaption>
@@ -58,7 +58,7 @@ Fragen zum aktuellen Status beantworten wir in unseren [FAQ](../../faq/#admissio
         </div>
         <div class="col-md-6">
             <figure>
-                <img src="./booster_note_detail_de.png" title="Detailansicht des Hinweises zur Auffrischimpfung" alt="Detailansicht des Hinweises zur Auffrischimpfung"style="align: center" width=250px>
+                <img src="./booster_note_detail_de.png" title="Detailansicht des Hinweises zur Auffrischimpfung" alt="Detailansicht des Hinweises zur Auffrischimpfung"style="align: center" width=250>
                 <figcaption aria-hidden="true">
                     <em>Abb. 3: Detailansicht des Hinweises zur Auffrischimpfung</em>
                 </figcaption>


### PR DESCRIPTION
This PR resolves an HTML-compliance issue in:

- https://www.coronawarn.app/en/blog/2022-02-23-cwa-2-18/ and
- https://www.coronawarn.app/de/blog/2022-02-23-cwa-2-18/

`px` is removed from `width` attributes in `img` tags. Pixel as unit is implied and must not be explicitly specified.

## Reference

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-width

"width
The intrinsic width of the image in pixels. Must be an integer without a unit."
