### PR TITLE
Update FAQ #update_faq: Link to GitHub file history

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -529,7 +529,6 @@ function replaceVersionNumbers() {
     .pipe(replace('[android.minimum-required-os-version]', '6'))
     .pipe(replace('[android.minimum-app-version]', '1.0.4'))
     .pipe(replace('[android.current-app-version]', '2.28.3'))
-    .pipe(replace('[last-update]', new Date().toISOString().split('T')[0]))
     .pipe(gulp.dest(PATHS.dist));
 }
 

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2484,7 +2484,8 @@
                                 "anchor": "update_faq",
                                 "active": false,
                                 "textblock": [
-                                    "Updated [last-update]"
+                                    "The Corona-Warn-App open source team updates this FAQ regularly and keeps it up to date. You can see when the last updates were made and what changes were made in the change history on <a href='#glossary_github'>GitHub</a>.",
+                                    "See: <a href='https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq.json' target='_blank' rel='noopener noreferrer'>GitHub: English Corona-Warn-App FAQ Change History</a>"
                                 ]
                             }
                         ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2484,7 +2484,7 @@
                                 "anchor": "update_faq",
                                 "active": false,
                                 "textblock": [
-                                    "Updated January 3rd, 2023",
+                                    "Updated January 4th, 2023",
                                     "<hr>",
                                     "The Corona-Warn-App open source team updates this FAQ regularly and keeps it up to date. You can see when the last updates were made and what changes were made in the change history on <a href='#glossary_github'>GitHub</a>.",
                                     "See: <a href='https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq.json' target='_blank' rel='noopener noreferrer'>GitHub: English Corona-Warn-App FAQ Change History</a>"

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2484,7 +2484,7 @@
                                 "anchor": "update_faq",
                                 "active": false,
                                 "textblock": [
-                                    "Updated January 4th, 2023",
+                                    "The last content changes to FAQ articles were made on January 4th, 2023.",
                                     "<hr>",
                                     "The Corona-Warn-App open source team updates this FAQ regularly and keeps it up to date. You can see when the last updates were made and what changes were made in the change history on <a href='#glossary_github'>GitHub</a>.",
                                     "See: <a href='https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq.json' target='_blank' rel='noopener noreferrer'>GitHub: English Corona-Warn-App FAQ Change History</a>"

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -2484,6 +2484,8 @@
                                 "anchor": "update_faq",
                                 "active": false,
                                 "textblock": [
+                                    "Updated January 3rd, 2023",
+                                    "<hr>",
                                     "The Corona-Warn-App open source team updates this FAQ regularly and keeps it up to date. You can see when the last updates were made and what changes were made in the change history on <a href='#glossary_github'>GitHub</a>.",
                                     "See: <a href='https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq.json' target='_blank' rel='noopener noreferrer'>GitHub: English Corona-Warn-App FAQ Change History</a>"
                                 ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2493,7 +2493,7 @@
                                 "anchor": "update_faq",
                                 "active": false,
                                 "textblock": [
-                                    "Stand: 3. Januar 2023",
+                                    "Stand: 4. Januar 2023",
                                     "<hr>",
                                     "Das Open-Source-Team der Corona-Warn-App aktualisiert diese FAQ regelmäßig und hält sie auf dem aktuellsten Stand. Wann die letzten Aktualisierungen erfolgten und welche Änderungen vorgenommen wurden, können Sie dem Änderungsverlauf auf <a href='#glossary_github'>GitHub</a> entnehmen.",
                                     "Siehe: <a href='https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq_de.json' target='_blank' rel='noopener noreferrer'>GitHub: Änderungsverlauf des Deutschen Corona-Warn-App FAQs</a>"

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2493,7 +2493,8 @@
                                 "anchor": "update_faq",
                                 "active": false,
                                 "textblock": [
-                                    "Stand: [last-update]"
+                                    "Das Open-Source-Team der Corona-Warn-App aktualisiert diese FAQ regelmäßig und hält sie auf dem aktuellsten Stand. Wann die letzten Aktualisierungen erfolgten und welche Änderungen vorgenommen wurden, können Sie dem Änderungsverlauf auf <a href='#glossary_github'>GitHub</a> entnehmen.",
+                                    "Siehe: <a href='https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq_de.json' target='_blank' rel='noopener noreferrer'>GitHub: Änderungsverlauf des Deutschen Corona-Warn-App FAQs</a>"
                                 ]
                             }
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2493,7 +2493,7 @@
                                 "anchor": "update_faq",
                                 "active": false,
                                 "textblock": [
-                                    "Stand: 4. Januar 2023",
+                                    "Die letzten inhaltlichen Änderungen an FAQ-Artikeln wurden am 4. Januar 2023 getätigt.",
                                     "<hr>",
                                     "Das Open-Source-Team der Corona-Warn-App aktualisiert diese FAQ regelmäßig und hält sie auf dem aktuellsten Stand. Wann die letzten Aktualisierungen erfolgten und welche Änderungen vorgenommen wurden, können Sie dem Änderungsverlauf auf <a href='#glossary_github'>GitHub</a> entnehmen.",
                                     "Siehe: <a href='https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq_de.json' target='_blank' rel='noopener noreferrer'>GitHub: Änderungsverlauf des Deutschen Corona-Warn-App FAQs</a>"

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -2493,6 +2493,8 @@
                                 "anchor": "update_faq",
                                 "active": false,
                                 "textblock": [
+                                    "Stand: 3. Januar 2023",
+                                    "<hr>",
                                     "Das Open-Source-Team der Corona-Warn-App aktualisiert diese FAQ regelmäßig und hält sie auf dem aktuellsten Stand. Wann die letzten Aktualisierungen erfolgten und welche Änderungen vorgenommen wurden, können Sie dem Änderungsverlauf auf <a href='#glossary_github'>GitHub</a> entnehmen.",
                                     "Siehe: <a href='https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq_de.json' target='_blank' rel='noopener noreferrer'>GitHub: Änderungsverlauf des Deutschen Corona-Warn-App FAQs</a>"
                                 ]


### PR DESCRIPTION
While going through the FAQ for another task, I came across the [#update_faq](https://www.coronawarn.app/en/faq/results/#update_faq) article and noticed something odd. Although we haven't merged any FAQ changes this year, it already showed a 2023 date. Instead of showing the date of the last FAQ change, it shows the date from when the site was built. Every merged PR or scheduled deployment would update that date, not just FAQ changes like intended. 

After thinking about fixing this, I came up with an alternative idea. In my opinion, it doesn't really make sense to specify this in the FAQ if it's always up to date anyway. Especially not if that is the only information included in the FAQ article, with no text whatsoever. Linking to the GitHub file history for [faq_de.json](https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq_de.json) / [faq.json](https://github.com/corona-warn-app/cwa-website/commits/master/src/data/faq.json) would give the visitors much more information. Not only would they see when the last change was made like before, but they would now see what has changed in specific. They can see any change that has been made to the file in a chronological order. 

(After taking the comments below into consideration, a date within the FAQ article itself has been re-added)

With the changes I've made in this PR, the article would look like this:

![image](https://user-images.githubusercontent.com/88365935/210550786-34830e9a-d13b-4a1a-b87d-5c30ffa62885.png)

![image](https://user-images.githubusercontent.com/88365935/210550803-dd2bfe11-61b2-493d-a6b0-0dfdc54fbda1.png)


I am looking forward to your feedback.

---

Internal Tracking ID: [EXPOSUREAPP-14522](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14522)