### PR TITLE
Check only main section for blog sub-entries

### DIFF
--- a/cypress/e2e/hybrid/check_links.cy.js
+++ b/cypress/e2e/hybrid/check_links.cy.js
@@ -51,9 +51,9 @@ context("Check for broken links", () => {
     it(`"${page}" - Check for broken links`, () => {
       cy.visit({log: false, url: page} )
       cy.get("a:not([href*='mailto:'],[href*='tel:'],[href*='#'])").not('.email').each(url => {
-        if (url.prop('href') && !allowlist.includes(url.prop('href'))) {         
+        if (url.prop('href') && !allowlist.includes(url.prop('href'))) {
           cy.request({
-            failOnStatusCode: false, 
+            failOnStatusCode: false,
             log: false,
             url: url.prop('href')
           }).then((response) => {
@@ -65,12 +65,12 @@ context("Check for broken links", () => {
               })
             }
           })
-        }         
+        }
       })
     })
   })
 
-  
+
 })
 
 context("Check for broken links on entries", () => {
@@ -87,10 +87,10 @@ context("Check for broken links on entries", () => {
       cy.get("a:not([href*='mailto:'],[href*='tel:'],[href*='#'])").not('.email').each(url => {
         if(url.prop('href').includes('localhost') && url.prop('href').includes(sub) && !pagesToAvoid.includes(url.prop('href').replace('http://localhost:8000', ''))) {
           cy.visit({log: false, url: url.prop('href')} )
-          cy.get("a:not([href*='mailto:'],[href*='tel:'])").not('.email').each(entry => {
+          cy.get("main a:not([href*='mailto:'],[href*='tel:'])").not('.email').each(entry => {
             if (entry.prop('href') && !allowlist.includes(entry.prop('href'))) {
               cy.request({
-                failOnStatusCode: false, 
+                failOnStatusCode: false,
                 log: false,
                 url: entry.prop('href')
               }).then((response) => {
@@ -105,7 +105,7 @@ context("Check for broken links on entries", () => {
             }
           })
         }
-      })  
-    })  
+      })
+    })
   })
 })


### PR DESCRIPTION
This PR improves the reliability and performance of the Cypress test [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js).

## Condition before PR

The test [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js) has been failing with a browser out-of-memory crash when it was attempting to check blog entries. This started to occur after the introduction of additional links to blog articles placed near the topic of https://www.coronawarn.app/en/blog/ and https://www.coronawarn.app/de/blog/ (see issue https://github.com/corona-warn-app/cwa-website/issues/3391).

About 50 new links were added, which is about a 50% increase in the number of links on the blog main page. These links, which duplicated links on the same page, cause their corresponding linked sub-entries to have their article contents checked a second time.

The headers and footers of the blog sub-entries are identical to each other and to the main blog page. Repeatedly checking these identical sections, which contain about 30 links each, means redundant checks were being made, and in some cases, websites such as Instagram or GitHub blocked the checks because of their rapidity and number, due to rate-limiting or security protection measures.

The four sub-entry tests `/de/blog`, `/en/blog`, `/de/science` and `/en/science` were carrying out 9817 link tests.

## Condition after PR

This PR changes the test strategy of blog and science blog entries by restricting the link check to the `main` section of each blog (sub-)entry. The `main` section is the part which makes each blog entry unique. This means that the `header` and `footer` of a blog sub-entry are not checked, since they are the same as the main blog pages.

The `header` and `footer` continue to be checked on the main blog pages.

## Comparison

The following table gives a comparison of before and after restricting the blog sub-entry test to the `main` section. The following parameters were measured on a Windows 11 system:

| Item                | time            | number of tests |
| ------------------- | --------------- | --------------- |
| Total Test duration | ~19:00 -> 10:06 | 39              |
| /de/blog            |                 | 4434 -> 794     |
| /en/blog            |                 | 4412 -> 772     |
| /de/science         |                 | 485 -> 317      |
| /en/science         |                 | 486 -> 318      |

It was difficult to get a complete performance baseline (before applying the PR) due to the test crashing. It took several attempts before the test ran without crashing.

## Result of PR

- Stops browser crash
- Removes > 7000 unnecessary link checks
- Cuts > 9 minutes off the total time of the test

## Verification

On a local clone of cwa-website

```bash
npm ci
npm run test:open
```

Select `check_links` and confirm that the test runs successfully.

```bash
npm test
```

to run the complete test suite and check that this also runs successfully.

---
Internal Tracking ID: [EXPOSUREAPP-14806](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14806)