### PR TITLE
Create build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,26 @@
+name: Build and Test
+
+on:
+#  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js 18 environment
+      uses: actions/setup-node@v3
+      with:
+        node-version: 'lts/hydrogen'
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Build the website
+      run: npm run-script build
+
+    - name: Test the website
+      run: npx start-server-and-test start-server http://localhost:8000 "cypress run -s 'cypress/e2e/*.js' --e2e --headless --browser chrome"


### PR DESCRIPTION
This PR implements the suggestion from issue https://github.com/corona-warn-app/cwa-website/issues/3308.

The workflow initially does not run automatically.

---
Internal Tracking ID: [EXPOSUREAPP-14535](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14535)