### PR TITLE
Release 3.0: Update FAQ articles mentioning "Warn for others"

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -355,9 +355,9 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated ?????</b>",
-                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 and cannot be used with the previous versions 2.9 to 2.28 after ??????, as the verification hotline (TAN hotline) will be discontinued on this date.",
+                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 onwards and cannot be used with the previous versions 2.9 to 2.28 after ??????, as the verification hotline (TAN hotline) will be discontinued on this date.",
                                     "<hr>",
-                                    "As an organizer of an event, starting with version 2.9 and up to version 2.28 of the Corona-Warn-App (through ??????), you can warn for others, such as for a person who has tested positive and was attending an event but not checked in via the Corona-Warn-App (CWA), upon request by the health department.",
+                                    "As an organizer of an event, starting with version 2.9 and up to version 2.28 of the Corona-Warn-App (until ??????), you can warn for others, such as for a person who has tested positive and was attending an event but not checked in via the Corona-Warn-App (CWA), upon request by the health department.",
                                     "If a person who has not checked in later tests positive, guests may be alerted if they were in the same room at the same time or up to 30 minutes after the person who tested positive.",
                                     "To alert other guests using the CWA as an event organizer, please follow these steps:",
                                     "<ul><li>If you subsequently become aware of the presence of a positively tested person at your event, and the health department has not yet contacted you as an event organizer, contact the health department. The health department can issue you a TAN if necessary.</li><li>Click 'Create QR Code' on the Status tab ('Start Screen' before version 2.12) of your CWA.</li><li>On the 'My QR Codes' page, click the three-dot menu in the upper right corner and then click the 'Warn for Others' menu item.</li><li>Click 'Continue' on the info screen.</li><li>Select an event for which you would like to warn others for an infected person. Or restore a deleted event by scanning the event's QR code again. Click 'Continue'.</li><li>Indicate the length of stay of the person who tested positive for whom you want to warn. You can get this information from the health department. Click on 'Continue'.</li><li>Enter the 10-digit TAN that you were given. Click on 'Send warning'.</li></ul>",
@@ -1190,7 +1190,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated ?????</b>",
-                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 and cannot be used with the previous versions 2.9 to 2.28 after ??????, as the verification hotline (TAN hotline) will be discontinued on this date.",
+                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 onwards and cannot be used with the previous versions 2.9 to 2.28 after ??????, as the verification hotline (TAN hotline) will be discontinued on this date.",
                                     "<hr>",
                                     "Organizers can warn for others regardless of which QR code they have scanned with the CWA. For more information on warning for others, see the following links:<ul><li><a href='#warn_for_others' target='_blank'>FAQ: How can I warn for others?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App version 2.9: Organizers can use the check-in function to warn guests on behalf of the health department</a></li></ul>"
                                 ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -354,10 +354,10 @@
                                 "anchor": "warn_for_others",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Updated ?????</b>",
-                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 onwards and cannot be used with the previous versions 2.9 to 2.28 after ??????, as the verification hotline (TAN hotline) will be discontinued on this date.",
+                                    "<b>Updated ?????r</b>",
+                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 onwards and cannot be used with the previous versions 2.9 to 2.28 after ??????h, as the verification hotline (TAN hotline) will be discontinued on this date.",
                                     "<hr>",
-                                    "As an organizer of an event, starting with version 2.9 and up to version 2.28 of the Corona-Warn-App (until ??????), you can warn for others, such as for a person who has tested positive and was attending an event but not checked in via the Corona-Warn-App (CWA), upon request by the health department.",
+                                    "As an organizer of an event, starting with version 2.9 and up to version 2.28 of the Corona-Warn-App (until ??????h), you can warn for others, such as for a person who has tested positive and was attending an event but not checked in via the Corona-Warn-App (CWA), upon request by the health department.",
                                     "If a person who has not checked in later tests positive, guests may be alerted if they were in the same room at the same time or up to 30 minutes after the person who tested positive.",
                                     "To alert other guests using the CWA as an event organizer, please follow these steps:",
                                     "<ul><li>If you subsequently become aware of the presence of a positively tested person at your event, and the health department has not yet contacted you as an event organizer, contact the health department. The health department can issue you a TAN if necessary.</li><li>Click 'Create QR Code' on the Status tab ('Start Screen' before version 2.12) of your CWA.</li><li>On the 'My QR Codes' page, click the three-dot menu in the upper right corner and then click the 'Warn for Others' menu item.</li><li>Click 'Continue' on the info screen.</li><li>Select an event for which you would like to warn others for an infected person. Or restore a deleted event by scanning the event's QR code again. Click 'Continue'.</li><li>Indicate the length of stay of the person who tested positive for whom you want to warn. You can get this information from the health department. Click on 'Continue'.</li><li>Enter the 10-digit TAN that you were given. Click on 'Send warning'.</li></ul>",
