### PR TITLE
Workflow for check_links

### DIFF
--- a/.github/workflows/test-check_links.yml
+++ b/.github/workflows/test-check_links.yml
@@ -1,0 +1,49 @@
+name: Test Links
+# This workflow runs the Cypress test
+# cypress/e2e/hybrid/check_links.cy.js
+# to check local and external hyperlinks.
+# It is separated from other tests because it may fails due to external conditions
+# on third-party webservers which are not under control of the CWA organization.
+
+on:
+  workflow_dispatch:
+  schedule:
+      # Run every Monday at 03:15 UTC
+    - cron: '15 3 * * 1'
+
+jobs:
+
+  test-check-links:
+    name: test (check_links)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js 18 environment
+      uses: actions/setup-node@v3
+      with:
+        node-version: 'lts/hydrogen'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build
+
+    - name: Test
+      run: npx start-server-and-test start-server http://localhost:8000 "cypress run -s 'cypress/e2e/hybrid/check_links.cy.js' --e2e --headless --browser chrome"
+      env:
+        NO_COLOR: true
+        TERM: xterm
+        # See issue https://github.com/cypress-io/cypress/issues/25357
+        ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
+
+    - name: Save Cypress logs
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: cypress_logs
+        path: cypress/logs
+        retention-days: 7


### PR DESCRIPTION
This PR creates a workflow `.github/workflows/test-check_links.yml` which runs the Cypress test [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js) to check hyperlinks which are not anchors.

The test is run weekly every Monday at 03:15 UTC and on demand.

The workflow does not have a `pull_request` trigger because the success of the test relies in many cases on the correct performance of external third-party websites over which cwa-website has no control. Any failure needs to be followed up manually and should not result in a CI failure of any PR. Also the test takes much longer to run than any other of the Cypress tests. (Tests in a fork showed that it typically runs for approximately 18 minutes when successful.)

If the test fails then log files are uploaded as artifacts to aid in troubleshooting.

~~It is currently draft status only. It may need some more tuning to remove any websites which prove to be too unreliable.~~

This is a follow-on from previous PRs https://github.com/corona-warn-app/cwa-website/pull/3384 and https://github.com/corona-warn-app/cwa-website/pull/3399.

![image](https://user-images.githubusercontent.com/66998419/220117109-b8602e7a-cab4-4d90-8da2-deaabec44f21.png)

![image](https://user-images.githubusercontent.com/66998419/220117246-e193de5f-9943-4d9f-b309-a7c67405703f.png)

---
Internal Tracking ID: [EXPOSUREAPP-14844](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14844)