### PR TITLE
Replace child main in faq by div section

### DIFF
--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -1,5 +1,5 @@
 {{#if page-contents}}
-  <main class="main text-center">
+  <div class="text-center">
     <div class="container-fluid pt-5 pb-5">
       <h1 class="headline headline-heavy pb-3" id="top">{{page-contents.section-main.headline.title}}</h1>
       <div class="d-flex justify-content-center">
@@ -46,6 +46,6 @@
       </div>
       <p class="pb-5 text-center"><a href="results/?search=&topic=glossary" class="glossary-link">{{page-contents.section-main.texts.glossary}}</a></p>
     </div>
-  </main>
+  
 </div>
 {{/if}}

--- a/src/partials/page-faq.html
+++ b/src/partials/page-faq.html
@@ -1,51 +1,59 @@
 {{#if page-contents}}
-  <div class="text-center">
-    <div class="container-fluid pt-5 pb-5">
-      <h1 class="headline headline-heavy pb-3" id="top">{{page-contents.section-main.headline.title}}</h1>
-      <div class="d-flex justify-content-center">
-        <form method="get" id="faq-search-form" class="container">
-          <div class="mb-2 row justify-content-center">
-            <div id="clean_search" class="col-12 col-lg-4 mb-2 px-2">
-              <input type="text" class="form-control searchbar-clean-padding" placeholder="{{page-contents.section-main.texts.search-placeholder}}" id="faq-search" name="search">
-            </div>
-            <div class="col-12 col-lg-3 mb-2 px-2">
-              <select class="form-select" id="faq-topic" name="topic">
-                <option value="all" selected>{{page-contents.section-main.texts.all-topics}}</option>
-                {{#each page-contents.section-main.topics}}
-                  <option value="{{id}}">{{{title}}}</option>
-                {{/each}}
-                <option value="glossary">{{page-contents.section-main.texts.glossary}}</option>
-              </select>
-            </div>  
-            <div class="mb-2 col-12 col-lg-2 px-2">
-              <button id="faq-submit" value="search" class="btn btn-primary col-12">{{page-contents.section-main.texts.search-button}}</button>
-            </div>
+<div class="text-center">
+  <div class="container-fluid pt-5 pb-5">
+    <h1 class="headline headline-heavy pb-3" id="top">{{page-contents.section-main.headline.title}}</h1>
+    <div class="d-flex justify-content-center">
+      <form method="get" id="faq-search-form" class="container">
+        <div class="mb-2 row justify-content-center">
+          <div id="clean_search" class="col-12 col-lg-4 mb-2 px-2">
+            <input type="text" class="form-control searchbar-clean-padding"
+              placeholder="{{page-contents.section-main.texts.search-placeholder}}" id="faq-search" name="search">
           </div>
-        </form>
-      </div>
-      <a href="results" class="no-decoration">{{page-contents.section-main.texts.view-all-topics-questions}}</a>
-    </div>
-
-    <div class="container">
-      <h1 class="headline headline-heavy mt-5 mb-3">{{page-contents.section-main.headline.subtitle}}</h1>
-      <div class="row d-flex justify-content-center text-left pb-5 pt-5">
-        {{#each page-contents.section-main.topics}}
-        <div class="pl-5 col-lg-2 col-sm-6 col-md-3 col-xs-6">
-          <img src="{{icon}}" alt="{{title}}" height="29">
-          <p><a href="results/?search=&topic={{id}}" class="no-decoration text-black"><b>{{{title}}}</b></a></p>
-          <div class="{{#if sections.[6]}}section-column{{/if}}">
-            {{#each sections}}
-            {{#if indexed}}
-              <p><a href="results/#{{id}}" class="section-link">{{{title}}}</a></p>
-            {{/if}}
-          {{/each}}
+          <div class="col-12 col-lg-3 mb-2 px-2">
+            <select class="form-select" id="faq-topic" name="topic">
+              <option value="all" selected>{{page-contents.section-main.texts.all-topics}}</option>
+              {{#each page-contents.section-main.topics}}
+              <option value="{{id}}">{{{title}}}</option>
+              {{/each}}
+              <option value="glossary">{{page-contents.section-main.texts.glossary}}</option>
+            </select>
           </div>
-          <p><a href="results/?search=&topic={{id}}" class="no-decoration">{{#if sections.[6]}}{{../page-contents.section-main.texts.view-all-topics-questions}}{{else}}{{../page-contents.section-main.texts.goto-topics}}{{/if}}</a></p>
+          <div class="mb-2 col-12 col-lg-2 px-2">
+            <button id="faq-submit" value="search"
+              class="btn btn-primary col-12">{{page-contents.section-main.texts.search-button}}</button>
+          </div>
         </div>
-        {{/each}}
-      </div>
-      <p class="pb-5 text-center"><a href="results/?search=&topic=glossary" class="glossary-link">{{page-contents.section-main.texts.glossary}}</a></p>
+      </form>
     </div>
-  
+    <a href="results" class="no-decoration">{{page-contents.section-main.texts.view-all-topics-questions}}</a>
+  </div>
+
+  <div class="container">
+    <h1 class="headline headline-heavy mt-5 mb-3">{{page-contents.section-main.headline.subtitle}}</h1>
+    <div class="row d-flex justify-content-center text-left pb-5 pt-5">
+      {{#each page-contents.section-main.topics}}
+      <div class="pl-5 col-lg-2 col-sm-6 col-md-3 col-xs-6">
+        <img src="{{icon}}" alt="{{title}}" height="29">
+        <p><a href="results/?search=&topic={{id}}" class="no-decoration text-black"><b>{{{title}}}</b></a></p>
+        <div class="{{#if sections.[6]}}section-column{{/if}}">
+          {{#each sections}}
+          {{#if indexed}}
+          <p><a href="results/#{{id}}" class="section-link">{{{title}}}</a></p>
+          {{/if}}
+          {{/each}}
+        </div>
+        <p><a href="results/?search=&topic={{id}}" class="no-decoration">
+            {{#if sections.[6]}}
+            {{../page-contents.section-main.texts.view-all-topics-questions}}
+            {{else}}
+            {{../page-contents.section-main.texts.goto-topics}}
+            {{/if}}</a>
+        </p>
+      </div>
+      {{/each}}
+    </div>
+    <p class="pb-5 text-center"><a href="results/?search=&topic=glossary"
+        class="glossary-link">{{page-contents.section-main.texts.glossary}}</a></p>
+  </div>
 </div>
 {{/if}}


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3264 "Nested main element in faq".

The child `main` element is converted to a `div` element. At the same time, a stray `</div>` end tag is cleaned up.

Since the indenting was not correct and therefore hard to read, I added a second commit with a combination of automatic and manual reformatting.

View commit https://github.com/corona-warn-app/cwa-website/commit/20abd0b22e048fb5b512f6b80b4f0befb020cec6 to look at the changes which are not caused by reformatting.

## Verification

Run https://validator.w3.org/ on https://www.coronawarn.app/en/faq/ and the following error messages should no longer appear:

- "The main element must not appear as a descendant of the main element."
- "A document must not include more than one visible main element"
- "Stray end tag div."