### PR TITLE
Permanent fix for broken back-link rendering on science-blog entries

### DIFF
--- a/src/data/english-texts.json
+++ b/src/data/english-texts.json
@@ -82,6 +82,8 @@
         "RPIs",
         "SafetyNet",
         "SARS-CoV-2-Exposition",
+        "Science",
+        "Science-Blog",
         "Scoping-Document",
         "Screenshots",
         "Secure Software Development Lifecycle",

--- a/src/partials/button-back-component.html
+++ b/src/partials/button-back-component.html
@@ -1,5 +1,5 @@
 {{#if button}}
 <a class="btn btn-link btn-link_narrow btn-link_icon"
   title="{{button.title}}" href="{{button.url}}">
-  <span class="icon icon_arrow-left"></span> &nbsp; {{button.title}}</a>
+  <span class="icon icon_arrow-left"></span><span> &nbsp; {{button.title}}</span></a>
 {{/if}}


### PR DESCRIPTION
PR #3368 introduced a temporary fix for the broken back-link rendering on Science-Blog Entries. 
This PR proposes a permanent fix for this problem. It adds the terms "Science" and "Science-Blog" again to the english-texts.json and wraps the complete text inside the link inside a span-tag to fix the rendering issue introduced by #3293.

Back Link after fix with english specifier:
![Bildschirmfoto 2023-02-13 um 09 18 55](https://user-images.githubusercontent.com/71256882/218408617-8db859a4-05e0-42f9-bb2e-3f154c76938b.png)
![Bildschirmfoto 2023-02-13 um 09 19 10](https://user-images.githubusercontent.com/71256882/218408628-24f3f474-407a-45c4-bba6-eff30d4984af.png)

---
Internal Tracking ID: [EXPOSUREAPP-14701](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14701)