@@ -1189,8 +1189,8 @@
                                 "anchor": "check_in_luca_warn_for_others",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Updated ?????</b>",
-                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 onwards and cannot be used with the previous versions 2.9 to 2.28 after ??????, as the verification hotline (TAN hotline) will be discontinued on this date.",
+                                    "<b>Updated ?????r</b>",
+                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 onwards and cannot be used with the previous versions 2.9 to 2.28 after ??????h, as the verification hotline (TAN hotline) will be discontinued on this date.",
                                     "<hr>",
                                     "Organizers can warn for others regardless of which QR code they have scanned with the CWA. For more information on warning for others, see the following links:<ul><li><a href='#warn_for_others' target='_blank'>FAQ: How can I warn for others?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App version 2.9: Organizers can use the check-in function to warn guests on behalf of the health department</a></li></ul>"
                                 ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -354,7 +354,10 @@
                                 "anchor": "warn_for_others",
                                 "active": false,
                                 "textblock": [
-                                    "As an organizer of an event, starting with version 2.9, you can warn for others, such as for a person who has tested positive and was attending an event but not checked in via the Corona-Warn-App (CWA), upon request by the health department.",
+                                    "<b>Updated ?????</b>",
+                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 and cannot be used with the previous versions 2.9 to 2.28 after ??????, as the verification hotline (TAN hotline) will be discontinued on this date.",
+                                    "<hr>",
+                                    "As an organizer of an event, starting with version 2.9 and up to version 2.28 of the Corona-Warn-App (through ??????), you can warn for others, such as for a person who has tested positive and was attending an event but not checked in via the Corona-Warn-App (CWA), upon request by the health department.",
                                     "If a person who has not checked in later tests positive, guests may be alerted if they were in the same room at the same time or up to 30 minutes after the person who tested positive.",
                                     "To alert other guests using the CWA as an event organizer, please follow these steps:",
                                     "<ul><li>If you subsequently become aware of the presence of a positively tested person at your event, and the health department has not yet contacted you as an event organizer, contact the health department. The health department can issue you a TAN if necessary.</li><li>Click 'Create QR Code' on the Status tab ('Start Screen' before version 2.12) of your CWA.</li><li>On the 'My QR Codes' page, click the three-dot menu in the upper right corner and then click the 'Warn for Others' menu item.</li><li>Click 'Continue' on the info screen.</li><li>Select an event for which you would like to warn others for an infected person. Or restore a deleted event by scanning the event's QR code again. Click 'Continue'.</li><li>Indicate the length of stay of the person who tested positive for whom you want to warn. You can get this information from the health department. Click on 'Continue'.</li><li>Enter the 10-digit TAN that you were given. Click on 'Send warning'.</li></ul>",
@@ -1186,6 +1189,9 @@
                                 "anchor": "check_in_luca_warn_for_others",
                                 "active": false,
                                 "textblock": [
+                                    "<b>Updated ?????</b>",
+                                    "This feature of the Corona-Warn-App is no longer available from version 3.0 and cannot be used with the previous versions 2.9 to 2.28 after ??????, as the verification hotline (TAN hotline) will be discontinued on this date.",
+                                    "<hr>",
                                     "Organizers can warn for others regardless of which QR code they have scanned with the CWA. For more information on warning for others, see the following links:<ul><li><a href='#warn_for_others' target='_blank'>FAQ: How can I warn for others?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App version 2.9: Organizers can use the check-in function to warn guests on behalf of the health department</a></li></ul>"
                                 ]
                             },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -354,7 +354,10 @@
                                 "anchor": "warn_for_others",
                                 "active": false,
                                 "textblock": [
-                                    "Als Organisator einer Veranstaltung können Sie ab der Version 2.9 nach Aufforderung durch das Gesundheitsamt Ihre Gäste in Vertretung für eine positiv getestete Person warnen, die an einer Veranstaltung teilgenommen hat, aber nicht über die Corona-Warn-App (CWA) eingecheckt war.",
+                                    "<b>Aktualisiert am ?????</b>",
+                                    "Diese Funktion der Corona-Warn-App steht ab der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem ?????? genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.",
+                                    "<hr>",
+                                    "Als Organisator einer Veranstaltung können Sie ab der Version 2.9 bis zu der Version 2.28 der Corona-Warn-App (bis zum ??????) nach Aufforderung durch das Gesundheitsamt Ihre Gäste in Vertretung für eine positiv getestete Person warnen, die an einer Veranstaltung teilgenommen hat, aber nicht über die Corona-Warn-App (CWA) eingecheckt war.",
                                     "Wird eine nicht eingecheckte Person später positiv getestet, können die Gäste gewarnt werden, wenn sie sich zur gleichen Zeit oder bis zu 30 Minuten nach der positiv getesteten Person im gleichen Raum aufgehalten haben.",
                                     "Um als Organisator einer Veranstaltung andere Gäste über die CWA zu warnen, gehen Sie bitte folgendermaßen vor:",
                                     "<ul><li>Erhalten Sie im Nachhinein Kenntnis von der Gegenwart einer positiv getesteten Person auf Ihrer Veranstaltung, und hat das Gesundheitsamt Sie als Organisator einer Veranstaltung noch nicht kontaktiert, setzen Sie sich mit dem Gesundheitsamt in Verbindung. Das Gesundheitsamt kann Ihnen gegebenenfalls eine TAN ausstellen.</li><li>Klicken Sie unter Status (vor Version 2.12 'Startseite') in Ihrer CWA auf „QR-Code erstellen“.</li><li>Klicken Sie auf der „Meine QR-Codes“-Seite oben rechts auf das Drei-Punkte-Menü und dann auf den Menüpunkt „In Vertretung warnen“.</li><li>Klicken Sie auf dem Infoscreen auf „Weiter“.</li><li>Wählen Sie eine Veranstaltung, für welches Sie in Vertretung einer infizierten Person andere warnen möchten. Oder stellen Sie eine gelöschte Veranstaltung wieder her, indem Sie den QR-Code der Veranstaltung erneut einscannen. Klicken Sie auf „Weiter“.</li><li>Geben Sie die Aufenthaltsdauer der positiv getesteten Person an, für die gewarnt werden soll. Diese Information erhalten Sie vom Gesundheitsamt. Klicken Sie auf „Weiter“.</li><li>Geben Sie die 10-stellige TAN ein, die Ihnen mitgeteilt wurde. Klicken Sie auf „Warnung abschicken“.</li></ul>",
@@ -1185,6 +1188,9 @@
                                 "anchor": "check_in_luca_warn_for_others",
                                 "active": false,
                                 "textblock": [
+                                    "<b>Aktualisiert am ?????</b>",
+                                    "Diese Funktion der Corona-Warn-App steht ab der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem ?????? genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.",
+                                    "<hr>",
                                     "Veranstalter:innen können unabhängig davon, welchen QR-Code sie mit der CWA eingescannt haben, die sogenannte Stellvertreter-Warnung verwenden. Weitere Informationen zur Stellvertreter-Warnung finden Sie unter den folgenden Links: <ul><li><a href='#warn_for_others' target='_blank'>FAQ: Wie kann ich in Vertretung warnen?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App Version 2.9: Veranstalter*innen können Gäste im Auftrag des Gesundheitsamtes über die Check-in-Funktion warnen</a></li></ul>"
                                 ]
                             },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1191,7 +1191,7 @@
                                     "<b>Aktualisiert am ?????</b>",
                                     "Diese Funktion der Corona-Warn-App steht ab der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem ?????? genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.",
                                     "<hr>",
