### PR TITLE
Add workflow to test links

### DIFF
--- a/.github/workflows/test-links.yml
+++ b/.github/workflows/test-links.yml
@@ -1,0 +1,37 @@
+name: Test Links
+# This workflow executes a subset of Cypress tests
+# concerning
+# - anchor links
+# - external links
+
+on:
+  workflow_dispatch:
+  schedule:
+      # Run every Monday at 03:15 UTC
+    - cron: '15 3 * * 1'
+
+jobs:
+
+  test-links:
+    runs-on: ubuntu-latest
+    env:
+      # See issue https://github.com/cypress-io/cypress/issues/25357
+      ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Check anchor links
+      uses: cypress-io/github-action@v5
+      with:
+        start: npm start
+        wait-on: http://localhost:8000
+        spec: cypress/e2e/check_anchor_links.cy.js
+        browser: chrome
+
+    - name: Check external links
+      uses: cypress-io/github-action@v5
+      with:
+        install: false
+        spec: cypress/e2e/hybrid/check_links.cy.js
+        browser: chrome


### PR DESCRIPTION
This PR provides an additional workflow to test links in the website. It fills a gap in assisted testing which is currently missing.

`npm test` will run a full test locally, however there is no workflow which includes Cypress tests for external links.

The workflow is submitted for manually triggering only (`workflow_dispatch`). This could be changed later to trigger it also on `pull_request` for instance.

It tests:

- anchor links
- full links, including external links

The workflow currently fails due to bad links.

---
Internal Tracking ID: [EXPOSUREAPP-](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-)
