### PR TITLE
Update highlight.js | Remove warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8208,10 +8208,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.9.1.tgz",
-      "integrity": "sha512-t2PInfxDlvHEk4yROFNv4w53D2DtdRAO8Oz9GUVOHE/Wu9IPSKjZLO6Pjvl3vAX77sBpPuBAupQbqF6TFfErEw==",
-      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "engines": {
         "node": "*"
       }
@@ -11601,7 +11600,7 @@
         "front-matter": "^2.0.5",
         "glob": "^7.1.4",
         "handlebars": "^4.0.5",
-        "highlight.js": "^8.9.1",
+        "highlight.js": "^10.4.1",
         "js-yaml": "^3.14.0",
         "marked": "^2",
         "nopt": "^4.0.1",
@@ -22210,9 +22209,9 @@
       }
     },
     "highlight.js": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.9.1.tgz",
-      "integrity": "sha512-t2PInfxDlvHEk4yROFNv4w53D2DtdRAO8Oz9GUVOHE/Wu9IPSKjZLO6Pjvl3vAX77sBpPuBAupQbqF6TFfErEw=="
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -24734,7 +24733,7 @@
         "front-matter": "^2.0.5",
         "glob": "^7.1.4",
         "handlebars": "^4.0.5",
-        "highlight.js": "^8.9.1",
+        "highlight.js": "^10.4.1",
         "js-yaml": "^3.14.0",
         "marked": "^2",
         "nopt": "^4.0.1",


### PR DESCRIPTION
This PR updates highlight.js to a higher version so that the vulnerabilty warning disappears

---
Internal Tracking ID: [EXPOSUREAPP-14718](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14718)