### PR TITLE
Add workflow to check markdown links

### DIFF
--- a/.github/workflows/test-checklinks-md.yml
+++ b/.github/workflows/test-checklinks-md.yml
@@ -1,0 +1,26 @@
+name: Test Links (Markdown)
+# This workflow executes npm run checklinks
+# to call in turn markdown-link-check
+# This checks markdown files (*.md) in the top level of the
+# repository and in the docs/ directory.
+# These are documents used by contributors and maintainers.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  test-checklinks-markdown:
+    name: test (checklinks - markdown)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Test
+      run: npm run checklinks


### PR DESCRIPTION
This PR implements the suggestion from https://github.com/corona-warn-app/cwa-website/issues/3407 "Add a workflow to check Markdown links".

The workflow is triggered by a pull_request or manually and it executes the command

```bash
npm run checklinks
```

to check Markdown (*.md) files in the top level of cwa-website and in the `docs/` directory.