### PR TITLE
Update english-texts.json | Remove "Science" and "Science-Blog"

### DIFF
--- a/src/data/english-texts.json
+++ b/src/data/english-texts.json
@@ -82,8 +82,6 @@
         "RPIs",
         "SafetyNet",
         "SARS-CoV-2-Exposition",
-        "Science",
-        "Science-Blog",
         "Scoping-Document",
         "Screenshots",
         "Secure Software Development Lifecycle",


### PR DESCRIPTION
This PR temporarily removes "Science" and "Science-Blog" from our accessibility automation that puts occurences in `<span>` tags. There will be a follow up PR that will fix the root cause of the problem and add "Science" and "Science-Blog" back to `english-texts.json` once we find a sufficient solution.

Example of the problem we're currently facing:
![image](https://user-images.githubusercontent.com/88365935/217262639-7ad5c837-f17b-4078-a0ce-a39b7b94504f.png)
![image](https://user-images.githubusercontent.com/88365935/217262655-557a4bd8-7a7b-4810-9491-d8903f41f35e.png)

---
Internal Tracking ID: [EXPOSUREAPP-14701](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14701)