### PR TITLE
Center the FAQ lists

### DIFF
--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -30,7 +30,7 @@
       <h1 class="headline headline-heavy mt-5 mb-3">{{page-contents.section-main.headline.subtitle}}</h1>
       <div class="row d-flex justify-content-center text-left pb-5 pt-5">
         {{#each page-contents.section-main.topics}}
-        <div class="col-lg-2 col-sm-6 col-md-3 col-xs-6">
+        <div class="pl-5 col-lg-2 col-sm-6 col-md-3 col-xs-6">
           <img src="{{icon}}" alt="{{title}}" height="29">
           <p><a href="results/?search=&topic={{id}}" class="no-decoration text-black"><b>{{{title}}}</b></a></p>
           <div class="{{#if sections.[6]}}section-column{{/if}}">

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -1,7 +1,7 @@
 {{#if page-contents}}
-  <main class="main">
+  <main class="main text-center">
     <div class="container-fluid pt-5 pb-5">
-      <h1 class="headline headline-heavy text-center pb-3" id="top">{{page-contents.section-main.headline.title}}</h1>
+      <h1 class="headline headline-heavy pb-3" id="top">{{page-contents.section-main.headline.title}}</h1>
       <div class="d-flex justify-content-center">
         <form method="get" id="faq-search-form" class="container">
           <div class="mb-2 row justify-content-center">
@@ -23,12 +23,12 @@
           </div>
         </form>
       </div>
-      <center><a href="results" class="no-decoration">{{page-contents.section-main.texts.view-all-topics-questions}}</a></center>
+      <a href="results" class="no-decoration">{{page-contents.section-main.texts.view-all-topics-questions}}</a>
     </div>
 
     <div class="container">
       <h1 class="headline headline-heavy mt-5 mb-3">{{page-contents.section-main.headline.subtitle}}</h1>
-      <div class="row pb-5 pt-5">
+      <div class="row d-flex justify-content-center text-left pb-5 pt-5">
         {{#each page-contents.section-main.topics}}
         <div class="col-lg-2 col-sm-6 col-md-3 col-xs-6">
           <img src="{{icon}}" alt="{{title}}" height="29">


### PR DESCRIPTION
This PR resolves the enhancement request https://github.com/corona-warn-app/cwa-website/issues/3246 "FAQ Sections is not centered".

The lower section of https://www.coronawarn.app/en/faq/ is now centered so that it has a consistent look independently of the available browser width.

## Old
---
Previously
![image](https://user-images.githubusercontent.com/12231155/204078797-4994bbc1-b610-4e60-86b8-a058d8b410dd.png)

## New
---
Desktop wide
![FAQ wide](https://user-images.githubusercontent.com/66998419/204272894-8cd86a9e-ad72-4054-8509-1a70139c0cbc.jpg)

---
Desktop narrow
![FAQ narrow](https://user-images.githubusercontent.com/66998419/204272919-1fe00f25-226e-46ad-819a-be2e8ee6ea75.jpg)

---
Mobile
![FAQ mobile](https://user-images.githubusercontent.com/66998419/204272945-6fc143f9-a7eb-434c-84c4-ec62ff34772f.jpg)

