### PR TITLE
Release 3.0 | Update FAQ: Add "Warning without TAN" section

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -457,7 +457,7 @@
                                 "active": false,
                                 "textblock": [
                                     "From an epidemiological point of view, a PCR test is of course significantly more accurate and informative than a self-test performed by non-professionals. Therefore, a PCR test is recommended for confirmation (or verification of any false positives) of the self-test.",
-                                    "Therefore, in order to comply with local regulations, we recommend that after a positive self-test, you contact their local health department or trusted doctor to discuss further action."
+                                    "Therefore, in order to comply with local regulations, we recommend that after a positive self-test, you contact your local health department or doctor to discuss further action."
                                 ]
                             },
                             {
@@ -516,7 +516,7 @@
                                 "anchor": "warn_without_tan_isolation",
                                 "active": false,
                                 "textblock": [
-                                    "After each positive test, we recommend, for the sake of personal responsibility, to first minimize contacts as far as possible and to contact your trusted doctor or the public health department to coordinate further steps.",
+                                    "After each positive test, we recommend, for the sake of personal responsibility, to first minimize contacts as far as possible and to contact your doctor or the public health department to coordinate further steps.",
                                     "Current isolation rules are based on the IfSG and local applicable regulations."
                                 ]
                             },
@@ -581,11 +581,12 @@
                                 ]
                             },
                             {
-                                "title": "Does a warning based on the new feature disappear from the app by itself, or do I have to delete it independently?",
-                                "anchor": "warn_without_tan_warning",
+                                "title": "Can warnings of different test types be differentiated?",
+                                "anchor": "warn_without_tan_differentiate_warning",
                                 "active": false,
                                 "textblock": [
-                                    "No, this is not necessary. After a period of 10 days at the most, the warning in the app is automatically reset because the time window for the risk warnings is then also expired."
+                                    "Contacts will receive a warning in their Corona-Warn-App about an encounter on a low risk (green tile) or increased risk (red tile) day.",
+                                    "Whether the warning was based on a rapid test or PCR test, whose result was received via the app, or on a self-test or other test, whose result was not transmitted in the app, is not disclosed to the warned person."
                                 ]
                             }
                         ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -385,7 +385,7 @@
                         "indexed": true,
                         "accordion": [
                             {
-                                "title": "Information about warning without TAN",
+                                "title": "Information about warning without a TAN",
                                 "anchor": "warn_without_tan",
                                 "active": false,
                                 "textblock": [
@@ -457,7 +457,7 @@
                                 "active": false,
                                 "textblock": [
                                     "From an epidemiological point of view, a PCR test is of course significantly more accurate and informative than a self-test performed by non-professionals. Therefore, a PCR test is recommended for confirmation (or verification of any false positives) of the self-test.",
-                                    "Therefore, in order to comply with local regulations, we recommend that after a positive self-test, they contact their local health department or trusted doctor to discuss further action."
+                                    "Therefore, in order to comply with local regulations, we recommend that after a positive self-test, you contact their local health department or trusted doctor to discuss further action."
                                 ]
                             },
                             {
@@ -500,7 +500,7 @@
                                 "anchor": "warn_without_tan_family",
                                 "active": false,
                                 "textblock": [
-                                    "No, this is not technically possible because the risk contacts of the person tested positive were not necessarily also recorded on their smartphone by contact tracing. Warning for others from your smartphone would therefore not reach these contacts at all, but only your (i.e. the wrong) contacts."
+                                    "No, this is not technically possible because the risk contacts of the person tested positive were not necessarily also recorded on your smartphone by contact tracing. Warning for others from your smartphone would therefore not reach these contacts at all, but only your (i.e. the wrong) contacts."
                                 ]
                             },
                             {
@@ -551,7 +551,7 @@
                                 "anchor": "warn_without_tan_sickness_certificate",
                                 "active": false,
                                 "textblock": [
-                                    "No, alerting others with the new \"Manage Your Tests and Warn Others\" feature does not result in the display of a positive test result in the Corona-Warn-App at all. Aside from that, displaying it in the CWA is not permitted by labor law for sick leave or work/school release. Please contact the doctor you trust or the responsible health office."
+                                    "No, alerting others with the \"Manage Your Tests and Warn Others\" feature does not result in the display of a positive test result in the Corona-Warn-App at all, it is only used to warn your contacts. Aside from that, displaying it in the CWA is not permitted by labor law for sick leave or work/school release. Please contact the doctor you trust or the responsible health office."
                                 ]
                             },
                             {
@@ -559,25 +559,25 @@
                                 "anchor": "warn_without_tan_in_app_display",
                                 "active": false,
                                 "textblock": [
-                                    "Warning others with the new \"Manage Your Tests and Warn Others\" feature does not display a positive test result in the Corona-Warn-App at all.",
-                                    "For tests that are registered in the app as before, the same still applies: Tests always represent only a snapshot in the diagnosis of infectious diseases, they are therefore not valid indefinitely. After 72 hours, a registered test will therefore be grayed out as \"out of date\" in the Corona-Warn-App."
+                                    "Warning others with the new \"Manage Your Tests and Warn Others\" feature does not display a positive test result in the Corona-Warn-App at all, it is only used to warn your contacts.",
+                                    "For tests that are registered in the app as before, the same still applies: Tests always represent only a snapshot in the diagnosis of infectious diseases, they are therefore not valid indefinitely. After 72 hours, a registered test will therefore be displayed as \"out of date\" in the Corona-Warn-App."
                                 ]
                             },
                             {
-                                "title": "After sharing the positive result, does my risk assessment stop? How long?",
+                                "title": "After sharing the positive result, does my risk assessment stop?",
                                 "anchor": "warn_without_tan_risk_assessment",
                                 "active": false,
                                 "textblock": [
-                                    "No, risk assessment and the contact tracing protocol are not stopped. Warning others with the new \"Manage Your Tests and Warn Others\" feature does not affect risk assessment.",
-                                    "If you are out in public despite testing positive, please be mindful of spacing and hygiene rules and, if possible, wear a mask to reduce a risk of infection to others."
+                                    "No, the risk assessment is not stopped. Thus, the Corona-Warn-App continues to record its contacts and send out random IDs. Therefore, warning others with the \"Manage Your Tests and Warn Others\" function has no effect on the risk assessment.",
+                                    "If you are out in public despite testing positive, please be mindful of spacing and hygiene rules and, if possible, wear a mask to reduce the risk of infection of others."
                                 ]
                             },
                             {
-                                "title": "Does the risk calculation for an alert on my smartphone differ by test type from the person who tested positive?",
+                                "title": "Does the risk calculation for a warning on my smartphone differ depending on the test type used to warn?",
                                 "anchor": "warn_without_tan_risk_assessment_different",
                                 "active": false,
                                 "textblock": [
-                                    "No, the procedure for calculating the risk of infection has not been changed. Regardless of the type of test used to detect infection, the same parameters apply when calculating the risk for others."
+                                    "No, the procedure for calculating the risk of infection has not been changed. Regardless of the type of test used to initiate the warning, the same parameters apply in the risk calculation."
                                 ]
                             },
                             {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -379,7 +379,7 @@
                     {
                         "title": "Warning without TAN",
                         "id": "warning_without_tan",
-                        "indexed": false,
+                        "indexed": true,
                         "accordion": [
                             {
                                 "title": "Information about warning without TAN",

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -470,13 +470,13 @@
                                 ]
                             },
                             {
-                                "title": "A few days after the last positive test, I am still positive on the self-test. Should I warn again? Why does it not work the second time?",
+                                "title": "A few days after the last positive test, I am still positive on the self-test. Should I warn again?",
                                 "anchor": "warn_without_tan_still_positive",
                                 "active": false,
                                 "textblock": [
-                                    "In order to avoid misuse of the function for pointless initiation of warnings that are not based on real risk contacts at all, it was decided that a user can only warn others with the new function once within a certain period of time.",
-                                    "After this time period has elapsed, it is then possible to warn again based on a test that was registered in the app without a TAN.",
-                                    "However, we still recommend that after a positive self-test, you behave sensibly on your own responsibility so that no other persons are infected."
+                                    "We further recommend that after a positive self-test, you behave reasonably on your own responsibility in a way that does not infect others. If you behave in this way, no further warning is necessary.",
+                                    "To prevent the feature from being abused and creating unnecessary warnings that are not based on real risk contacts, it was decided that a user with the new feature can warn others only once within a certain period of time.",
+                                    "After this period has elapsed, it is then possible again to issue a warning without a TAN based on your own positive test result. This restriction does not apply to positive test results transmitted via app."
                                 ]
                             },
                             {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -560,8 +560,7 @@
                                 "anchor": "warn_without_tan_in_app_display",
                                 "active": false,
                                 "textblock": [
-                                    "Warning others with the new \"Manage Your Tests and Warn Others\" feature does not display a positive test result in the Corona-Warn-App at all, it is only used to warn your contacts.",
-                                    "For tests that are registered in the app as before, the same still applies: Tests always represent only a snapshot in the diagnosis of infectious diseases, they are therefore not valid indefinitely. After 72 hours, a registered test will therefore be displayed as \"out of date\" in the Corona-Warn-App."
+                                    "Warning others with the new \"Manage Your Tests and Warn Others\" feature does not display a positive test result in the Corona-Warn-App at all, it is only used to warn your contacts."
                                 ]
                             },
                             {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -350,6 +350,9 @@
                                 ]
                             },
                             {
+                                "duplicate": "warn_without_tan_family"
+                            },
+                            {
                                 "title": "How can I warn for others?",
                                 "anchor": "warn_for_others",
                                 "active": false,
@@ -399,7 +402,7 @@
                                 "textblock": [
                                     "Note that you should only warn others based on your own positive test result.",
                                     "If you installed the app just recently, you may not yet be able to warn without a TAN. This is to prevent misuse. If necessary, try again at a later time.",
-                                    "Follow these step-by-step instructions to send an warning to other users of the Corona-Warn-App: <ul><li>Tap on the \"Status\" tab.</li><li>In the \"Manage Your Tests and Warn Others\" tile, tap \"Continue\".</li><li>Tap \"Positive self-test?\" if you have a positive self-test result.</li><li>Tap \"Positive test and no result in the app?\" if you have a positive result from another test type.</li><li>Under the consent form, tap \"Accept\" to continue.</li><li>Unless you want to warn with a positive self-test result, you now have the option to specify the type of test performed. Tap on the appropriate test or alternatively on \"No answer\".</li><li>Provided that you have past check-ins, these can be selected afterwards to warn specifically also the participants of this event.</li><li>You can now specify whether you had symptoms. Should you tap \"Yes\", you can then provide information about the symptom start.</li><li>Confirm that you want to warn by tapping \"Warn others\".</li><li>Finally, the \"Thank you\" screen provides you with further instructions. Tapping \"Done\" will take you back to the \"Status\" tab of the Corona-Warn-App.</li></ul>"
+                                    "Follow these step-by-step instructions to send a warning to other users of the Corona-Warn-App using your own positive test result: <ol><li>Tap on the \"Status\" tab.</li><li>In the \"Manage Your Tests and Warn Others\" tile, tap \"Continue\".</li><li>Tap \"Positive self-test?\" if you have a positive self-test result.</li><li>Tap \"Positive test and no result in the app?\" if you have a positive result from another test type.</li><li>Under the consent form, tap \"Accept\" to continue.</li><li>Unless you want to warn with a positive self-test result, you now have the option to specify the type of test performed. Tap on the appropriate test or alternatively on \"No answer\".</li><li>Provided that you have past check-ins, these can be selected afterwards to warn specifically also the participants of this event.</li><li>You can now specify whether you had symptoms. Should you tap \"Yes\", you can then provide information about the symptom start.</li><li>Confirm that you want to warn by tapping \"Warn others\".</li><li>Finally, the \"Thank you\" screen provides you with further instructions. Tapping \"Done\" will take you back to the \"Status\" tab of the Corona-Warn-App.</li></ol>"
                                 ]
                             },
                             {
@@ -408,7 +411,7 @@
                                 "active": false,
                                 "textblock": [
                                     "You cannot warn others under the following circumstances: <ul><li>You have installed the app just a short time ago.</li><li>Not enough time has passed since your last warning.</li></ul>",
-                                    "These are precautions that have been taken to avoid misuse of this feature. Note that you can still warn with positive test results that you receive in your app."
+                                    "These are precautions taken to avoid misuse of this feature. Note that you can still warn with positive test results obtained by scanning a QR code in your app."
                                 ]
                             },
                             {
@@ -420,13 +423,13 @@
                                 ]
                             },
                             {
-                                "title": "I got my positive result via alternative ways (email, phone call...), but no result in the app - can I still warn my contacts?",
+                                "title": "I did not receive my positive result via the app - can I still warn my contacts?",
                                 "anchor": "warn_without_tan_external_result",
                                 "active": false,
                                 "textblock": [
                                     "Yes, use the new function \"Manage Your Tests and Warn Others\" as of version 3.0; this may require an update of the app.",
                                     "Use it to warn others based on the received positive result manually in the CWA.",
-                                    "See: <a href='warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
+                                    "See: <a href='#warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
                                 ]
                             },
                             {
@@ -438,18 +441,18 @@
                                 ]
                             },
                             {
-                                "title": "Do I need to upgrade to the new release, or will my current version of CWA continue to run?",
+                                "title": "Do I need to upgrade to version 3.0, or will my current version of CWA continue to run?",
                                 "anchor": "warn_without_tan_version",
                                 "active": false,
                                 "textblock": [
-                                    "If you do not update the Corona-Warn-App to the new version, the verification hotline will still be available for a transitional period (until ??????h), where you can have a TAN issued.",
+                                    "If you do not update the Corona-Warn-App to version 3.0, the verification hotline will still be available for a transitional period (until ??????h), where you can have a TAN issued.",
                                     "After this date, either the test results will only be transmitted directly digitally from the test sites to the CWA, as before, you will then have the opportunity to warn others. Or you will receive the test result by other means. Then you can - after an update to version 3.0 - manually warn others directly using the new function \"Manage Your Tests and Warn Others\".",
-                                    "For all other functions, the new version does not differ from the previous version of the CWA.",
-                                    "See also: <a href='warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
+                                    "For all other functions, the version 3.0 does not differ from the previous version of the CWA.",
+                                    "See also: <a href='#warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
                                 ]
                             },
                             {
-                                "title": "Do I have to do a PCR test after I have warned with a self-test (positive result)?",
+                                "title": "Do I have to do a PCR test after I have warned with a positive self-test?",
                                 "anchor": "warn_without_tan_pcr_after_self_test",
                                 "active": false,
                                 "textblock": [
@@ -462,7 +465,7 @@
                                 "anchor": "warn_without_tan_warn_twice",
                                 "active": false,
                                 "textblock": [
-                                    "The new function allows only one further registered PCR/rapid test after a recorded self-test. If a warning has already been given with the positive self-test, such a further \"official\" test with a positive result would then possibly give some of the contacts a further risk warning.",
+                                    "The new function allows only one further registered PCR test or rapid test after a recorded self-test. If a warning has already been given with the positive self-test, such a further \"official\" test with a positive result would then possibly give some of the contacts a further risk warning.",
                                     "However, we still recommend that after a positive self-test, people behave sensibly on their own responsibility so that no other people are infected. Then further warnings are no longer necessary."
                                 ]
                             },
@@ -471,8 +474,8 @@
                                 "anchor": "warn_without_tan_still_positive",
                                 "active": false,
                                 "textblock": [
-                                    "In order to avoid misuse or to minimize that unnecessary warnings are triggered which are not based on real risk contacts at all, it was decided that a user can warn others with the new function only once within a certain period of time.",
-                                    "After this time period has elapsed, it is then possible to warn again based on a positive test in the app.",
+                                    "In order to avoid misuse of the function for pointless initiation of warnings that are not based on real risk contacts at all, it was decided that a user can only warn others with the new function once within a certain period of time.",
+                                    "After this time period has elapsed, it is then possible to warn again based on a test that was registered in the app without a TAN.",
                                     "However, we still recommend that after a positive self-test, you behave sensibly on your own responsibility so that no other persons are infected."
                                 ]
                             },
@@ -485,11 +488,11 @@
                                 ]
                             },
                             {
-                                "title": "How often can I warn?",
+                                "title": "How often can I warn without TAN?",
                                 "anchor": "warn_without_tan_how_often",
                                 "active": false,
                                 "textblock": [
-                                    "Within a certain period you can warn once without TAN. After this blocking period has expired, you can warn again. In principle, there are no upper limits to how often you can warn, as long as these intervals are not undercut. However, we hope of course that there is no need for you to warn again and again at even shorter intervals."
+                                    "Within a certain period you can warn once without TAN. After the blocking period has expired, you can warn again without a TAN. In principle, there are no upper limits to how often you can warn without a TAN, as long as the intervals are not undercut."
                                 ]
                             },
                             {
@@ -501,7 +504,7 @@
                                 ]
                             },
                             {
-                                "title": "I was checked into a restaurant (at an event) via QR code. Can I warn the guests of the event with the new function? Will I remain anonymous in the process?",
+                                "title": "I was checked in to an event via QR code. Can I warn the guests of the event with the function? Will I remain anonymous in the process?",
                                 "anchor": "warn_without_tan_event",
                                 "active": false,
                                 "textblock": [
@@ -509,20 +512,20 @@
                                 ]
                             },
                             {
-                                "title": "Do I have to go into quarantine/isolation after a positive (self-)test?",
-                                "anchor": "warn_without_tan_quarantine",
+                                "title": "Do I have to go into isolation after a positive (self-)test?",
+                                "anchor": "warn_without_tan_isolation",
                                 "active": false,
                                 "textblock": [
                                     "After each positive test, we recommend, for the sake of personal responsibility, to first minimize contacts as far as possible and to contact your trusted doctor or the public health department to coordinate further steps.",
-                                    "Current quarantine rules are based on the IfSG and local applicable regulations."
+                                    "Current isolation rules are based on the IfSG and local applicable regulations."
                                 ]
                             },
                             {
-                                "title": "If I have another negative rapid test, can I end the quarantine?",
+                                "title": "If I have another negative rapid test, can I end the isolation?",
                                 "anchor": "warn_without_tan_negative",
                                 "active": false,
                                 "textblock": [
-                                    "The Corona-Warn-App cannot make a medical diagnosis of whether you are infected or not. Therefore, please clarify the question of ending the quarantine with the responsible health department or your doctor."
+                                    "The Corona-Warn-App cannot make a medical diagnosis of whether you are infected or not. Therefore, please clarify the question of ending the isolation with the responsible health department or your doctor."
                                 ]
                             },
                             {
@@ -532,7 +535,7 @@
                                 "textblock": [
                                     "Yes, if you register a positive test result (even without a TAN) in the Corona-Warn-App, this test will also be entered in the contact journal as before. This happens regardless of the type of test.",
                                     "If you manually warn other CWA users directly via the new function \"Manage Your Tests and Warn Others\", no test will be registered in the app, but it will be documented in the journal that you have warned others.",
-                                    "See also: <a href='warn_for_others_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
+                                    "See also: <a href='#warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
                                 ]
                             },
                             {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -377,6 +377,217 @@
                         ]
                     },
                     {
+                        "title": "Warning without TAN",
+                        "id": "warning_without_tan",
+                        "indexed": false,
+                        "accordion": [
+                            {
+                                "title": "Information about warning without TAN",
+                                "anchor": "warn_without_tan",
+                                "active": false,
+                                "textblock": [
+                                    "Here you can find a short summary of relevant FAQ articles covering the topic \"Warning without TAN\":",
+                                    "Did you receive an error notification in the app? <ul><li><a href='#warn_without_tan_error' target='_blank'>Error message \"You Cannot Warn Others\": Why can't I warn others at the moment?</a></li></ul>",
+                                    "How does warning without TAN work? <ul><li>Step-by-step guide: <a href='#warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a></li><li><a href='#warn_without_tan_how_often' target='_blank'>How often can I warn?</a></li><li><a href='#warn_without_tan_hotline' target='_blank'>Do I still have to call the hotline?</a></li><li><a href='#warn_without_tan_version' target='_blank'>Do I need to upgrade to the new release, or will my current version of CWA continue to run?</a></li><li><a href='#warn_without_tan_photo' target='_blank'>Do I need to take a picture of my test to prove the test?</a></li><li><a href='#warn_without_tan_risk_assessment_different' target='_blank'>Does the risk calculation for an alert on my smartphone differ by test type from the person who tested positive?</a></ul>",
+                                    "For an overview of all FAQ articles on the topic \"Warning without TAN\" you can filter for them in the section menu on the left, or follow this link: <a href='#warning_without_tan' target='_blank'>Warning without TAN</a>"
+                                ]
+                            },
+                            {
+                                "title": "How can I warn other users if I have tested positive?",
+                                "anchor": "warn_without_tan_how_to",
+                                "active": false,
+                                "textblock": [
+                                    "Note that you should only warn others based on your own positive test result.",
+                                    "If you installed the app just recently, you may not yet be able to warn without a TAN. This is to prevent misuse. If necessary, try again at a later time.",
+                                    "Follow these step-by-step instructions to send an warning to other users of the Corona-Warn-App: <ul><li>Tap on the \"Status\" tab.</li><li>In the \"Manage Your Tests and Warn Others\" tile, tap \"Continue\".</li><li>Tap \"Positive self-test?\" if you have a positive self-test result.</li><li>Tap \"Positive test and no result in the app?\" if you have a positive result from another test type.</li><li>Under the consent form, tap \"Accept\" to continue.</li><li>Unless you want to warn with a positive self-test result, you now have the option to specify the type of test performed. Tap on the appropriate test or alternatively on \"No answer\".</li><li>Provided that you have past check-ins, these can be selected afterwards to warn specifically also the participants of this event.</li><li>You can now specify whether you had symptoms. Should you tap \"Yes\", you can then provide information about the symptom start.</li><li>Confirm that you want to warn by tapping \"Warn others\".</li><li>Finally, the \"Thank you\" screen provides you with further instructions. Tapping \"Done\" will take you back to the \"Status\" tab of the Corona-Warn-App.</li></ul>"
+                                ]
+                            },
+                            {
+                                "title": "Error message \"You Cannot Warn Others\": Why can't I warn others at the moment?",
+                                "anchor": "warn_without_tan_error",
+                                "active": false,
+                                "textblock": [
+                                    "You cannot warn others under the following circumstances: <ul><li>You have installed the app just a short time ago.</li><li>Not enough time has passed since your last warning.</li></ul>",
+                                    "These are precautions that have been taken to avoid misuse of this feature. Note that you can still warn with positive test results that you receive in your app."
+                                ]
+                            },
+                            {
+                                "title": "Will the results still be transferred digitally to the app despite the new function?",
+                                "anchor": "warn_without_tan_digital_result",
+                                "active": false,
+                                "textblock": [
+                                    "Of course; as long as the test site or the commissioned laboratory are technically connected to the infrastructure, the results of the detection tests can continue to be provided digitally for the Corona-Warn-App. For the users of the CWA, this function does not change. The previous procedure is merely extended by the new function in order to be able to warn with all types of tests and thus to interrupt even more contact chains in a timely manner."
+                                ]
+                            },
+                            {
+                                "title": "I got my positive result via alternative ways (email, phone call...), but no result in the app - can I still warn my contacts?",
+                                "anchor": "warn_without_tan_external_result",
+                                "active": false,
+                                "textblock": [
+                                    "Yes, use the new function \"Manage Your Tests and Warn Others\" as of version 3.0; this may require an update of the app.",
+                                    "Use it to warn others based on the received positive result manually in the CWA.",
+                                    "See: <a href='warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
+                                ]
+                            },
+                            {
+                                "title": "Do I still have to call the hotline?",
+                                "anchor": "warn_without_tan_hotline",
+                                "active": false,
+                                "textblock": [
+                                    "No, as of version 3.0 of the Corona-Warn-App, it is no longer necessary to call the verification hotline."
+                                ]
+                            },
+                            {
+                                "title": "Do I need to upgrade to the new release, or will my current version of CWA continue to run?",
+                                "anchor": "warn_without_tan_version",
+                                "active": false,
+                                "textblock": [
+                                    "If you do not update the Corona-Warn-App to the new version, the verification hotline will still be available for a transitional period (until ??????h), where you can have a TAN issued.",
+                                    "After this date, either the test results will only be transmitted directly digitally from the test sites to the CWA, as before, you will then have the opportunity to warn others. Or you will receive the test result by other means. Then you can - after an update to version 3.0 - manually warn others directly using the new function \"Manage Your Tests and Warn Others\".",
+                                    "For all other functions, the new version does not differ from the previous version of the CWA.",
+                                    "See also: <a href='warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
+                                ]
+                            },
+                            {
+                                "title": "Do I have to do a PCR test after I have warned with a self-test (positive result)?",
+                                "anchor": "warn_without_tan_pcr_after_self_test",
+                                "active": false,
+                                "textblock": [
+                                    "From an epidemiological point of view, a PCR test is of course significantly more accurate and informative than a self-test performed by non-professionals. Therefore, a PCR test is recommended for confirmation (or verification of any false positives) of the self-test.",
+                                    "Therefore, in order to comply with local regulations, we recommend that after a positive self-test, they contact their local health department or trusted doctor to discuss further action."
+                                ]
+                            },
+                            {
+                                "title": "What happens if I warn again with a positive PCR test after a positive self-test? Is that even possible?",
+                                "anchor": "warn_without_tan_warn_twice",
+                                "active": false,
+                                "textblock": [
+                                    "The new function allows only one further registered PCR/rapid test after a recorded self-test. If a warning has already been given with the positive self-test, such a further \"official\" test with a positive result would then possibly give some of the contacts a further risk warning.",
+                                    "However, we still recommend that after a positive self-test, people behave sensibly on their own responsibility so that no other people are infected. Then further warnings are no longer necessary."
+                                ]
+                            },
+                            {
+                                "title": "A few days after the last positive test, I am still positive on the self-test. Should I warn again? Why does it not work the second time?",
+                                "anchor": "warn_without_tan_still_positive",
+                                "active": false,
+                                "textblock": [
+                                    "In order to avoid misuse or to minimize that unnecessary warnings are triggered which are not based on real risk contacts at all, it was decided that a user can warn others with the new function only once within a certain period of time.",
+                                    "After this time period has elapsed, it is then possible to warn again based on a positive test in the app.",
+                                    "However, we still recommend that after a positive self-test, you behave sensibly on your own responsibility so that no other persons are infected."
+                                ]
+                            },
+                            {
+                                "title": "Do I need to take a picture of my test to prove the test?",
+                                "anchor": "warn_without_tan_photo",
+                                "active": false,
+                                "textblock": [
+                                    "No, the Corona-Warn-App does not provide for uploading photos or other documents to prove that a test really took place, or to process them in any other way. We deliberately rely on the prudence and personal responsibility of our users."
+                                ]
+                            },
+                            {
+                                "title": "How often can I warn?",
+                                "anchor": "warn_without_tan_how_often",
+                                "active": false,
+                                "textblock": [
+                                    "Within a certain period you can warn once without TAN. After this blocking period has expired, you can warn again. In principle, there are no upper limits to how often you can warn, as long as these intervals are not undercut. However, we hope of course that there is no need for you to warn again and again at even shorter intervals."
+                                ]
+                            },
+                            {
+                                "title": "Can I warn on behalf of family members, such as my infected child?",
+                                "anchor": "warn_without_tan_family",
+                                "active": false,
+                                "textblock": [
+                                    "No, this is not technically possible because the risk contacts of the person tested positive were not necessarily also recorded on their smartphone by contact tracing. Warning for others from your smartphone would therefore not reach these contacts at all, but only your (i.e. the wrong) contacts."
+                                ]
+                            },
+                            {
+                                "title": "I was checked into a restaurant (at an event) via QR code. Can I warn the guests of the event with the new function? Will I remain anonymous in the process?",
+                                "anchor": "warn_without_tan_event",
+                                "active": false,
+                                "textblock": [
+                                    "Yes, if you have checked in via event QR code, you can continue to warn the other guests during the period of your check-in. As before, your identity remains anonymous."
+                                ]
+                            },
+                            {
+                                "title": "Do I have to go into quarantine/isolation after a positive (self-)test?",
+                                "anchor": "warn_without_tan_quarantine",
+                                "active": false,
+                                "textblock": [
+                                    "After each positive test, we recommend, for the sake of personal responsibility, to first minimize contacts as far as possible and to contact your trusted doctor or the public health department to coordinate further steps.",
+                                    "Current quarantine rules are based on the IfSG and local applicable regulations."
+                                ]
+                            },
+                            {
+                                "title": "If I have another negative rapid test, can I end the quarantine?",
+                                "anchor": "warn_without_tan_negative",
+                                "active": false,
+                                "textblock": [
+                                    "The Corona-Warn-App cannot make a medical diagnosis of whether you are infected or not. Therefore, please clarify the question of ending the quarantine with the responsible health department or your doctor."
+                                ]
+                            },
+                            {
+                                "title": "Will the positive test result or warning be noted in my contact journal?",
+                                "anchor": "warn_without_tan_contact_journal",
+                                "active": false,
+                                "textblock": [
+                                    "Yes, if you register a positive test result (even without a TAN) in the Corona-Warn-App, this test will also be entered in the contact journal as before. This happens regardless of the type of test.",
+                                    "If you manually warn other CWA users directly via the new function \"Manage Your Tests and Warn Others\", no test will be registered in the app, but it will be documented in the journal that you have warned others.",
+                                    "See also: <a href='warn_for_others_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
+                                ]
+                            },
+                            {
+                                "title": "Can I get an official digital certificate for a self-test?",
+                                "anchor": "warn_without_tan_self_test_certificate",
+                                "active": false,
+                                "textblock": [
+                                    "No, Europe-wide digital certificates are not provided for self-tests. Test certificates can only be issued for supervised PCR tests (except PoC-NAT PCR tests) and supervised rapid tests."
+                                ]
+                            },
+                            {
+                                "title": "Can I use a registered positive test result as a sickness certificate?",
+                                "anchor": "warn_without_tan_sickness_certificate",
+                                "active": false,
+                                "textblock": [
+                                    "No, alerting others with the new \"Manage Your Tests and Warn Others\" feature does not result in the display of a positive test result in the Corona-Warn-App at all. Aside from that, displaying it in the CWA is not permitted by labor law for sick leave or work/school release. Please contact the doctor you trust or the responsible health office."
+                                ]
+                            },
+                            {
+                                "title": "How long will the test remain visible in the app?",
+                                "anchor": "warn_without_tan_in_app_display",
+                                "active": false,
+                                "textblock": [
+                                    "Warning others with the new \"Manage Your Tests and Warn Others\" feature does not display a positive test result in the Corona-Warn-App at all.",
+                                    "For tests that are registered in the app as before, the same still applies: Tests always represent only a snapshot in the diagnosis of infectious diseases, they are therefore not valid indefinitely. After 72 hours, a registered test will therefore be grayed out as \"out of date\" in the Corona-Warn-App."
+                                ]
+                            },
+                            {
+                                "title": "After sharing the positive result, does my risk assessment stop? How long?",
+                                "anchor": "warn_without_tan_risk_assessment",
+                                "active": false,
+                                "textblock": [
+                                    "No, risk assessment and the contact tracing protocol are not stopped. Warning others with the new \"Manage Your Tests and Warn Others\" feature does not affect risk assessment.",
+                                    "If you are out in public despite testing positive, please be mindful of spacing and hygiene rules and, if possible, wear a mask to reduce a risk of infection to others."
+                                ]
+                            },
+                            {
+                                "title": "Does the risk calculation for an alert on my smartphone differ by test type from the person who tested positive?",
+                                "anchor": "warn_without_tan_risk_assessment_different",
+                                "active": false,
+                                "textblock": [
+                                    "No, the procedure for calculating the risk of infection has not been changed. Regardless of the type of test used to detect infection, the same parameters apply when calculating the risk for others."
+                                ]
+                            },
+                            {
+                                "title": "Does a warning based on the new feature disappear from the app by itself, or do I have to delete it independently?",
+                                "anchor": "warn_without_tan_warning",
+                                "active": false,
+                                "textblock": [
+                                    "No, this is not necessary. After a period of 10 days at the most, the warning in the app is automatically reset because the time window for the risk warnings is then also expired."
+                                ]
+                            }
+                        ]
+                    },
+                    {
                         "title": "Certificates",
                         "id": "eu_dcc",
                         "indexed": true,

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -533,8 +533,9 @@
                                 "anchor": "warn_without_tan_contact_journal",
                                 "active": false,
                                 "textblock": [
-                                    "Yes, if you register a positive test result (even without a TAN) in the Corona-Warn-App, this test will also be entered in the contact journal as before. This happens regardless of the type of test.",
-                                    "If you manually warn other CWA users directly via the new function \"Manage Your Tests and Warn Others\", no test will be registered in the app, but it will be documented in the journal that you have warned others.",
+                                    "If you have entered the result of a PCR test or rapid test into the Corona-Warn-App using a QR code or TAN, a corresponding entry appears in the contact journal.",
+                                    "If you manually warn other CWA users directly using the \"Manage Your Tests and Warn Others\" feature, no test will be registered in the app, so no corresponding entry will be created in the contact journal.",
+                                    "Regardless of the type of test and how it was registered, you will see the date of the warning in the contact journal.",
                                     "See also: <a href='#warn_without_tan_how_to' target='_blank'>How can I warn other users if I have tested positive?</a>"
                                 ]
                             },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -398,7 +398,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Beachten Sie, dass Sie nur aufgrund Ihres eigenen positiven Testergebnisses andere warnen sollten.",
