### PR TITLE
Cypress test remove dependency on cypress-io/github-action

### DIFF
--- a/.github/workflows/cypress-test-prod.yml
+++ b/.github/workflows/cypress-test-prod.yml
@@ -13,15 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NO_COLOR: true
+      TERM: xterm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
+      - name: Setup Node.js 18 environment
+        uses: actions/setup-node@v3
         with:
-          browser: chrome
-          headed: false
-          config: baseUrl=https://coronawarn.app
-          # Only run tests in top level of integration directory
-          spec: cypress/e2e/*.js
+          node-version: 'lts/hydrogen'
+      
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Cypress run
+        run: npx cypress run -s 'cypress/e2e/*.js' -c baseUrl=https://coronawarn.app --e2e --headless --browser chrome 


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-website/issues/3276 "Cypress production test runs with older Node.js 16 version" by removing the dependency of the workflow on the action [cypress-io/github-action@v4](https://github.com/cypress-io/github-action) and replacing it by a direct call of Cypress.

The Cypress call is preceded by a call to [actions/setup-node](https://github.com/actions/setup-node) to install the Node.js `lts/hydrogen` version 18.12.1 and by a call to `npm ci` to install npm dependencies, including Cypress. The environment variable `TERM: xterm` is added to prevent a spurious warning `tput: No value for $TERM and no -T specified` from Cypress running in headless mode.

## Verification

Check the version of Node.js reported by Cypress is as follows:

"Node Version:   v18.12.1 (/opt/hostedtoolcache/node/18.12.1/x64/bin/node)"

and that the Cypress run is successful:

"All specs passed!"