### PR TITLE
PoC Cypress check anchor and external links in GitHub workflow

### DIFF
--- a/.github/workflows/test-links.yml
+++ b/.github/workflows/test-links.yml
@@ -1,0 +1,48 @@
+name: Test Links
+# This workflow executes a subset of Cypress tests
+# concerning
+# - external links
+# - anchor links
+
+
+on:
+  workflow_dispatch:
+  schedule:
+      # Run every Monday at 03:15 UTC
+    - cron: '15 3 * * 1'
+
+jobs:
+
+  test-links:
+    runs-on: ubuntu-latest
+    env:
+      # See issue https://github.com/cypress-io/cypress/issues/25357
+      ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Check external links
+      uses: cypress-io/github-action@v5
+      with:
+        build: npm run build
+        start: npm run start-server
+        wait-on: http://localhost:8000
+        spec: cypress/e2e/hybrid/check_links.cy.js
+        browser: chrome
+
+    - name: Check anchor links
+      uses: cypress-io/github-action@v5
+      if: always()
+      with:
+        install: false
+        spec: cypress/e2e/check_anchor_links.cy.js
+        browser: chrome
+
+    - name: Save Cypress logs
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: cypress_logs
+        path: cypress/logs
+        retention-days: 7

--- a/cypress/e2e/hybrid/check_links.cy.js
+++ b/cypress/e2e/hybrid/check_links.cy.js
@@ -79,7 +79,9 @@ context("Check for broken links on entries", () => {
   const allowlist = [
     'https://emergentalliance.org/calculation-of-the-effective-reproduction-number-germany/',
     'https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999',
-    'https://onlinelibrary.wiley.com/doi/abs/10.2307/3315826.n1'
+    'https://onlinelibrary.wiley.com/doi/abs/10.2307/3315826.n1',
+    'https://www.t-systems.com/',
+    'https://developer.apple.com/help/app-store-connect/reference/app-metrics'
   ]
   subpages.forEach(sub => {
     it(`"${sub}" entries - Check for broken links`, () => {


### PR DESCRIPTION
I managed to overcome some difficulties from PR https://github.com/corona-warn-app/cwa-website/pull/3384 in running 

[cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js) in a GitHub runner.

This draft PR now has the status of PoC (Proof of Concept) of using the above test with [cypress-io/github-action](https://github.com/cypress-io/github-action) to test links in the website https://www.coronawarn.app/.

It uses both:

- [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js) and
- [cypress/e2e/check_anchor_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/check_anchor_links.cy.js)

so that external and anchor categories of links are tested.

It took 21m 26s to run, including:

- 15.5m for `check_links`
- 2.5m for `check_anchor_links`