### PR TITLE
Update `.browserslistrc`

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,5 @@
 # Browsers that we support
 last 2 versions
-ie >= 9
-ios >= 7
-android >= 4.4
+ie >= 11
+ios >= 12
+android >= 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -3723,9 +3723,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001426",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
-      "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
+      "version": "1.0.30001434",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
+      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -18135,9 +18135,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001426",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
-      "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A=="
+      "version": "1.0.30001434",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
+      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA=="
     },
     "canvg": {
       "version": "3.0.10",


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3247 "Outdated `.browserslistrc` with the following changes":

1. The database is updated with<br>npx browserslist@latest --update-db

2. The browser list [.browserslistrc](https://github.com/corona-warn-app/cwa-website/blob/master/.browserslistrc) is changed:

   -  Internet Explorer to 11
   -  iOS to 12 to match the minimum CWA version
   -  Android to 5 since this is the minimum that the Google Exposure Notifications API supports (see https://developers.google.com/android/exposure-notifications/exposure-notifications-api)

## Verification

Execute `npx browserslist` and expect the following list:

```
and_chr 107
and_ff 106
and_qq 13.1
and_uc 13.4
android 107
baidu 13.18
bb 10
bb 7
chrome 107
chrome 106
edge 107
edge 106
firefox 107
firefox 106
ie 11
ie 10
ie_mob 11
ie_mob 10
ios_saf 16.1
ios_saf 16.0
ios_saf 15.6
ios_saf 15.5
ios_saf 15.4
ios_saf 15.2-15.3
ios_saf 15.0-15.1
ios_saf 14.5-14.8
ios_saf 14.0-14.4
ios_saf 13.4-13.7
ios_saf 13.3
ios_saf 13.2
ios_saf 13.0-13.1
ios_saf 12.2-12.5
ios_saf 12.0-12.1
kaios 2.5
op_mini all
op_mob 72
op_mob 12.1
opera 92
opera 91
safari 16.1
safari 16.0
samsung 19.0
samsung 18.0
```
