### PR TITLE
Remove GitHub issue link from FAQ entry `where_can_i_get_tested`

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1783,7 +1783,6 @@
                                     "<hr/>",
                                     "<div class='container'><div class='row'><div class='col-sm'>An overview of the <b>PCR and rapid antigen test sites</b> can be found on this <a href='https://www.zusammengegencorona.de/testen/?articlefilter=alleartikel' target='_blank' rel='noopener noreferrer'>BMG webpage</a> (not clear whether the test site is connected to the CWA or not).</div><div class='col-sm'><img class='img-fluid' src='/assets/img/faq/BMG_testzentren.png' alt='PCR- and rapid antigen test information BMG'></div></div></div>",
                                     "<hr/>",
-                                    "Another list of test sites from the GitHub community: <a href='https://github.com/corona-warn-app/cwa-documentation/issues/569' target='_blank' rel='noopener noreferrer'>Where to get tested?</a>",
                                     "See also <a href=#test_result_issues target='_blank'>What can I do if I have not received my test result or test certificate?</a>"
                                 ]
                             },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1776,7 +1776,6 @@
                                     "<hr/>",
                                     "<div class='container'><div class='row'><div class='col-sm'>Eine Übersicht der <b>PCR- und Schnell-Teststellen</b> finden Sie auf dieser <a href='https://www.zusammengegencorona.de/testen/?articlefilter=alleartikel' target='_blank' rel='noopener noreferrer'>BMG Seite</a> (nicht ersichtlich, ob die Teststelle an die CWA angebunden ist oder nicht).</div><div class='col-sm'><img class='img-fluid' src='/assets/img/faq/BMG_testzentren.png' alt='PCR- und Schnelltestinformationen BMG'></div></div></div>",
                                     "<hr/>",
-                                    "Weitere Liste mit Teststellen aus der GitHub-Community: <a href='https://github.com/corona-warn-app/cwa-documentation/issues/569' target='_blank' rel='noopener noreferrer'>Wo kann man sich testen lassen?</a>",
                                     "Siehe auch <a href=#test_result_issues target='_blank'>Was kann ich tun, wenn ich mein Testergebnis oder Testzertifikat nicht erhalten habe?</a>"
                                 ]
                             },


### PR DESCRIPTION
## Description
This PR removes the link to the GitHub issue https://github.com/corona-warn-app/cwa-documentation/issues/569 from the FAQ entry `where_can_i_get_tested`.

## What was changed

- https://www.coronawarn.app/de/faq/results/#where_can_i_get_tested
- https://www.coronawarn.app/en/faq/results/#where_can_i_get_tested

**This PR needs normal review & approve process!**

---
Internal Tracking ID: [EXPOSUREAPP-14848](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14848)