-                                    "Wenn Sie die App erst vor unmittelbarer Zeit installiert haben, kann es vorkommen, dass Sie noch nicht ohne TAN warnen können. Dies dient der Missbrauchsprävention. Versuchen Sie es gegebenenfalls zu einem späteren Zeitpunkt erneut.",
+                                    "Wenn Sie die App erst vor kurzer Zeit installiert haben, kann es vorkommen, dass Sie noch nicht ohne TAN warnen können. Dies dient der Missbrauchsprävention. Versuchen Sie es gegebenenfalls zu einem späteren Zeitpunkt erneut.",
                                     "Folgen Sie dieser Schritt-für-Schritt Anleitung, um eine Warnung an andere Nutzer der Corona-Warn-App zu schicken: <ul><li>Tippen Sie auf den \"Status\"-Reiter.</li><li>Tippen Sie in der \"Tests erfassen und andere warnen\"-Kachel auf \"Weiter\".</li><li>Tippen Sie auf \"Selbsttest positiv?\", wenn Ihnen ein positives Selbsttestergebnis vorliegt.</li><li>Tippen Sie auf \"Test positiv und kein Ergebnis in der App?\", wenn Ihnen ein positives Ergebnis einer anderen Testart vorliegt.</li><li>Tippen Sie unter der Einverständniserklärung auf \"Einverstanden\" um fortzufahren.</li><li>Sofern Sie nicht mit einem positiven Selbsttestergebnis warnen möchten, haben Sie nun die Möglichkeit, die Art des durchgeführten Tests anzugeben. Tippen Sie auf den passenden Test oder alternativ auf \"Keine Angabe\".</li><li>Sofern Sie vergangene Check-ins haben, können diese im Anschluss ausgewählt werden, um gezielt auch die Teilnehmer dieser Veranstaltung zu warnen.</li><li>Sie können nun angeben, ob Sie Symptome hatten. Sollten Sie \"Ja\" antippen, können Sie daraufhin Angaben zu dem Symptom-Beginn machen.</li><li>Bestätigen Sie, dass Sie warnen möchten, indem Sie auf \"Andere warnen\" tippen.</li><li>Abschließend finden Sie auf der \"Vielen Dank\"-Ansicht weitere Hinweise. Durch das Tippen auf \"Fertig\" gelangen Sie zurück zum \"Status\"-Reiter der Corona-Warn-App.</li></ul>"
                                 ]
                             },
