### PR TITLE
Update ua-parser-js | Remove warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3468,7 +3468,7 @@
         "serve-static": "1.13.2",
         "server-destroy": "1.0.1",
         "socket.io": "^4.4.1",
-        "ua-parser-js": "1.0.2",
+        "ua-parser-js": "1.0.33",
         "yargs": "^17.3.1"
       },
       "bin": {
@@ -15107,9 +15107,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
+      "integrity": "sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -18538,7 +18538,7 @@
         "serve-static": "1.13.2",
         "server-destroy": "1.0.1",
         "socket.io": "^4.4.1",
-        "ua-parser-js": "1.0.2",
+        "ua-parser-js": "1.0.33",
         "yargs": "^17.3.1"
       }
     },
@@ -27419,9 +27419,9 @@
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
     },
     "ua-parser-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg=="
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
+      "integrity": "sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ=="
     },
     "uglify-js": {
       "version": "3.17.4",


### PR DESCRIPTION
This PR updates ua-parser-js to a higher version so that the vulnerabilty warning disappears

---
Internal Tracking ID: [EXPOSUREAPP-14718](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14718)