### PR TITLE
Removed outdated and duplicated FAQ #multiple_exposure_checks (DE)

### DIFF
--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -3041,14 +3041,6 @@
                                 ]
                             },
                             {
-                                "title": "Meine Begegnungsüberprüfung zeigt mehrere zeitgleiche Einträge. Ist das ein Fehler?",
-                                "anchor": "multiple_exposure_checks",
-                                "active": false,
-                                "textblock": [
-                                    "Sobald die App die aktuellen Diagnoseschlüssel vom Server lädt, wird eine Überprüfung der Begegnungsaufzeichnungen durchgeführt. Dabei wird für jeden der letzte 14 Tage (10 Tage ab Version 2.20), für den Diagnoseschlüssel vorhanden sind, eine separate Überprüfung der Begegnungsaufzeichnungen durchgeführt. Es ist also daher kein Fehler, dass pro Tag mehrere Einträge in der Überprüfungs-Historie vorhanden sind. Sie können zudem auf die Überprüfungseinträge klicken und sehen, dass immer unterschiedlich viele Schlüssel geprüft werden."
-                                ]
-                            },
-                            {
                                 "title": "In den Begegnungsüberprüfungen sind die Aufzeichnungen von weniger als 14 Tagen gespeichert",
                                 "anchor": "exposure_check",
                                 "active": false,


### PR DESCRIPTION
This PR resolves the issue https://github.com/corona-warn-app/cwa-website/issues/3249 "Duplicated FAQ article #multiple_exposure_checks (DE)"

The out of date article #multiple_exposure_checks is deleted from the section https://www.coronawarn.app/de/faq/results/#risk_assessment "Technische Zusammen­hänge / Risiko-Ermittlung" where it is misplaced and missing the updated information.

## Verification

Open https://www.coronawarn.app/de/faq/results/ and search for the term "zeitgleiche Einträge"

Only one article should appear and this should be in the section https://www.coronawarn.app/de/faq/results/#resolved "Support / Geklärt".

Open the article https://www.coronawarn.app/de/faq/results/#multiple_exposure_checks and check that it contains the text "AKTUELL
Seit Version 1.6.0 der Corona-Warn-App ..."