@@ -407,8 +407,8 @@
                                 "anchor": "warn_without_tan_error",
                                 "active": false,
                                 "textblock": [
-                                    "Unter folgenden Umständen können Sie andere nicht warnen: <ul><li>Sie haben die App erst vor unmittelbarer Zeit installiert.</li><li>Seit Ihrer letzten Warnung ist nicht genügend Zeit verstrichen.</li></ul>",
-                                    "Es handelt sich hierbei um Vorkehrungen, die getroffen worden sind, um Missbrauch dieser Funktion zu vermeiden. Beachten Sie, dass Sie mit positiven Testergebnissen, die Sie in Ihrer App erhalten, trotzdem warnen können."
+                                    "Unter folgenden Umständen können Sie andere nicht warnen: <ul><li>Sie haben die App erst vor kurzer Zeit installiert.</li><li>Seit Ihrer letzten Warnung ist nicht genügend Zeit verstrichen.</li></ul>",
+                                    "Es handelt sich hierbei um Vorkehrungen, die getroffen wurden, um Missbrauch dieser Funktion zu vermeiden. Beachten Sie, dass Sie mit positiven Testergebnissen, die Sie durch das Einscannen eines QR-Codes in Ihrer App erhalten, trotzdem warnen können."
                                 ]
                             },
                             {
@@ -420,11 +420,11 @@
                                 ]
                             },
                             {
-                                "title": "Ich habe mein positives Ergebnis aus anderem Wege erfahren (E-Mail, Telefonat…), aber kein Ergebnis in der App – kann ich trotzdem meine Kontakte warnen?",
+                                "title": "Ich habe mein positives Ergebnis nicht über die App erhalten – kann ich meine Kontakte trotzdem warnen?",
                                 "anchor": "warn_without_tan_external_result",
                                 "active": false,
                                 "textblock": [
-                                    "Ja, nutzen Sie ab Release 3.0 die neue Funktion \"Tests erfassen und andere warnen\", dazu ist ggf. ein Update der App nötig.",
+                                    "Ja, nutzen Sie ab Version 3.0 die neue Funktion \"Tests erfassen und andere warnen\", dazu ist ggf. ein Update der App nötig.",
                                     "Warnen Sie damit Andere auf Basis des empfangenen positiven Ergebnisses manuell in der CWA.",
                                     "Siehe: <a href='placeholder' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
                                 ]
@@ -434,22 +434,22 @@
                                 "anchor": "warn_without_tan_hotline",
                                 "active": false,
                                 "textblock": [
-                                    "Nein, ab Release 3.0 der Corona-Warn-App ist es nicht mehr notwendig, die Verifikations-Hotline anzurufen."
+                                    "Nein, ab Version 3.0 der Corona-Warn-App ist es nicht mehr notwendig, die Verifikations-Hotline anzurufen."
                                 ]
                             },
                             {
-                                "title": "Muss ich auf das neue Release umsteigen, oder läuft meine aktuelle Version der CWA weiter?",
+                                "title": "Muss ich auf Version 3.0 umsteigen, oder läuft meine aktuelle Version der CWA weiter?",
                                 "anchor": "warn_without_tan_version",
                                 "active": false,
                                 "textblock": [
-                                    "Wenn Sie die Corona-Warn-App nicht auf das neue Release aktualisieren, wird für eine Übergangsfrist (bis zum ??????h) noch die Verifikations-Hotline zur Verfügung stehen, bei der Sie sich eine TAN ausstellen lassen können.",
-                                    "Nach diesem Zeitpunkt werden entweder die Testergebnisse nur noch direkt digital von den Teststellen in die CWA übertragen, wie bisher haben Sie dann die Möglichkeit, andere zu warnen. Oder Sie erhalten das Testergebnis auf anderem Wege. Dann können Sie – nach einem Update auf Release 3.0 – manuell mit der neuen Funktion \"Tests erfassen und andere warnen\" andere direkt warnen.",
-                                    "Für alle anderen Funktionen unterscheidet sich das neue Release von der vorherigen Version der CWA nicht.",
+                                    "Wenn Sie die Corona-Warn-App nicht auf Version 3.0 aktualisieren, wird für eine Übergangsfrist (bis zum ??????h) noch die Verifikations-Hotline zur Verfügung stehen, bei der Sie sich eine TAN ausstellen lassen können.",
+                                    "Nach diesem Zeitpunkt werden entweder die Testergebnisse nur noch direkt digital von den Teststellen in die CWA übertragen, wie bisher haben Sie dann die Möglichkeit, andere zu warnen. Oder Sie erhalten das Testergebnis auf anderem Wege. Dann können Sie – nach einem Update auf Version 3.0 – manuell mit der Funktion \"Tests erfassen und andere warnen\" andere direkt warnen.",
+                                    "Für alle anderen Funktionen unterscheidet sich Version 3.0 von der vorherigen Version der CWA nicht.",
                                     "Siehe auch: <a href='placeholder' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
                                 ]
                             },
                             {
-                                "title": "Muss ich einen PCR-Test machen, nachdem ich mit einem Selbsttest (positives Ergebnis) gewarnt habe?",
+                                "title": "Muss ich einen PCR-Test machen, nachdem ich mit einem positiven Selbsttest gewarnt habe?",
                                 "anchor": "warn_without_tan_pcr_after_self_test",
                                 "active": false,
                                 "textblock": [
@@ -462,7 +462,7 @@
                                 "anchor": "warn_without_tan_warn_twice",
                                 "active": false,
                                 "textblock": [
-                                    "Die neue Funktion lässt nach einem erfassten Selbsttest nur noch einen weiteren registrierten PCR-/Schnelltest-Test zu. Falls mit dem positiven Selbsttest schon gewarnt wurde, würden durch einen solchen weiteren „offiziellen“ Test mit positivem Ergebnis dann ggf. einige der Kontakte eine weitere Risikowarnung erhalten.",
+                                    "Die neue Funktion lässt nach einem erfassten Selbsttest nur noch einen weiteren registrierten PCR-Test oder Schnelltest zu. Falls mit dem positiven Selbsttest schon gewarnt wurde, würden durch einen solchen weiteren „offiziellen“ Test mit positivem Ergebnis dann ggf. einige der Kontakte eine weitere Risikowarnung erhalten.",
                                     "Wir empfehlen aber weiterhin, sich nach einem positiven Selbsttest eigenverantwortlich so vernünftig zu verhalten, dass keine anderen Personen angesteckt werden. Dann sind weitere Warnungen auch nicht mehr nötig."
                                 ]
                             },
@@ -471,8 +471,8 @@
                                 "anchor": "warn_without_tan_still_positive",
                                 "active": false,
                                 "textblock": [
-                                    "Um einen Missbrauch zu vermeiden oder zu minimieren, dass sinnlose Warnungen getriggert werden, die gar nicht auf realen Risikokontakten beruhen, wurde entscheiden, dass ein Anwender mit der neuen Funktion nur einmal innerhalb einer bestimmten Zeitspanne Andere warnen kann.",
-                                    "Nach Ablauf dieser Zeitspanne ist es dann wieder möglich, auf Basis eines positiven Tests in der App zu warnen.",
+                                    "Um eine missbräuchliche Nutzung der Funktion zum sinnlosen Auslösen von Warnungen, die gar nicht auf realen Risikokontakten beruhen, zu vermeiden, wurde entscheiden, dass ein Anwender mit der neuen Funktion nur einmal innerhalb einer bestimmten Zeitspanne Andere warnen kann.",
+                                    "Nach Ablauf dieser Zeitspanne ist es dann wieder möglich, auf Basis eines Tests, der ohne TAN in der App registriert wurde, zu warnen.",
                                     "Wir empfehlen aber weiterhin, sich nach einem positiven Selbsttest eigenverantwortlich so vernünftig zu verhalten, dass keine anderen Personen angesteckt werden."
                                 ]
                             },
