### PR TITLE
New script `test:links` for web hyperlink checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "corona-warn-app-landingpage",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "corona-warn-app-landingpage",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.20.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-warn-app-landingpage",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Corona-Warn-App website coronawarn.app",
   "main": "gulpfile.mjs",
   "scripts": {
@@ -22,7 +22,10 @@
     "test:firefox": "run-s build test:firefox:phase2",
     "test:short": "run-s build test:short:phase2",
     "test:short:phase2": "start-server-and-test start-server http://localhost:8000 cypress:run:short",
-    "checklinks": "find . docs -maxdepth 1 -name '*.md' -print0 | xargs -0 -n1 markdown-link-check"
+    "checklinks": "find . docs -maxdepth 1 -name '*.md' -print0 | xargs -0 -n1 markdown-link-check",
+    "test:links": "run-s build test:checklinks:phase2",
+    "cypress:run:checklinks": "cypress run -s 'cypress/e2e/hybrid/check_links.cy.js' --e2e --browser chrome --headless",
+    "test:checklinks:phase2": "start-server-and-test start-server http://localhost:8000 cypress:run:checklinks"
   },
   "author": "SAP Corona-Warn-App Open Source Team <corona-warn-app.opensource@sap.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR adds a new script `test:links` which runs the [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js) test locally.

This makes it easier for a contributor to check external links in the website to be published on https://www.coronawarn.app/ before submitting a PR or after making changes to it.

Other tests can already be run using `npm run test:short`. The full set of tests can be run using `npm test` (which is an alias for `npm run test`).

Due to the dependency of this test on external websites, which may or may not be working correctly when the test is run, and on the run time of approx. 15 - 25 minutes, the workflow check in [.github/workflows/test-check_links.yml](https://github.com/corona-warn-app/cwa-website/blob/master/.github/workflows/test-check_links.yml) is not triggered by pull request. Instead it runs once a week or if triggered manually.

To run the test locally, execute:

```bash
npm run test:links
```

(Note, there is another test (`npm run checklinks`) which checks Markdown files which are published only to https://github.com/corona-warn-app/cwa-website. The name `test:links` above is aligned to the other Cypress tests.)

I plan to add this to some changed README documentation soon.

---
Internal Tracking ID: [EXPOSUREAPP-14860](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14860)