### PR TITLE
Update science blogs: Improve update: text

### DIFF
--- a/science/2021-06-15-science-blog-1/index.md
+++ b/science/2021-06-15-science-blog-1/index.md
@@ -5,7 +5,7 @@ page-name: science-blog-1
 page-name_de: science-blog-1
 author: CWA Team
 date: "2021-06-26"
-update: "last updated June 15, 2021 (German version)"
+update: "from German version (last updated June 15, 2021)"
 layout: science
 ---
 

--- a/science/2021-07-08-science-blog-2/index.md
+++ b/science/2021-07-08-science-blog-2/index.md
@@ -5,7 +5,7 @@ page-name: science-blog-2
 page-name_de: science-blog-2
 author: CWA Team
 date: "2021-09-20"
-update: "last updated July 8, 2021 (German version)"
+update: "from German version (last updated July 8, 2021)"
 layout: science
 ---
 

--- a/science/2021-08-02-science-blog-3/index.md
+++ b/science/2021-08-02-science-blog-3/index.md
@@ -5,7 +5,7 @@ page-name: science-blog-3
 page-name_de: science-blog-3
 author: CWA Team
 date: "2021-10-28"
-update: "last updated September 20, 2021 (German version)"
+update: "from German version (last updated September 20, 2021)"
 layout: science
 ---
 

--- a/science/2021-10-15-science-blog-4/index.md
+++ b/science/2021-10-15-science-blog-4/index.md
@@ -5,7 +5,7 @@ page-name: science-blog-4
 page-name_de: science-blog-4
 author: CWA Team
 date: "2021-12-02"
-update: "last updated October 15, 2021 (German version)"
+update: "from German version (last updated October 15, 2021)"
 layout: science
 ---
 This article is the first in our focus on data donation and the Corona-Warn-App. We analyse the extent to which the voluntary, data protection-compliant provision of user data can provide information about user behaviour and the processes involved in the CWA ecosystem.

--- a/science/2022-03-03-science-blog-5/index.md
+++ b/science/2022-03-03-science-blog-5/index.md
@@ -5,7 +5,7 @@ page-name: science-blog-5
 page-name_de: science-blog-5
 author: CWA Team
 date: "2022-07-29"
-update: "last updated March 3, 2022 (German version)"
+update: "from German version (last updated March 3, 2022)"
 layout: science
 ---
 


### PR DESCRIPTION
This PR updates the `update:` text in English science blogs containing information on when they were published and when their German counterparts were last edited. Thanks to @MikeMcC399 for the suggestion. For Science Blog 6, this has been done in https://github.com/corona-warn-app/cwa-website/pull/3363/commits/880c749b83a36aa3e8815fbb88a153aa158317f0.
![image](https://user-images.githubusercontent.com/88365935/217465108-7793d372-570d-488d-8e6d-6f40cc866a72.png)

---
Internal Tracking ID: [EXPOSUREAPP-14705)](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14705)
