### PR TITLE
Update http-cache-semantics | Remove warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3665,7 +3665,7 @@
       "dependencies": {
         "clone-response": "1.0.2",
         "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
+        "http-cache-semantics": "4.1.1",
         "keyv": "3.0.0",
         "lowercase-keys": "1.0.0",
         "normalize-url": "2.0.1",
@@ -8329,9 +8329,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -18674,7 +18674,7 @@
       "requires": {
         "clone-response": "1.0.2",
         "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
+        "http-cache-semantics": "4.1.1",
         "keyv": "3.0.0",
         "lowercase-keys": "1.0.0",
         "normalize-url": "2.0.1",
@@ -22298,9 +22298,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",


### PR DESCRIPTION
This PR updates http-cache-semantics to a higher version so that the vulnerabilty warning disappears

---
Internal Tracking ID: [EXPOSUREAPP-14718](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14718)