### PR TITLE
Update dashboard: Move fallback file

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -157,7 +157,9 @@ function analyseData() {
     })
     .catch((e) => {
       const data = fs.readFileSync('src/data/analyse-backup.json', 'utf8');
-      if (!fs.existsSync('public')) fs.mkdirSync('public');
+      if (!fs.existsSync('public/assets/dashboard')) {
+        fs.mkdirSync('public/assets/dashboard');
+      }
       return fs.writeFileSync(`./public/${analyseConfig.fallbackFile}`, data, { flag: 'w' });
     });
 }

--- a/src/data/analyse.json
+++ b/src/data/analyse.json
@@ -1,6 +1,6 @@
 {
     "fetchUrl": "https://obs.eu-de.otc.t-systems.com/obs-public-dashboard/json/v1/nested_cwa_public_dashboard_data.json",
-    "fallbackFile": "/analyseData.json",
+    "fallbackFile": "/assets/dashboard/analyseData.json",
     "startDate": "2020-05-15",
     "switchStart": "2",
     "pickerButtonText": {


### PR DESCRIPTION
This PR puts the dashboard fallback file to public/assets/dashboard instead of the public root directory.

---
Internal Tracking ID: [EXPOSUREAPP-14800](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14800) 