### PR TITLE
Update trim-newlines | Remove warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10622,7 +10622,7 @@
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "trim-newlines": "^3.0.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -15032,11 +15032,11 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/trim-repeated": {
@@ -24016,7 +24016,7 @@
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "trim-newlines": "^3.0.1"
       }
     },
     "merge-stream": {
@@ -27366,9 +27366,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "trim-repeated": {
       "version": "1.0.0",


### PR DESCRIPTION
This PR updates trim-newlines to a higher version so that the vulnerabilty warning disappears

---
Internal Tracking ID: [EXPOSUREAPP-14718](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14718)