-                                    "Veranstalter:innen können unabhängig davon, welchen QR-Code sie mit der CWA eingescannt haben, die sogenannte Stellvertreter-Warnung verwenden. Weitere Informationen zur Stellvertreter-Warnung finden Sie unter den folgenden Links: <ul><li><a href='#warn_for_others' target='_blank'>FAQ: Wie kann ich in Vertretung warnen?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App Version 2.9: Veranstalter*innen können Gäste im Auftrag des Gesundheitsamtes über die Check-in-Funktion warnen</a></li></ul>"
+                                    "Veranstalter*innen können unabhängig davon, welchen QR-Code sie mit der CWA eingescannt haben, die sogenannte Stellvertreter-Warnung verwenden. Weitere Informationen zur Stellvertreter-Warnung finden Sie unter den folgenden Links: <ul><li><a href='#warn_for_others' target='_blank'>FAQ: Wie kann ich in Vertretung warnen?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App Version 2.9: Veranstalter*innen können Gäste im Auftrag des Gesundheitsamtes über die Check-in-Funktion warnen</a></li></ul>"
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -354,10 +354,10 @@
                                 "anchor": "warn_for_others",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Aktualisiert am ?????</b>",
-                                    "Diese Funktion der Corona-Warn-App steht ab der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem ?????? genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.",
+                                    "<b>Aktualisiert am ?????r</b>",
+                                    "Diese Funktion der Corona-Warn-App steht ab der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem ??????h genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.",
                                     "<hr>",
