### PR TITLE
Update FAQ_SEARCH_SUMMARY: Invalid gulpfile link

### DIFF
--- a/docs/FAQ_SEARCH_SUMMARY.md
+++ b/docs/FAQ_SEARCH_SUMMARY.md
@@ -5,7 +5,7 @@ It comprises two main parts that you need to alter, if you want to optimize or c
 
 ## Gulp Function
 
-The `gulp build` tasks in the [gulpfile](../gulpfile.js) performs a step called `copyFAQs`. This takes the faq files ([en](../src/data/faq.json), [de](../src/data/faq_de.json)) and transforms them into a searchable structure.
+The `gulp build` tasks in the [gulpfile](../gulpfile.mjs) performs a step called `copyFAQs`. This takes the faq files ([en](../src/data/faq.json), [de](../src/data/faq_de.json)) and transforms them into a searchable structure.
 
 Text blocks are merged into a single string and HTML tags are removed. Additionally, the question text is added. Indexes of the structure are the FAQ anchors. The resulting very straightforward JavaScript objects (one per language) are copied to the `{lang}/faq/faq.json` folders of the distribution.
 


### PR DESCRIPTION
In [FAQ_SEARCH_SUMMARY.md](https://github.com/corona-warn-app/cwa-website/blob/master/docs/FAQ_SEARCH_SUMMARY.md), there is a link to the gulpfile. As it was renamed from gulpfile.js to gulpfile.mjs [here](https://github.com/corona-warn-app/cwa-website/pull/3181), the link to the gulpfile from there must have not worked ever since. With this PR, it now links to the gulpfile again.