### PR TITLE
Update semver-regex | Remove warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6376,7 +6376,7 @@
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "dependencies": {
-        "semver-regex": "^2.0.0"
+        "semver-regex": "^3.1.4"
       },
       "engines": {
         "node": ">=6"
@@ -13152,11 +13152,14 @@
       }
     },
     "node_modules/semver-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
-      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semver-truncate": {
@@ -20786,7 +20789,7 @@
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "requires": {
-        "semver-regex": "^2.0.0"
+        "semver-regex": "^3.1.4"
       }
     },
     "findup-sync": {
@@ -25896,9 +25899,9 @@
       }
     },
     "semver-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
-      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA=="
     },
     "semver-truncate": {
       "version": "1.1.2",


### PR DESCRIPTION
This PR updates semver-regex to a higher version so that the vulnerabilty warning disappears

---
Internal Tracking ID: [EXPOSUREAPP-14718](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14718)