### PR TITLE
Correct copyright footer closing div

### DIFF
--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -54,7 +54,7 @@
         {{#if language.copyright}}
         <a href="{{language.copyright.url}}"{{#if language.copyright.external}} target="_blank" rel="noopener noreferrer"{{/if}}>{{language.copyright.title}}</a>
         {{/if}}
-        <div/>
+      </div>
       <div class="privacy text-center text-sm-right">
         {{#if language.privacy}}
         <a href="{{language.privacy.url}}"{{#if language.privacy.external}} target="_blank" rel="noopener noreferrer"{{/if}}>{{language.privacy.title}}</a>


### PR DESCRIPTION
- This PR resolves the issue https://github.com/corona-warn-app/cwa-website/issues/3223 "Incorrect copyright Division in footer".

- It changes the copyright division closing tag to `</div>` in https://github.com/corona-warn-app/cwa-website/blob/master/src/partials/footer.html.

- The incorrect tag was introduced by https://github.com/corona-warn-app/cwa-website/pull/2644

## Verification

Run https://validator.w3.org on https://www.coronawarn.app/en/ and the following errors should no longer produced:

- "Self-closing syntax (/>) used on a non-void HTML element"
- "End tag footer seen, but there were open elements"
- "Unclosed element div"