### PR TITLE
Improve check_links Cypress test to block hostnames not URLs

### DIFF
--- a/cypress/e2e/hybrid/check_links.cy.js
+++ b/cypress/e2e/hybrid/check_links.cy.js
@@ -5,6 +5,7 @@ const noCheckHosts = [
   'ec.europa.eu',              // HTTP 502 bad gateway
   'health.ec.europa.eu',       // HTTP 502 bad gateway
   'onlinelibrary.wiley.com',   // HTTP 503 service unavailable
+  'reopen.europa.eu',          // Timeout - no response
   'support.apple.com',         // Timeout - no response
   'testbuchen.de',             // HTTP 403 permission denied
   'www.instagram.com',         // SSLV3_ALERT_CLOSE_NOTIFY


### PR DESCRIPTION
This PR improves the Cypress test [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js) regarding maintaining the list of link targets which cannot be checked due to their network or security setup.

In the past there were two separate lists, one for the main check and one for the blog checks. The lists were complete URLs.

## Reason for PR

The motivation for this PR is to enable this Cypress test spec to be called successfully from a GitHub workflow. Some websites which allowed testing from a local environment cannot be automatically tested from GitHub, meaning that the list was getting longer and less manageable.

## Changes

- The two lists are merged into one list.
- The list is now based on hostnames e.g. instead of the full URL `https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999` the hostname `testbuchen.de` is used.
- If an problem is found where the host responds with an error code, the hostname is also logged to the `broken_links_result.txt` log file.
- The reason for each of the entries is added as a comment.
- The source code is also reformatted using standard VSCode settings.

## Benefits

The advantages are:

- One list is easier to maintain and avoids duplication.
- Using hostnames significantly shortens the length of entries. It also makes the list more robust, since in general it is the host server, not a particular URL which causes hard errors in attempting to test, so instead of adding multiple URLs for the same server it is now sufficient to add the one common hostname.
- Logging the hostname to the log file means that in the case of a hard error the hostname can be copied and pasted exactly to the list `noCheckHosts`.
- The comments regarding previous errors and reasons for adding the hostname to the list aid maintaining the list.

## Verification

### Local test

```bash
npm run test:open
```

select `check_links` and ensure that the test runs successfully. Repeat the test twice more.

### GitHub verification

This PR will be verified as part of PR https://github.com/corona-warn-app/cwa-website/pull/3402. It has already been checked to run on GitHub.

---
Internal Tracking ID: [EXPOSUREAPP-14842](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14842)