@@ -485,11 +485,11 @@
                                 ]
                             },
                             {
-                                "title": "Wie oft kann ich warnen?",
+                                "title": "Wie oft kann ich ohne TAN warnen?",
                                 "anchor": "warn_without_tan_how_often",
                                 "active": false,
                                 "textblock": [
-                                    "Innerhalb einer bestimmten Periode können Sie einmal ohne TAN warnen. Nach Ablauf dieser Sperrfrist können Sie erneut warnen. Grundsätzlich gibt es nach oben keine Grenzen, wie oft Sie warnen können, solange diese Abstände nicht unterschritten werden. Wir hoffen aber natürlich, dass es keine Notwendigkeit für Sie gibt, in noch kürzeren Abständen immer wieder neu zu warnen."
+                                    "Innerhalb eines bestimmten Zeitraums können Sie einmal ohne TAN warnen. Nach Ablauf der Sperrfrist können Sie erneut ohne TAN warnen. Grundsätzlich gibt es nach oben keine Grenzen, wie oft Sie ohne TAN warnen können, solange die Abstände nicht unterschritten werden."
                                 ]
                             },
                             {
@@ -505,24 +505,24 @@
                                 "anchor": "warn_without_tan_event",
                                 "active": false,
                                 "textblock": [
-                                    "Ja, wenn Sie sich per Event-QR-Code eingecheckt haben, können Sie den Zeitraum Ihres Check-ins die anderen Gäste weiterhin warnen. Dabei bleibt, wie bisher, Ihre Identität anonym."
+                                    "Ja, wenn Sie sich per Event-QR-Code eingecheckt haben, können Sie in dem Zeitraum Ihres Check-ins die anderen Gäste weiterhin warnen. Dabei bleibt, wie bisher, Ihre Identität anonym."
                                 ]
                             },
                             {
-                                "title": "Muss ich nach einem positiven (Selbst-)Test in Quarantäne/Isolation?",
-                                "anchor": "warn_without_tan_quarantine",
+                                "title": "Muss ich nach einem positiven (Selbst-)Test in Isolation?",
+                                "anchor": "warn_without_tan_isolation",
                                 "active": false,
                                 "textblock": [
                                     "Nach jedem positiven Test empfehlen wir im Sinne der Eigenverantwortung, zunächst Kontakte weitgehend zu minimieren und mit dem Arzt Ihres Vertrauens oder dem Gesundheitsamt Kontakt aufzunehmen und die weiteren Schritte abzustimmen.",
-                                    "Die aktuellen Quarantäne-Regeln richten sich nach dem IfSG und nach den lokalen geltenden Bestimmungen."
+                                    "Die aktuellen Isolations-Regeln richten sich nach dem IfSG und nach den lokalen geltenden Bestimmungen."
                                 ]
                             },
                             {
-                                "title": "Wenn ich wieder einen negativen Schnelltest habe, kann ich die Quarantäne dann beenden?",
+                                "title": "Wenn ich wieder einen negativen Schnelltest habe, kann ich die Isolation dann beenden?",
                                 "anchor": "warn_without_tan_negative",
                                 "active": false,
                                 "textblock": [
-                                    "Die Corona-Warn-App kann keine medizinische Diagnose stellen, ob Sie infiziert sind oder nicht. Daher klären Sie bitte die Frage der Beendigung der Quarantäne mit dem zuständigen Gesundheitsamt bzw. Ihrem Arzt."
+                                    "Die Corona-Warn-App kann keine medizinische Diagnose stellen, ob Sie infiziert sind oder nicht. Daher klären Sie bitte die Frage der Beendigung der Isolation mit dem zuständigen Gesundheitsamt bzw. Ihrem Arzt."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -379,7 +379,7 @@
                     {
                         "title": "Warnen ohne TAN",
                         "id": "warning_without_tan",
-                        "indexed": false,
+                        "indexed": true,
                         "accordion": [
                             {
                                 "title": "Informationen zum Warnen ohne TAN",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -350,6 +350,9 @@
                                 ]
                             },
                             {
+                                "duplicate": "warn_without_tan_family"
+                            },
+                            {
                                 "title": "Wie kann ich in Vertretung warnen?",
                                 "anchor": "warn_for_others",
                                 "active": false,
@@ -397,9 +400,8 @@
                                 "anchor": "warn_without_tan_how_to",
                                 "active": false,
                                 "textblock": [
-                                    "Beachten Sie, dass Sie nur aufgrund Ihres eigenen positiven Testergebnisses andere warnen sollten.",
                                     "Wenn Sie die App erst vor kurzer Zeit installiert haben, kann es vorkommen, dass Sie noch nicht ohne TAN warnen können. Dies dient der Missbrauchsprävention. Versuchen Sie es gegebenenfalls zu einem späteren Zeitpunkt erneut.",
-                                    "Folgen Sie dieser Schritt-für-Schritt Anleitung, um eine Warnung an andere Nutzer der Corona-Warn-App zu schicken: <ul><li>Tippen Sie auf den \"Status\"-Reiter.</li><li>Tippen Sie in der \"Tests erfassen und andere warnen\"-Kachel auf \"Weiter\".</li><li>Tippen Sie auf \"Selbsttest positiv?\", wenn Ihnen ein positives Selbsttestergebnis vorliegt.</li><li>Tippen Sie auf \"Test positiv und kein Ergebnis in der App?\", wenn Ihnen ein positives Ergebnis einer anderen Testart vorliegt.</li><li>Tippen Sie unter der Einverständniserklärung auf \"Einverstanden\" um fortzufahren.</li><li>Sofern Sie nicht mit einem positiven Selbsttestergebnis warnen möchten, haben Sie nun die Möglichkeit, die Art des durchgeführten Tests anzugeben. Tippen Sie auf den passenden Test oder alternativ auf \"Keine Angabe\".</li><li>Sofern Sie vergangene Check-ins haben, können diese im Anschluss ausgewählt werden, um gezielt auch die Teilnehmer dieser Veranstaltung zu warnen.</li><li>Sie können nun angeben, ob Sie Symptome hatten. Sollten Sie \"Ja\" antippen, können Sie daraufhin Angaben zu dem Symptom-Beginn machen.</li><li>Bestätigen Sie, dass Sie warnen möchten, indem Sie auf \"Andere warnen\" tippen.</li><li>Abschließend finden Sie auf der \"Vielen Dank\"-Ansicht weitere Hinweise. Durch das Tippen auf \"Fertig\" gelangen Sie zurück zum \"Status\"-Reiter der Corona-Warn-App.</li></ul>"
+                                    "Folgen Sie dieser Schritt-für-Schritt Anleitung, um eine Warnung aufgrund Ihres eigenen positiven Testergebnisses an andere Nutzer der Corona-Warn-App zu senden: <ol><li>Tippen Sie auf den \"Status\"-Reiter.</li><li>Tippen Sie in der \"Tests erfassen und andere warnen\"-Kachel auf \"Weiter\".</li><li>Tippen Sie auf \"Selbsttest positiv?\", wenn Ihnen ein positives Selbsttestergebnis vorliegt.</li><li>Tippen Sie auf \"Test positiv und kein Ergebnis in der App?\", wenn Ihnen ein positives Ergebnis einer anderen Testart vorliegt.</li><li>Tippen Sie unter der Einverständniserklärung auf \"Einverstanden\" um fortzufahren.</li><li>Sofern Sie nicht mit einem positiven Selbsttestergebnis warnen möchten, haben Sie nun die Möglichkeit, die Art des durchgeführten Tests anzugeben. Tippen Sie auf den passenden Test oder alternativ auf \"Keine Angabe\".</li><li>Sofern Sie vergangene Check-ins haben, können diese im Anschluss ausgewählt werden, um gezielt auch die Teilnehmer dieser Veranstaltung zu warnen.</li><li>Sie können nun angeben, ob Sie Symptome hatten. Sollten Sie \"Ja\" antippen, können Sie daraufhin Angaben zu dem Symptom-Beginn machen.</li><li>Bestätigen Sie, dass Sie warnen möchten, indem Sie auf \"Andere warnen\" tippen.</li><li>Abschließend finden Sie auf der \"Vielen Dank\"-Ansicht weitere Hinweise. Durch das Tippen auf \"Fertig\" gelangen Sie zurück zum \"Status\"-Reiter der Corona-Warn-App.</li></ol>"
                                 ]
                             },
                             {
@@ -426,7 +428,7 @@
                                 "textblock": [
                                     "Ja, nutzen Sie ab Version 3.0 die neue Funktion \"Tests erfassen und andere warnen\", dazu ist ggf. ein Update der App nötig.",
                                     "Warnen Sie damit Andere auf Basis des empfangenen positiven Ergebnisses manuell in der CWA.",
-                                    "Siehe: <a href='placeholder' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
+                                    "Siehe: <a href='#warn_without_tan_how_to' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
                                 ]
                             },
                             {
@@ -445,7 +447,7 @@
                                     "Wenn Sie die Corona-Warn-App nicht auf Version 3.0 aktualisieren, wird für eine Übergangsfrist (bis zum ??????h) noch die Verifikations-Hotline zur Verfügung stehen, bei der Sie sich eine TAN ausstellen lassen können.",
                                     "Nach diesem Zeitpunkt werden entweder die Testergebnisse nur noch direkt digital von den Teststellen in die CWA übertragen, wie bisher haben Sie dann die Möglichkeit, andere zu warnen. Oder Sie erhalten das Testergebnis auf anderem Wege. Dann können Sie – nach einem Update auf Version 3.0 – manuell mit der Funktion \"Tests erfassen und andere warnen\" andere direkt warnen.",
                                     "Für alle anderen Funktionen unterscheidet sich Version 3.0 von der vorherigen Version der CWA nicht.",
-                                    "Siehe auch: <a href='placeholder' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
+                                    "Siehe auch: <a href='#warn_without_tan_how_to' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
                                 ]
                             },
                             {
@@ -501,7 +503,7 @@
                                 ]
                             },
                             {
-                                "title": "Ich war in einem Restaurant (auf einem Event) per QR-Code eingecheckt. Kann ich die Gäste des Events mit der neuen Funktion warnen? Bleibe ich dabei anonym?",
+                                "title": "Ich war bei einer Veranstaltung per QR-Code eingecheckt. Kann ich die Gäste des Events mit der Funktion warnen? Bleibe ich dabei anonym?",
                                 "anchor": "warn_without_tan_event",
                                 "active": false,
                                 "textblock": [
@@ -532,7 +534,7 @@
                                 "textblock": [
                                     "Ja, wenn Sie einen positiven Testbefund (auch ohne TAN) in der Corona-Warn-App registrieren, wird dieser Test wie bisher auch im Kontakt-Tagebuch eingetragen. Das geschieht unabhängig von der Art des Tests.",
                                     "Wenn Sie manuell über die neue Funktion \"Tests erfassen und andere warnen\" andere CWA-Anwender*innen direkt warnen, wird zwar kein Test in der App registriert, aber im Tagebuch dokumentiert, dass Sie Andere gewarnt haben.",
-                                    "Siehe auch: <a href='placeholder' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
+                                    "Siehe auch: <a href='#warn_without_tan_how_to' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -567,7 +567,7 @@
                                 "anchor": "warn_without_tan_risk_assessment",
                                 "active": false,
                                 "textblock": [
-                                    "Nein, die Risiko-Ermittlung wird nicht gestoppt. Die Corona-Warn-App zeichnet also weiterhin ihre Kontakte auf und sendet Zufalls-IDs aus. Die Warnung anderer mit der Funktion \"Tests erfassen und andere warnen\" hat also keine Auswirkungen auf die Risiko-Ermittlung.",
+                                    "Nein, die Risiko-Ermittlung wird nicht gestoppt. Die Corona-Warn-App zeichnet also weiterhin Ihre Kontakte auf und sendet Zufalls-IDs aus. Die Warnung anderer mit der Funktion \"Tests erfassen und andere warnen\" hat also keine Auswirkungen auf die Risiko-Ermittlung.",
                                     "Wenn Sie sich trotz positiven Tests in der Öffentlichkeit bewegen, achten Sie bitte auf die Abstands- und Hygieneregeln und tragen Sie, wenn möglich, eine Maske zur Verringerung der Infektionsgefahr für andere."
                                 ]
                             },
@@ -580,11 +580,12 @@
                                 ]
                             },
                             {
-                                "title": "Verschwindet eine Warnung auf Basis der neuen Funktion von selbst von der App, oder muss ich sie selbständig löschen?",
-                                "anchor": "warn_without_tan_warning",
+                                "title": "Können Warnungen verschiedener Testarten unterschieden werden?",
+                                "anchor": "warn_without_tan_differentiate_warning",
                                 "active": false,
                                 "textblock": [
-                                    "Nein, das ist nicht nötig. Nach einer Zeitspanne von max. 10 Tagen wird die Warnung in der App automatisch zurückgesetzt, weil dann auch das Zeitfenster für die Risikowarnungen erschöpft ist."
+                                    "Kontaktpersonen erhalten in ihrer Corona-Warn-App eine Warnung über eine Begegnung an einem Tag mit niedrigem (grüne Kachel) oder erhöhtem Risiko (rote Kachel).",
+                                    "Ob die Warnung aufgrund eines Schnelltests bzw. aufgrund eines PCR-Tests erfolgte, dessen Ergebnis per App empfangen wurde, oder aufgrund eines Selbsttests bzw. eines anderweitigen Tests, dessen Ergebnis nicht in der App übermittelt wurde, ist für die gewarnte Person nicht ersichtlich."
                                 ]
                             }
                         ]

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -385,7 +385,7 @@
                         "indexed": true,
                         "accordion": [
                             {
-                                "title": "Informationen zum Warnen ohne TAN",
+                                "title": "Informationen zum Warnen ohne eine TAN",
                                 "anchor": "warn_without_tan",
                                 "active": false,
                                 "textblock": [
@@ -456,7 +456,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Aus epidemiologischer Sicht ist ein PCR-Test natürlich deutlich genauer und aussagekräftiger als ein von Laien durchgeführter Selbsttest. Daher wird zur Bestätigung (bzw. zur Überprüfung von ggf. False-Positives) des Selbsttests ein PCR-Test empfohlen.",
-                                    "Um die lokalen Bestimmungen zu befolgen, empfehlen wir daher, dass sie nach einem positiven Selbsttest Kontakt mit dem zuständigen Gesundheitsamt oder dem Arzt Ihres Vertrauens aufnehmen und das weitere Vorgehen besprechen."
+                                    "Um die lokalen Bestimmungen zu befolgen, empfehlen wir daher, dass Sie nach einem positiven Selbsttest Kontakt mit dem zuständigen Gesundheitsamt oder dem Arzt Ihres Vertrauens aufnehmen und das weitere Vorgehen besprechen."
                                 ]
                             },
                             {
@@ -495,11 +495,11 @@
                                 ]
                             },
                             {
-                                "title": "Kann ich in Vertretung von Familienmitgliedern warnen, z.B. für mein infiziertes Kind?",
+                                "title": "Kann ich in Vertretung von Familienmitgliedern warnen, z.&nbsp;B. für mein infiziertes Kind?",
                                 "anchor": "warn_without_tan_family",
                                 "active": false,
                                 "textblock": [
-                                    "Nein, das ist technisch nicht möglich, weil die Risikokontakte der positiv getesteten Person nicht zwingend durch das Contact Tracing auch auf ihrem Smartphone aufgezeichnet wurden. Eine stellvertretende Warnung von Ihrem Smartphone aus würde daher diese Kontakte gar nicht erreichen, sondern nur Ihre (also die falschen) Kontakte."
+                                    "Nein, das ist technisch nicht möglich, weil die Risikokontakte der positiv getesteten Person nicht zwingend durch das Contact Tracing auch auf Ihrem Smartphone aufgezeichnet wurden. Eine stellvertretende Warnung von Ihrem Smartphone aus würde daher diese Kontakte gar nicht erreichen, sondern nur Ihre (also die falschen) Kontakte."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -532,9 +532,9 @@
                                 "anchor": "warn_without_tan_contact_journal",
                                 "active": false,
                                 "textblock": [
-                                    "Haben Sie das Ergebnis eines PCR-Tests oder Schnelltests mit Hilfe eines QR-Codes oder einer TAN in die Corona-Warn-App eingepflegt, erscheint im Tagebuch ein entsprechender Eintrag.",
-                                    "Wenn Sie manuell über die Funktion \"Tests erfassen und andere warnen\" andere CWA-Anwender*innen direkt warnen, wird kein Test in der App registriert, es wird also auch kein entsprechender Eintrag im Tagebuch erstellt.",
-                                   "Unabhängig von der Art des Tests und wie er registriert wurde, sehen Sie im Tagebuch das Datum der Warnung.",
+                                    "Haben Sie das Ergebnis eines PCR-Tests oder Schnelltests mit Hilfe eines QR-Codes oder einer TAN in die Corona-Warn-App eingepflegt, erscheint im Kontakt-Tagebuch ein entsprechender Eintrag.",
+                                    "Wenn Sie manuell über die Funktion \"Tests erfassen und andere warnen\" andere CWA-Anwender*innen direkt warnen, wird kein Test in der App registriert, es wird also auch kein entsprechender Eintrag im Kontakt-Tagebuch erstellt.",
+                                    "Unabhängig von der Art des Tests und wie er registriert wurde, sehen Sie im Kontakt-Tagebuch das Datum der Warnung.",
                                     "Siehe auch: <a href='#warn_without_tan_how_to' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
                                 ]
                             },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -532,8 +532,9 @@
                                 "anchor": "warn_without_tan_contact_journal",
                                 "active": false,
                                 "textblock": [
-                                    "Ja, wenn Sie einen positiven Testbefund (auch ohne TAN) in der Corona-Warn-App registrieren, wird dieser Test wie bisher auch im Kontakt-Tagebuch eingetragen. Das geschieht unabhängig von der Art des Tests.",
-                                    "Wenn Sie manuell über die neue Funktion \"Tests erfassen und andere warnen\" andere CWA-Anwender*innen direkt warnen, wird zwar kein Test in der App registriert, aber im Tagebuch dokumentiert, dass Sie Andere gewarnt haben.",
+                                    "Haben Sie das Ergebnis eines PCR-Tests oder Schnelltests mit Hilfe eines QR-Codes oder einer TAN in die Corona-Warn-App eingepflegt, erscheint im Tagebuch ein entsprechender Eintrag.",
+                                    "Wenn Sie manuell über die Funktion \"Tests erfassen und andere warnen\" andere CWA-Anwender*innen direkt warnen, wird kein Test in der App registriert, es wird also auch kein entsprechender Eintrag im Tagebuch erstellt.",
+                                   "Unabhängig von der Art des Tests und wie er registriert wurde, sehen Sie im Tagebuch das Datum der Warnung.",
                                     "Siehe auch: <a href='#warn_without_tan_how_to' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
                                 ]
                             },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -377,6 +377,217 @@
                         ]
                     },
                     {
+                        "title": "Warnen ohne TAN",
+                        "id": "warning_without_tan",
+                        "indexed": false,
+                        "accordion": [
+                            {
+                                "title": "Informationen zum Warnen ohne TAN",
+                                "anchor": "warn_without_tan",
+                                "active": false,
+                                "textblock": [
+                                    "Hier finden Sie eine kurze Zusammenfassung an relevanten FAQ-Artikeln, welche das Thema \"Warnen ohne TAN\" behandeln:",
+                                    "Haben Sie eine Fehlermeldung in der App erhalten? <ul><li><a href='#warn_without_tan_error' target='_blank'>Fehlermeldung \"Andere warnen nicht möglich\": Warum kann ich momentan andere nicht warnen?</a></li></ul>",
+                                    "Wie funktioniert das Warnen ohne TAN? <ul><li>Schritt-für-Schritt Anleitung: <a href='#warn_without_tan_how_to' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a></li><li><a href='#warn_without_tan_how_often' target='_blank'>Wie oft kann ich warnen?</a></li><li><a href='#warn_without_tan_hotline' target='_blank'>Muss ich trotzdem die Hotline anrufen?</a></li><li><a href='#warn_without_tan_version' target='_blank'>Muss ich auf das neue Release umsteigen, oder läuft meine aktuelle Version der CWA weiter?</a></li><li><a href='#warn_without_tan_photo' target='_blank'>Muss ich ein Foto meines Tests machen, um den Test nachzuweisen?</a></li><li><a href='#warn_without_tan_risk_assessment_different' target='_blank'>Unterscheidet die Risikokalkulation bei einer Warnung auf meinem Smartphone je nach Test-Art von der positiv getesteten Person?</a></ul>",
+                                    "Für eine Übersicht über alle FAQ-Artikel zum Thema \"Warnen ohne TAN\" können Sie nach diesen links im Sektionsmenü filtern, oder diesem Link folgen: <a href='#warning_without_tan' target='_blank'>Warnen ohne TAN</a>"
+                                ]
+                            },
+                            {
+                                "title": "Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?",
+                                "anchor": "warn_without_tan_how_to",
+                                "active": false,
+                                "textblock": [
+                                    "Beachten Sie, dass Sie nur aufgrund Ihres eigenen positiven Testergebnisses andere warnen sollten.",
+                                    "Wenn Sie die App erst vor unmittelbarer Zeit installiert haben, kann es vorkommen, dass Sie noch nicht ohne TAN warnen können. Dies dient der Missbrauchsprävention. Versuchen Sie es gegebenenfalls zu einem späteren Zeitpunkt erneut.",
+                                    "Folgen Sie dieser Schritt-für-Schritt Anleitung, um eine Warnung an andere Nutzer der Corona-Warn-App zu schicken: <ul><li>Tippen Sie auf den \"Status\"-Reiter.</li><li>Tippen Sie in der \"Tests erfassen und andere warnen\"-Kachel auf \"Weiter\".</li><li>Tippen Sie auf \"Selbsttest positiv?\", wenn Ihnen ein positives Selbsttestergebnis vorliegt.</li><li>Tippen Sie auf \"Test positiv und kein Ergebnis in der App?\", wenn Ihnen ein positives Ergebnis einer anderen Testart vorliegt.</li><li>Tippen Sie unter der Einverständniserklärung auf \"Einverstanden\" um fortzufahren.</li><li>Sofern Sie nicht mit einem positiven Selbsttestergebnis warnen möchten, haben Sie nun die Möglichkeit, die Art des durchgeführten Tests anzugeben. Tippen Sie auf den passenden Test oder alternativ auf \"Keine Angabe\".</li><li>Sofern Sie vergangene Check-ins haben, können diese im Anschluss ausgewählt werden, um gezielt auch die Teilnehmer dieser Veranstaltung zu warnen.</li><li>Sie können nun angeben, ob Sie Symptome hatten. Sollten Sie \"Ja\" antippen, können Sie daraufhin Angaben zu dem Symptom-Beginn machen.</li><li>Bestätigen Sie, dass Sie warnen möchten, indem Sie auf \"Andere warnen\" tippen.</li><li>Abschließend finden Sie auf der \"Vielen Dank\"-Ansicht weitere Hinweise. Durch das Tippen auf \"Fertig\" gelangen Sie zurück zum \"Status\"-Reiter der Corona-Warn-App.</li></ul>"
+                                ]
+                            },
+                            {
+                                "title": "Fehlermeldung \"Andere warnen nicht möglich\": Warum kann ich momentan andere nicht warnen?",
+                                "anchor": "warn_without_tan_error",
+                                "active": false,
+                                "textblock": [
+                                    "Unter folgenden Umständen können Sie andere nicht warnen: <ul><li>Sie haben die App erst vor unmittelbarer Zeit installiert.</li><li>Seit Ihrer letzten Warnung ist nicht genügend Zeit verstrichen.</li></ul>",
+                                    "Es handelt sich hierbei um Vorkehrungen, die getroffen worden sind, um Missbrauch dieser Funktion zu vermeiden. Beachten Sie, dass Sie mit positiven Testergebnissen, die Sie in Ihrer App erhalten, trotzdem warnen können."
+                                ]
+                            },
+                            {
+                                "title": "Werden trotz der neuen Funktion die Ergebnisse auch weiterhin digital in die App übertragen?",
+                                "anchor": "warn_without_tan_digital_result",
+                                "active": false,
+                                "textblock": [
+                                    "Selbstverständlich; sofern die Teststelle bzw. das beauftragte Labor technisch an die Infrastruktur angebunden sind, können auch weiterhin die Ergebnisse der Nachweistests digital für die Corona-Warn-App bereitgestellt werden. Für die Anwender*innen der CWA ändert sich diese Funktion nicht. Das bisherige Verfahren wird durch die neue Funktion lediglich ergänzt, um mit allen Testarten warnen und damit noch mehr Kontaktketten zeitnah unterbrechen zu können."
+                                ]
+                            },
+                            {
+                                "title": "Ich habe mein positives Ergebnis aus anderem Wege erfahren (E-Mail, Telefonat…), aber kein Ergebnis in der App – kann ich trotzdem meine Kontakte warnen?",
+                                "anchor": "warn_without_tan_external_result",
+                                "active": false,
+                                "textblock": [
+                                    "Ja, nutzen Sie ab Release 3.0 die neue Funktion \"Tests erfassen und andere warnen\", dazu ist ggf. ein Update der App nötig.",
+                                    "Warnen Sie damit Andere auf Basis des empfangenen positiven Ergebnisses manuell in der CWA.",
+                                    "Siehe: <a href='placeholder' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
+                                ]
+                            },
+                            {
+                                "title": "Muss ich trotzdem die Hotline anrufen?",
+                                "anchor": "warn_without_tan_hotline",
+                                "active": false,
+                                "textblock": [
+                                    "Nein, ab Release 3.0 der Corona-Warn-App ist es nicht mehr notwendig, die Verifikations-Hotline anzurufen."
+                                ]
+                            },
+                            {
+                                "title": "Muss ich auf das neue Release umsteigen, oder läuft meine aktuelle Version der CWA weiter?",
+                                "anchor": "warn_without_tan_version",
+                                "active": false,
+                                "textblock": [
+                                    "Wenn Sie die Corona-Warn-App nicht auf das neue Release aktualisieren, wird für eine Übergangsfrist (bis zum ??????h) noch die Verifikations-Hotline zur Verfügung stehen, bei der Sie sich eine TAN ausstellen lassen können.",
+                                    "Nach diesem Zeitpunkt werden entweder die Testergebnisse nur noch direkt digital von den Teststellen in die CWA übertragen, wie bisher haben Sie dann die Möglichkeit, andere zu warnen. Oder Sie erhalten das Testergebnis auf anderem Wege. Dann können Sie – nach einem Update auf Release 3.0 – manuell mit der neuen Funktion \"Tests erfassen und andere warnen\" andere direkt warnen.",
+                                    "Für alle anderen Funktionen unterscheidet sich das neue Release von der vorherigen Version der CWA nicht.",
+                                    "Siehe auch: <a href='placeholder' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
+                                ]
+                            },
+                            {
+                                "title": "Muss ich einen PCR-Test machen, nachdem ich mit einem Selbsttest (positives Ergebnis) gewarnt habe?",
+                                "anchor": "warn_without_tan_pcr_after_self_test",
+                                "active": false,
+                                "textblock": [
+                                    "Aus epidemiologischer Sicht ist ein PCR-Test natürlich deutlich genauer und aussagekräftiger als ein von Laien durchgeführter Selbsttest. Daher wird zur Bestätigung (bzw. zur Überprüfung von ggf. False-Positives) des Selbsttests ein PCR-Test empfohlen.",
+                                    "Um die lokalen Bestimmungen zu befolgen, empfehlen wir daher, dass sie nach einem positiven Selbsttest Kontakt mit dem zuständigen Gesundheitsamt oder dem Arzt Ihres Vertrauens aufnehmen und das weitere Vorgehen besprechen."
+                                ]
+                            },
+                            {
+                                "title": "Was passiert, wenn ich nach einem positiven Selbsttest noch einmal mit einem positiven PCR-Test warne? Geht das überhaupt?",
+                                "anchor": "warn_without_tan_warn_twice",
+                                "active": false,
+                                "textblock": [
+                                    "Die neue Funktion lässt nach einem erfassten Selbsttest nur noch einen weiteren registrierten PCR-/Schnelltest-Test zu. Falls mit dem positiven Selbsttest schon gewarnt wurde, würden durch einen solchen weiteren „offiziellen“ Test mit positivem Ergebnis dann ggf. einige der Kontakte eine weitere Risikowarnung erhalten.",
+                                    "Wir empfehlen aber weiterhin, sich nach einem positiven Selbsttest eigenverantwortlich so vernünftig zu verhalten, dass keine anderen Personen angesteckt werden. Dann sind weitere Warnungen auch nicht mehr nötig."
+                                ]
+                            },
+                            {
+                                "title": "Einige Tage nach dem letzten positiven Test bin ich beim Selbsttest noch immer positiv. Soll ich nochmal warnen? Warum funktioniert das beim zweiten Mal nicht?",
+                                "anchor": "warn_without_tan_still_positive",
+                                "active": false,
+                                "textblock": [
+                                    "Um einen Missbrauch zu vermeiden oder zu minimieren, dass sinnlose Warnungen getriggert werden, die gar nicht auf realen Risikokontakten beruhen, wurde entscheiden, dass ein Anwender mit der neuen Funktion nur einmal innerhalb einer bestimmten Zeitspanne Andere warnen kann.",
+                                    "Nach Ablauf dieser Zeitspanne ist es dann wieder möglich, auf Basis eines positiven Tests in der App zu warnen.",
+                                    "Wir empfehlen aber weiterhin, sich nach einem positiven Selbsttest eigenverantwortlich so vernünftig zu verhalten, dass keine anderen Personen angesteckt werden."
+                                ]
+                            },
+                            {
+                                "title": "Muss ich ein Foto meines Tests machen, um den Test nachzuweisen?",
+                                "anchor": "warn_without_tan_photo",
+                                "active": false,
+                                "textblock": [
+                                    "Nein, in der Corona-Warn-App ist nicht vorgesehen, Fotos oder andere Dokumente zum Nachweis, dass ein Test wirklich stattgefunden hat, hochzuladen oder anderweitig zu prozessieren. Wir setzen hier bewusst auf die Umsicht und Eigenverantwortung unserer Anwender*innen."
+                                ]
+                            },
+                            {
+                                "title": "Wie oft kann ich warnen?",
+                                "anchor": "warn_without_tan_how_often",
+                                "active": false,
+                                "textblock": [
+                                    "Innerhalb einer bestimmten Periode können Sie einmal ohne TAN warnen. Nach Ablauf dieser Sperrfrist können Sie erneut warnen. Grundsätzlich gibt es nach oben keine Grenzen, wie oft Sie warnen können, solange diese Abstände nicht unterschritten werden. Wir hoffen aber natürlich, dass es keine Notwendigkeit für Sie gibt, in noch kürzeren Abständen immer wieder neu zu warnen."
+                                ]
+                            },
+                            {
+                                "title": "Kann ich in Vertretung von Familienmitgliedern warnen, z.B. für mein infiziertes Kind?",
+                                "anchor": "warn_without_tan_family",
+                                "active": false,
+                                "textblock": [
+                                    "Nein, das ist technisch nicht möglich, weil die Risikokontakte der positiv getesteten Person nicht zwingend durch das Contact Tracing auch auf ihrem Smartphone aufgezeichnet wurden. Eine stellvertretende Warnung von Ihrem Smartphone aus würde daher diese Kontakte gar nicht erreichen, sondern nur Ihre (also die falschen) Kontakte."
+                                ]
+                            },
+                            {
+                                "title": "Ich war in einem Restaurant (auf einem Event) per QR-Code eingecheckt. Kann ich die Gäste des Events mit der neuen Funktion warnen? Bleibe ich dabei anonym?",
+                                "anchor": "warn_without_tan_event",
+                                "active": false,
+                                "textblock": [
+                                    "Ja, wenn Sie sich per Event-QR-Code eingecheckt haben, können Sie den Zeitraum Ihres Check-ins die anderen Gäste weiterhin warnen. Dabei bleibt, wie bisher, Ihre Identität anonym."
+                                ]
+                            },
+                            {
+                                "title": "Muss ich nach einem positiven (Selbst-)Test in Quarantäne/Isolation?",
+                                "anchor": "warn_without_tan_quarantine",
+                                "active": false,
+                                "textblock": [
+                                    "Nach jedem positiven Test empfehlen wir im Sinne der Eigenverantwortung, zunächst Kontakte weitgehend zu minimieren und mit dem Arzt Ihres Vertrauens oder dem Gesundheitsamt Kontakt aufzunehmen und die weiteren Schritte abzustimmen.",
+                                    "Die aktuellen Quarantäne-Regeln richten sich nach dem IfSG und nach den lokalen geltenden Bestimmungen."
+                                ]
+                            },
+                            {
+                                "title": "Wenn ich wieder einen negativen Schnelltest habe, kann ich die Quarantäne dann beenden?",
+                                "anchor": "warn_without_tan_negative",
+                                "active": false,
+                                "textblock": [
+                                    "Die Corona-Warn-App kann keine medizinische Diagnose stellen, ob Sie infiziert sind oder nicht. Daher klären Sie bitte die Frage der Beendigung der Quarantäne mit dem zuständigen Gesundheitsamt bzw. Ihrem Arzt."
+                                ]
+                            },
+                            {
+                                "title": "Wird das positive Testergebnis bzw. das Warnen in meinem Kontakt-Tagebuch vermerkt?",
+                                "anchor": "warn_without_tan_contact_journal",
+                                "active": false,
+                                "textblock": [
+                                    "Ja, wenn Sie einen positiven Testbefund (auch ohne TAN) in der Corona-Warn-App registrieren, wird dieser Test wie bisher auch im Kontakt-Tagebuch eingetragen. Das geschieht unabhängig von der Art des Tests.",
+                                    "Wenn Sie manuell über die neue Funktion \"Tests erfassen und andere warnen\" andere CWA-Anwender*innen direkt warnen, wird zwar kein Test in der App registriert, aber im Tagebuch dokumentiert, dass Sie Andere gewarnt haben.",
+                                    "Siehe auch: <a href='placeholder' target='_blank'>Wie kann ich andere Nutzer warnen, wenn ich positiv getestet worden bin?</a>"
+                                ]
+                            },
+                            {
+                                "title": "Kann ich für einen Selbsttest ein offizielles digitales Zertifikat erhalten?",
+                                "anchor": "warn_without_tan_self_test_certificate",
+                                "active": false,
+                                "textblock": [
+                                    "Nein, europaweit sind für Selbsttests keine digitalen Zertifikate vorgesehen. Testzertifikaten können nur für beaufsichtigte PCR-Tests (ausgenommen PoC-NAT PCR-Tests) und beaufsichtigte Schnelltests ausgestellt werden."
+                                ]
+                            },
+                            {
+                                "title": "Kann ich für einen registrierten positiven Testbefund als Krankschreibung nutzen?",
+                                "anchor": "warn_without_tan_sickness_certificate",
+                                "active": false,
+                                "textblock": [
+                                    "Nein, die Warnung anderer mit der neuen Funktion \"Tests erfassen und andere warnen\" führt gar nicht zur Anzeige eines positiven Testergebnisses in der Corona-Warn-App. Abgesehen davon ist die Anzeige in der CWA arbeitsrechtlich nicht zur Krankschreibung bzw. Arbeits-/Schulbefreiung zugelassen. Wenden Sie sich bitte an den Arzt Ihres Vertrauens oder an das zuständige Gesundheitsamt."
+                                ]
+                            },
+                            {
+                                "title": "Wie lange bleibt der Test in der App zu sehen?",
+                                "anchor": "warn_without_tan_in_app_display",
+                                "active": false,
+                                "textblock": [
+                                    "Die Warnung anderer mit der neuen Funktion \"Tests erfassen und andere warnen\" führt gar nicht zur Anzeige eines positiven Testergebnisses in der Corona-Warn-App.",
+                                    "Für Tests, die wie bisher in der App registriert werden, gilt nach wie vor: Tests stellen in der Diagnostik von Infektionskrankheiten immer nur eine Momentaufnahme dar, sie sind daher nicht unbegrenzt lange gültig. Nach 72 Stunden wird daher ein registrierter Test in der Corona-Warn-App als „veraltet“ grau dargestellt."
+                                ]
+                            },
+                            {
+                                "title": "Stoppt nach dem Teilen des positiven Ergebnisses meine Risikoermittlung? Wie lange?",
+                                "anchor": "warn_without_tan_risk_assessment",
+                                "active": false,
+                                "textblock": [
+                                    "Nein, die Risikoermittlung und das Contact Tracing Protokoll werden nicht gestoppt. Die Warnung anderer mit den neuen Funktion \"Tests erfassen und andere warnen\" hat keine Auswirkungen auf die Risikoermittlung.",
+                                    "Wenn Sie sich trotz positiven Tests in der Öffentlichkeit bewegen, achten Sie bitte auf die Abstands- und Hygieneregeln und tragen Sie, wenn möglich, eine Maske zur Verringerung einer Infektionsgefahr für andere."
+                                ]
+                            },
+                            {
+                                "title": "Unterscheidet die Risikokalkulation bei einer Warnung auf meinem Smartphone je nach Test-Art  von der positiv getesteten Person?",
+                                "anchor": "warn_without_tan_risk_assessment_different",
+                                "active": false,
+                                "textblock": [
+                                    "Nein, das Verfahren zur Kalkulation des Infektionsrisikos wurde nicht geändert. Unabhängig von der Art des Tests zum Nachweis einer Infektion gelten dieselben Paramater bei der Berechnung des Risikos für andere."
+                                ]
+                            },
+                            {
+                                "title": "Verschwindet eine Warnung auf Basis der neuen Funktion von selbst von der App, oder muss ich sie selbständig löschen?",
+                                "anchor": "warn_without_tan_warning",
+                                "active": false,
+                                "textblock": [
+                                    "Nein, das ist nicht nötig. Nach einer Zeitspanne von max. 10 Tagen wird die Warnung in der App automatisch zurückgesetzt, weil dann auch das Zeitfenster für die Risikowarnungen erschöpft ist."
+                                ]
+                            }
+                        ]
+                    },
+                    {
                         "title": "Zertifikate",
                         "id": "eu_dcc",
                         "indexed": true,

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -547,7 +547,7 @@
                                 ]
                             },
                             {
-                                "title": "Kann ich für einen registrierten positiven Testbefund als Krankschreibung nutzen?",
+                                "title": "Kann ich einen registrierten positiven Testbefund als Krankschreibung nutzen?",
                                 "anchor": "warn_without_tan_sickness_certificate",
                                 "active": false,
                                 "textblock": [

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -469,13 +469,13 @@
                                 ]
                             },
                             {
-                                "title": "Einige Tage nach dem letzten positiven Test bin ich beim Selbsttest noch immer positiv. Soll ich nochmal warnen? Warum funktioniert das beim zweiten Mal nicht?",
+                                "title": "Einige Tage nach dem letzten positiven Test bin ich beim Selbsttest noch immer positiv. Soll ich nochmal warnen?",
                                 "anchor": "warn_without_tan_still_positive",
                                 "active": false,
                                 "textblock": [
-                                    "Um eine missbräuchliche Nutzung der Funktion zum sinnlosen Auslösen von Warnungen, die gar nicht auf realen Risikokontakten beruhen, zu vermeiden, wurde entscheiden, dass ein Anwender mit der neuen Funktion nur einmal innerhalb einer bestimmten Zeitspanne Andere warnen kann.",
-                                    "Nach Ablauf dieser Zeitspanne ist es dann wieder möglich, auf Basis eines Tests, der ohne TAN in der App registriert wurde, zu warnen.",
-                                    "Wir empfehlen aber weiterhin, sich nach einem positiven Selbsttest eigenverantwortlich so vernünftig zu verhalten, dass keine anderen Personen angesteckt werden."
+                                    "Wir empfehlen weiterhin, dass Sie sich nach einem positiven Selbsttest eigenverantwortlich so vernünftig verhalten, dass Sie andere nicht anstecken. Wenn Sie sich so verhalten, ist eine weitere Warnung nicht notwendig.",
+                                    "Um zu verhindern, dass die Funktion missbraucht wird und sinnlose Warnungen ausgelöst werden, die nicht auf realen Risikokontakten beruhen, wurde beschlossen, dass ein Nutzer mit der neuen Funktion andere nur einmal innerhalb eines bestimmten Zeitraums warnen kann.",
+                                    "Nach Ablauf dieser Zeitspanne ist es dann wieder möglich, aufgrund eines eigenen positive Testergebnisses ohne TAN zu warnen. Diese Einschränkung gilt nicht für positive Testergebnisse, die per App übermittelt werden."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -559,8 +559,7 @@
                                 "anchor": "warn_without_tan_in_app_display",
                                 "active": false,
                                 "textblock": [
-                                    "Die Warnung anderer mit der neuen Funktion \"Tests erfassen und andere warnen\" führt gar nicht zur Anzeige eines positiven Testergebnisses in der Corona-Warn-App, sondern dient lediglich dazu, Ihre Kontakte zu warnen.",
-                                    "Für Tests, die wie bisher in der App registriert werden, gilt nach wie vor: Tests stellen in der Diagnostik von Infektionskrankheiten immer nur eine Momentaufnahme dar, sie sind daher nicht unbegrenzt lange gültig. Nach 72 Stunden wird daher ein registrierter Test in der Corona-Warn-App als „veraltet“ angezeigt."
+                                    "Die Warnung anderer mit der neuen Funktion \"Tests erfassen und andere warnen\" führt gar nicht zur Anzeige eines positiven Testergebnisses in der Corona-Warn-App, sondern dient lediglich dazu, Ihre Kontakte zu warnen."
                                 ]
                             },
                             {


### PR DESCRIPTION
This PR adds the "Warning without TAN" section to the FAQ for the version 3.0 release.

For simplicity, I've put them all into one screenshot for each language. I hope this is sufficient for reviewing. 

Anchors:
- Section: #warning_without_tan
- Articles (in correct order): 
#warn_without_tan,
#warn_without_tan_how_to,
#warn_without_tan_error,
#warn_without_tan_digital_result, 
#warn_without_tan_external_result,
#warn_without_tan_hotline,
#warn_without_tan_version,
#warn_without_tan_pcr_after_self_test,
#warn_without_tan_twice,
#warn_without_tan_still_positive,
#warn_without_tan_photo,
#warn_without_tan_how_often,
#warn_without_tan_family,
#warn_without_tan_event,
#warn_without_tan_quarantine,
#warn_without_tan_negative,
#warn_without_tan_contact_journal,
#warn_without_tan_self_test_certificate,
#warn_without_tan_sickness_certificate,
#warn_without_tan_in_app_display,
#warn_without_tan_risk_assessment,
#warn_without_tan_risk_assessment_different,
#warn_without_tan_differentiate_warning

![screencapture-localhost-8000-en-faq-results-2023-01-17-16_09_24](https://user-images.githubusercontent.com/88365935/212935451-b339f65c-ee2f-499a-bbd6-b7b52450b0ba.png)
![screencapture-localhost-8000-de-faq-results-2023-01-17-16_09_53](https://user-images.githubusercontent.com/88365935/212935459-a2dee094-3103-42d5-b82f-619939126627.png)


---
Internal Tracking ID: [EXPOSUREAPP-14205](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14205)