### PR TITLE
Remove role="main" from layout files

### DIFF
--- a/src/layouts/blog.html
+++ b/src/layouts/blog.html
@@ -25,7 +25,7 @@
     flattened page is created. --}}
 
     {{> header}}
-    <main class="main-content" role="main">
+    <main class="main-content">
       <section>
         <div class="container">
           <div class="container-inner contents-normal">

--- a/src/layouts/default.html
+++ b/src/layouts/default.html
@@ -27,7 +27,7 @@
     <a class="skip-main" href="#main">Skip to main content</a>
     {{> header}} 
 
-    <main id="main" class="main-content" role="main" tabindex="-1">
+    <main id="main" class="main-content" tabindex="-1">
       {{> body}}
     </main>
     {{#unless lang_de}}

--- a/src/layouts/error-pages.html
+++ b/src/layouts/error-pages.html
@@ -20,7 +20,7 @@
     flattened page is created. --}} 
     
     {{> header-for-error-pages}} 
-    <main class="main-content" role="main">
+    <main class="main-content">
     {{> body}}
     </main>
     {{> footer language=global.lang.en}}

--- a/src/layouts/science.html
+++ b/src/layouts/science.html
@@ -45,7 +45,7 @@
     flattened page is created. --}}
 
     {{> header}}
-    <main class="main-content" role="main">
+    <main class="main-content">
       <section>
         <div class="container">
           <div class="container-inner contents-normal">


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3266 "main role (ARIA) not recommended."

The attribute declaration `role="main"` is removed from layout html files in [src/layouts](https://github.com/corona-warn-app/cwa-website/tree/master/src/layouts)

## Verification

Run https://validator.w3.org/ on 

- https://www.coronawarn.app/en/ 
- https://www.coronawarn.app/en/blog/
- https://www.coronawarn.app/en/science/

https://www.coronawarn.app/en/faq/ and ensure that the following warning message does not appear:

"The main role is unnecessary for element main."

Also check:

- https://www.coronawarn.app/en/unknown

and select "Validate error pages" before clicking on "Check".