### PR TITLE
Change Cypress baseURL to https://www.coronawarn.app

### DIFF
--- a/.github/workflows/cypress-test-prod.yml
+++ b/.github/workflows/cypress-test-prod.yml
@@ -27,4 +27,4 @@ jobs:
         run: npm ci
 
       - name: Cypress run
-        run: npx cypress run -s 'cypress/e2e/*.js' -c baseUrl=https://coronawarn.app --e2e --headless --browser chrome 
+        run: npx cypress run -s 'cypress/e2e/*.js' -c baseUrl=https://www.coronawarn.app --e2e --headless --browser chrome 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ Best practice is to use `data-e2e="your_test_id"` element attributes to select s
 
 To run all tests included in Cypress Test Production execute:
 
-`npx cypress run -s 'cypress/e2e/*.js' -c baseUrl=https://coronawarn.app --headed` => test results are printed in the console, also you can see browser's movements
+`npx cypress run -s 'cypress/e2e/*.js' -c baseUrl=https://www.coronawarn.app --headed` => test results are printed in the console, also you can see browser's movements
 
-`npx cypress run -s 'cypress/e2e/*.js' -c baseUrl=https://coronawarn.app --headless --browser chrome` => test results are printed in the console, the browser is not displayed
+`npx cypress run -s 'cypress/e2e/*.js' -c baseUrl=https://www.coronawarn.app --headless --browser chrome` => test results are printed in the console, the browser is not displayed
 
 ### Updating coronawarn.app
 

--- a/cypress/e2e/mime.cy.js
+++ b/cypress/e2e/mime.cy.js
@@ -1,8 +1,8 @@
 /// <reference types="Cypress" />
 
-// To run this test on https://coronawarn.app execute the following
+// To run this test on https://www.coronawarn.app execute the following
 // from the root directory of a local copy of cwa-website
-// npx cypress run -s cypress/integration/mime.js -c baseUrl=https://coronawarn.app
+// npx cypress run -s cypress/integration/mime.js -c baseUrl=https://www.coronawarn.app
 
 describe("Test MIME types", () => {
 


### PR DESCRIPTION
This PR implements a workaround proposed in #3071.

When visiting FAQ articles with a non-legacy FAQ-URL in a Cypress test with the baseURL https://coronawarn.app, the second visit times out. If the URL is replaced with https://www.coronawarn.app, it doesn't time out. Steps to reproduce can be found in the aforementioned issue.

---
Internal Tracking ID: [EXPOSUREAPP-14103](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14103)