### PR TITLE
Update build-and-test.yml: Enable PR trigger

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR enables the PR trigger in the [build-and-test.yml](https://github.com/corona-warn-app/cwa-website/blob/master/.github/workflows/build-and-test.yml) workflow. 

The first manually triggered workflow ran successfully, as seen [here](https://github.com/corona-warn-app/cwa-website/actions/runs/3882434456/jobs/6622581219).

Once this PR is merged, the [build.yml](https://github.com/corona-warn-app/cwa-website/blob/master/.github/workflows/build.yml) workflow will be disabled. In the next upcoming PR we should then only see this new workflow.

Thanks to @MikeMcC399 for initially providing this workflow and his extensive Cypress efforts in general. This will greatly improve the process of contributing to the project.

---
Internal Tracking ID: [EXPOSUREAPP-14535](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14535)