-                                    "Als Organisator einer Veranstaltung können Sie ab der Version 2.9 bis zu der Version 2.28 der Corona-Warn-App (bis zum ??????) nach Aufforderung durch das Gesundheitsamt Ihre Gäste in Vertretung für eine positiv getestete Person warnen, die an einer Veranstaltung teilgenommen hat, aber nicht über die Corona-Warn-App (CWA) eingecheckt war.",
+                                    "Als Organisator einer Veranstaltung können Sie ab der Version 2.9 bis zu der Version 2.28 der Corona-Warn-App (bis zum ??????h) nach Aufforderung durch das Gesundheitsamt Ihre Gäste in Vertretung für eine positiv getestete Person warnen, die an einer Veranstaltung teilgenommen hat, aber nicht über die Corona-Warn-App (CWA) eingecheckt war.",
                                     "Wird eine nicht eingecheckte Person später positiv getestet, können die Gäste gewarnt werden, wenn sie sich zur gleichen Zeit oder bis zu 30 Minuten nach der positiv getesteten Person im gleichen Raum aufgehalten haben.",
                                     "Um als Organisator einer Veranstaltung andere Gäste über die CWA zu warnen, gehen Sie bitte folgendermaßen vor:",
                                     "<ul><li>Erhalten Sie im Nachhinein Kenntnis von der Gegenwart einer positiv getesteten Person auf Ihrer Veranstaltung, und hat das Gesundheitsamt Sie als Organisator einer Veranstaltung noch nicht kontaktiert, setzen Sie sich mit dem Gesundheitsamt in Verbindung. Das Gesundheitsamt kann Ihnen gegebenenfalls eine TAN ausstellen.</li><li>Klicken Sie unter Status (vor Version 2.12 'Startseite') in Ihrer CWA auf „QR-Code erstellen“.</li><li>Klicken Sie auf der „Meine QR-Codes“-Seite oben rechts auf das Drei-Punkte-Menü und dann auf den Menüpunkt „In Vertretung warnen“.</li><li>Klicken Sie auf dem Infoscreen auf „Weiter“.</li><li>Wählen Sie eine Veranstaltung, für welches Sie in Vertretung einer infizierten Person andere warnen möchten. Oder stellen Sie eine gelöschte Veranstaltung wieder her, indem Sie den QR-Code der Veranstaltung erneut einscannen. Klicken Sie auf „Weiter“.</li><li>Geben Sie die Aufenthaltsdauer der positiv getesteten Person an, für die gewarnt werden soll. Diese Information erhalten Sie vom Gesundheitsamt. Klicken Sie auf „Weiter“.</li><li>Geben Sie die 10-stellige TAN ein, die Ihnen mitgeteilt wurde. Klicken Sie auf „Warnung abschicken“.</li></ul>",
@@ -1188,8 +1188,8 @@
                                 "anchor": "check_in_luca_warn_for_others",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Aktualisiert am ?????</b>",
-                                    "Diese Funktion der Corona-Warn-App steht ab der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem ?????? genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.",
+                                    "<b>Aktualisiert am ?????r</b>",
+                                    "Diese Funktion der Corona-Warn-App steht ab der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem ??????h genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.",
                                     "<hr>",
                                     "Veranstalter*innen können unabhängig davon, welchen QR-Code sie mit der CWA eingescannt haben, die sogenannte Stellvertreter-Warnung verwenden. Weitere Informationen zur Stellvertreter-Warnung finden Sie unter den folgenden Links: <ul><li><a href='#warn_for_others' target='_blank'>FAQ: Wie kann ich in Vertretung warnen?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App Version 2.9: Veranstalter*innen können Gäste im Auftrag des Gesundheitsamtes über die Check-in-Funktion warnen</a></li></ul>"
                                 ]


### PR DESCRIPTION
This PR updates "Warn for others" FAQs in response to changes regarding TAN procedures in 3.0.

Dates will be inserted once approved or shortly before being merged. Apart from that, this PR is ready to be reviewed.

[Kann ich die Stellvertreter-Funktion nutzen, egal welchen QR-Code ich eingescannt habe?](https://www.coronawarn.app/de/faq/results/#check_in_luca_warn_for_others)
![image](https://user-images.githubusercontent.com/88365935/211283198-0d7bc9ee-b154-4709-8d33-3af00d6b3eb2.png)
[Can I warn for others regardless of which QR code I have scanned?](https://www.coronawarn.app/en/faq/results/#check_in_luca_warn_for_others)
![image](https://user-images.githubusercontent.com/88365935/211283213-11bc916d-765e-4248-8552-017aa6e46a79.png)

[Wie kann ich in Vertretung warnen?](https://www.coronawarn.app/de/faq/results/#warn_for_others)
![image](https://user-images.githubusercontent.com/88365935/211283221-ab3b9872-d719-4b38-ab2f-248008f1c3f6.png)
[How can I warn for others?](https://www.coronawarn.app/en/faq/results/#warn_for_others)
![image](https://user-images.githubusercontent.com/88365935/211283228-7d40308a-2678-4dec-81a1-e936cac533dc.png)

---
Internal Tracking ID: [EXPOSUREAPP-14499](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14499)