### PR TITLE
Add TAN hotline shutdown date Jan 31, 2023 to web footer

### DIFF
--- a/src/data/global.json
+++ b/src/data/global.json
@@ -381,6 +381,10 @@
                         {
                             "title": "+49 30 498 75402",
                             "url": "tel:+493049875402"
+                        },
+                        {
+                            "title": "until Jan 31, 2023",
+                            "url": "/en/blog/2023-01-18-cwa-3-0/"
                         }
                     ],
                     "testid": "hotline-tan"
@@ -579,6 +583,10 @@
                         {
                             "title": "+49 30 498 75402",
                             "url": "tel:+493049875402"
+                        },
+                        {
+                            "title": "bis 31. Jan 2023",
+                            "url": "/de/blog/2023-01-18-cwa-3-0/"
                         }
                     ],
                     "testid": "hotline-tan"


### PR DESCRIPTION
This PR implements the suggestion from https://github.com/corona-warn-app/cwa-website/issues/3331 "References to TAN Hotline in footer" to add information about the shutdown of the TAN hotline on Jan 31, 2023 to the footer telephone numbers.

The shutdown date is added to the footer as a clickable link to the blog articles:

- [Version 3.0: CWA warnings now possible after positive self-test](https://www.coronawarn.app/en/blog/2023-01-18-cwa-3-0/) (EN)
- [Version 3.0: CWA-Warnungen jetzt auch nach positivem Selbsttest möglich](https://www.coronawarn.app/de/blog/2023-01-18-cwa-3-0/) (DE)

where more information is provided about the reasons for the shutdown and the fact that there will be a recorded message after the shutdown date.

This displays on the footer of a mobile device as follows:

| EN    | DE    |
| ----- | ----- |
| ![hotline-tan-EN](https://user-images.githubusercontent.com/66998419/213382801-9080eb60-a34b-443b-93bd-b3331f0fc8b6.jpg) | ![hotline-tan-DE](https://user-images.githubusercontent.com/66998419/213382890-935091f0-2752-4b51-9d37-61b97be27e8f.jpg) |