### PR TITLE
Remove unnecessary directories from video check

### DIFF
--- a/cypress/e2e/check_videos.cy.js
+++ b/cypress/e2e/check_videos.cy.js
@@ -36,7 +36,7 @@ context("Check for broken videos", () => {
     })
 })
 
-context("Check for broken links on blog/science entries", () => {
+context("Check for broken videos on blog/science entries", () => {
     const pages = ['/de/blog/','/en/blog/','/de/science/', '/en/science/']
 
     pages.map(page => {

--- a/cypress/e2e/check_videos.cy.js
+++ b/cypress/e2e/check_videos.cy.js
@@ -4,35 +4,13 @@ context("Check for broken videos", () => {
     const pages = [
         '/de',
         '/en',
-        '/de/eventregistration/',
-        '/en/eventregistration/',
-        '/de/community/',
-        '/en/community/',
-        '/de/analysis/',
-        '/en/analysis/',
-        '/de/blog/archiv/',
-        '/en/blog/archive/',
-        '/de/screenshots/',
-        '/en/screenshots/',
         '/de/faq/', '/de/faq/results/',
         '/en/faq/', '/en/faq/results/',
-        '/de/rat-partner/',
-        '/en/rat-partner/',
-        '/de/privacy/',
-        '/en/privacy/',
-        '/de/terms-of-use/',
-        '/en/terms-of-use/',
-        '/de/event-qr-code-guide/',
-        '/en/event-qr-code-guide/',
-        '/de/blog/','/en/blog/',
+        '/de/blog/', '/en/blog/',
         '/de/science/',
         '/en/science/',
-        '/de/simple-language/',
-        '/en/simple-language/',
         '/de/sign-language/',
-        '/en/sign-language/',
-        '/de/sitemap/',
-        '/en/sitemap/'
+        '/en/sign-language/'
     ];
 
 


### PR DESCRIPTION
This PR implements the suggestion from https://github.com/corona-warn-app/cwa-website/issues/3397 "Cypress video check on directories without videos" to remove directories from the list to check in the [cypress/e2e/check_videos.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/check_videos.cy.js) test spec, where there are no videos located and there are none to be expected:

```text
        '/de/eventregistration/',
        '/en/eventregistration/',
        '/de/community/',
        '/en/community/',
        '/de/analysis/',
        '/en/analysis/',
        '/de/blog/archiv/',
        '/en/blog/archive/',
        '/de/screenshots/',
        '/en/screenshots/',
        '/de/rat-partner/',
        '/en/rat-partner/',
        '/de/privacy/',
        '/en/privacy/',
        '/de/terms-of-use/',
        '/en/terms-of-use/',
        '/de/event-qr-code-guide/',
        '/en/event-qr-code-guide/',
        '/de/simple-language/',
        '/en/simple-language/',
        '/de/sitemap/',
        '/en/sitemap/'
```

Also a minor text correction is made to the Cypress log output when the test is checking videos in the blog and science sections.

---
Internal Tracking ID: [EXPOSUREAPP-14807](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14807)