### PR TITLE
Add short Cypress test script npm run test:short

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository contains the source files of the official website for the Corona
 
 You need the Node.js 18 (Active LTS) version of [Node.js](https://nodejs.org/en/) (which includes npm) to build the website.
 
-In case you use a Mac computer with Apple Silicon, make sure that [Rosetta](https://support.apple.com/en-us/HT211861) is installed. 
+In case you use a Mac computer with Apple Silicon, make sure that [Rosetta](https://support.apple.com/en-us/HT211861) is installed.
 
 ### Getting started
 
@@ -80,9 +80,16 @@ Manuals for the most common use cases of updating website content are available 
 [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html#In-a-nutshell) is used to run End-To-End tests. Tests are located in the `cypress/e2e` folder and can be run with:
 
 ```bash
-  npm run test
+npm test
 ```
-Alternatively, execute `npm run test:open` to select individual tests to run from the Cypress console.
+Since the full test includes testing of external links which can take 10 to 15 minutes to execute, a shorter version of the test is available, which excludes testing external links. It can be run with:
+```bash
+npm run test:short
+```
+To interactively run individual tests through the Cypress console use:
+```bash
+npm run test:open
+```
 
 To minimize the occurrence of errors we would ask you to perform all tests when contributing to our repository.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "corona-warn-app-landingpage",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "corona-warn-app-landingpage",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.20.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-warn-app-landingpage",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Corona-Warn-App website coronawarn.app",
   "main": "gulpfile.js",
   "scripts": {
@@ -11,6 +11,7 @@
     "cypress:open": "cypress open --e2e --browser chrome",
     "cypress:run:chrome": "cypress run --browser chrome --headed",
     "cypress:run:firefox": "cypress run --browser firefox --headed",
+    "cypress:run:short": "cypress run -s 'cypress/e2e/*.js' --e2e --headless",
     "start-server": "gulp start-server",
     "test:open:phase2": "start-server-and-test start-server http://localhost:8000 cypress:open",
     "test:open": "run-s build test:open:phase2",
@@ -18,7 +19,9 @@
     "test:chrome:phase2": "start-server-and-test start-server http://localhost:8000 cypress:run:chrome",
     "test:chrome": "run-s build test:chrome:phase2",
     "test:firefox:phase2": "start-server-and-test start-server http://localhost:8000 cypress:run:firefox",
-    "test:firefox": "run-s build test:firefox:phase2"
+    "test:firefox": "run-s build test:firefox:phase2",
+    "test:short": "run-s build test:short:phase2",
+    "test:short:phase2": "start-server-and-test start-server http://localhost:8000 cypress:run:short"
   },
   "author": "SAP Corona-Warn-App Open Source Team <corona-warn-app.opensource@sap.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "corona-warn-app-landingpage",
   "version": "1.2.0",
   "description": "Corona-Warn-App website coronawarn.app",
-  "main": "gulpfile.js",
+  "main": "gulpfile.mjs",
   "scripts": {
     "start-fast": "gulp --skip-compression",
     "start": "gulp",


### PR DESCRIPTION
This PR implements one suggestion from https://github.com/corona-warn-app/cwa-website/issues/3308 "Improve testing for PR submission".

It provides a new script which can be run with:

`npm run test:short`

This runs all Cypress tests except [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js).

## Verification

Execute

`npm run test:short`

and confirm that there are no errors reported.

---
Internal Tracking ID: [EXPOSUREAPP-14530](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14530)
