### PR TITLE
Update FAQ #cause2001: Add hints to restart device & try with mobile data

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2186,6 +2186,8 @@
                                     "Follow these steps in order to activate the security certificate. The exact path depends on the device.",
                                     "<ol><li>'Settings' &gt; 'Biometrics and security' &gt; 'Other security settings' &gt; 'View security certificates' &gt; 'SYSTEM'</li><li>Scroll down to <b>T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2</b></li><li>Enable the certificate using the slider</li></ol>",
                                     "If your network or device is using a firewall, check also that your device can access the domains listed in <a href='#access-list' target='_blank'>[Google/Android]: Firewall/Router configuration: CAUSE: 4000, error during web request, HTTP status 901</a>.",
+                                    "In some cases, it is necessary to restart the device.",
+                                    "If this error occurs when you try to share a positive test result via WLAN, you should try again with mobile data.",
                                     "Should these procedures not solve this issue, please write a comment here:  <a href='https://github.com/corona-warn-app/cwa-app-android/issues/968' target='_blank' rel='noopener noreferrer'>cwa-app-android/issues/968</a>."
                                 ]
                             },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2185,6 +2185,8 @@
                                     "Führen Sie die folgenden Schritte aus, um das Sicherheitszertifikat zu aktivieren. Der genaue Pfad hängt vom Gerät ab.",
                                     "<ol><li>'Einstellungen' &gt; 'Biometrische Daten und Sicherheit' &gt; 'Andere Sicherheitseinstellungen' &gt; 'Sicherheitszertifikate anzeigen' &gt; 'SYSTEM'</li><li>Scrollen Sie nach unten zu <b>T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2</b></li><li>Aktivieren Sie das Zertifikat mit dem Schieberegler</li></ol>",
                                     "Benutzt Ihr Netzwerk bzw. Ihr Gerät ein Firewall, überprüfen Sie die Erreichbarkeit der Domänen, die in <a href='#access-list' target='_blank'>[Google/Android]: Firewall/Router Konfiguration: URSACHE: 4000, error during web request, HTTP status 901</a> aufgelistet sind.",
+                                    "In einigen Fällen ist es notwendig, das Gerät neu zu starten.",
+                                    "Für den Fall, dass dieser Fehler auftritt, wenn Sie versuchen, über WLAN ein positives Test-Ergebnis zu teilen, sollten Sie es mit mobilen Daten erneut versuchen.",
                                     "Sollten diese Schritte das Problem nicht beheben, schreiben Sie bitte einen Kommentar hier: <a href='https://github.com/corona-warn-app/cwa-app-android/issues/968' target='_blank' rel='noopener noreferrer'>cwa-app-android/issues/968</a>."
                                 ]
                             },


### PR DESCRIPTION
This PR adds two more paragraphs to the [#cause2001](http://localhost:8000/en/faq/results/#cause2001) FAQ article. The content was previously suggested in [this issue](https://github.com/corona-warn-app/cwa-website/issues/925). 

![chrome_BicNrIu6nQ](https://user-images.githubusercontent.com/88365935/210204489-63fefb42-c6d2-41cb-8f3c-8bd1b99f095c.png)

![chrome_DKFXCcqkdq](https://user-images.githubusercontent.com/88365935/210204494-4a53c14c-c34e-4eee-94a5-1bae0f18d288.png)

---
Internal Tracking ID: [EXPOSUREAPP-14426](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14426)