### PR TITLE
Remove dead EcoCare link from blogs

### DIFF
--- a/blog/2021-05-02-cwa-2-1-schnelltests/index.md
+++ b/blog/2021-05-02-cwa-2-1-schnelltests/index.md
@@ -13,7 +13,7 @@ Deutsche Telekom and SAP’s project team have integrated the [announced rapid C
 
 <!-- overview -->
 
-Eight partners are participating in the launch of the rapid test integration, including **the Bavarian Red Cross, dm-drogerie markt, Doctorbox, EcoCare the healthcare brand of Ecolog Deutschland GmbH (with Lidl among others), Huber Health Care, and testbuchen.de/No-Q**. In addition, the **German Federal Chancellery**, which tests its employees, and the **Ministry of Education and Culture Saarland**, which provides rapid tests to teachers, are taking part. 
+Eight partners are participating in the launch of the rapid test integration, including **the Bavarian Red Cross, dm-drogerie markt, Doctorbox, EcoCare the healthcare brand of Ecolog Deutschland GmbH (with Lidl among others), Huber Health Care, and testbuchen.de/No-Q**. In addition, the **German Federal Chancellery**, which tests its employees, and the **Ministry of Education and Culture Saarland**, which provides rapid tests to teachers, are taking part.
 
 Since the announcement of the rapid test integration at the end of March, the project team has received **125 requests** from test centers and the retail sector, among others, that are interested in participating in the integration. Companies that are interested in participating can contact SAP and Telekom via [registrierung.labore.pandemietest@t-systems.com](mailto:registrierung.labore.pandemietest@t-systems.com).
 
@@ -23,7 +23,7 @@ Users will have the opportunity to be tested for COVID-19 by trained and authori
 
 - dm drogerie-märkte: [Schnelltest INOPAI (dm.de)](https://corona-schnelltest-zentren.dm.de/o/dm/login)
 
-- EcoCare (Lidl and Kaufland): [EcoCare - Bürgertest: EcoCare - Bürgertest](https://buergertest.ecocare.center/#c734)
+- EcoCare (Lidl and Kaufland): ~~EcoCare - Bürgertest: EcoCare - Bürgertest~~ *Update March 6, 2023: The website `https://buergertest.ecocare.center` belonging to "EcoCare - Bürgertest" is no longer in operation.*
 
 - testbuchen.de/No-Q (participating pharmacies, general practitioners and other test centers): [Finde deinen Testtermin (testbuchen.de)](https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999)
 
@@ -31,7 +31,7 @@ Users will have the opportunity to be tested for COVID-19 by trained and authori
 
 In the first days after the start of the integration, a few partners may still experience minor complications. Overall, however, the integration is running satisfactorily and users already seem to be using the option.
 
-After the test, a negative result will be displayed in the Corona-Warn-App for **48 hours**. A positive test results will be displayed in the app until the user has shared his or her result. 
+After the test, a negative result will be displayed in the Corona-Warn-App for **48 hours**. A positive test results will be displayed in the app until the user has shared his or her result.
 
 
 <br></br>

--- a/blog/2021-05-02-cwa-2-1-schnelltests/index_de.md
+++ b/blog/2021-05-02-cwa-2-1-schnelltests/index_de.md
@@ -23,7 +23,7 @@ Nutzer\*innen haben damit die Möglichkeit, sich bei vielen der beteiligten Part
 
 - dm drogerie-märkte: [Schnelltest INOPAI (dm.de)](https://corona-schnelltest-zentren.dm.de/o/dm/login)
 
-- EcoCare (Lidl und Kaufland): [EcoCare - Bürgertest: EcoCare - Bürgertest](https://buergertest.ecocare.center/#c734)
+- EcoCare (Lidl und Kaufland): ~~EcoCare - Bürgertest: EcoCare - Bürgertest~~ *Aktualisierung 6. März 2023: die Webseite `https://buergertest.ecocare.center` zu "EcoCare - Bürgertest" ist nicht mehr im Betrieb.*
 
 - testbuchen.de/No-Q (teilnehmende Apotheken, Hausärzte und weitere Testzentren): [Finde deinen Testtermin (testbuchen.de)](https://testbuchen.de/#/?zoom=0&lat=47.71401323721353&lng=8.66960999999999)
 
@@ -32,7 +32,7 @@ Nutzer\*innen haben damit die Möglichkeit, sich bei vielen der beteiligten Part
 
 In den ersten Tagen nach Start der Integration kann es bei wenigen Partnern noch zu kleineren technischen Schluckaufs kommen. Insgesamt läuft die Integration aber zufriedenstellend und die Nutzer\*innen scheinen die Option bereits sehr gut anzunehmen.
 
-Nach dem Test kann ein negatives Testergebnis für **48 Stunden** in der App angezeigt werden. Ein positives Testergebnis wird in der App angezeigt, bis der oder die Nutzer\*in es teilen. So soll sichergestellt werden, dass Nutzer\*innen andere so schnell wie möglich warnen, um eine mögliche Infektionskette schnell zu unterbrechen. 
+Nach dem Test kann ein negatives Testergebnis für **48 Stunden** in der App angezeigt werden. Ein positives Testergebnis wird in der App angezeigt, bis der oder die Nutzer\*in es teilen. So soll sichergestellt werden, dass Nutzer\*innen andere so schnell wie möglich warnen, um eine mögliche Infektionskette schnell zu unterbrechen.
 
 <br></br>
 <div class="text-center"><img src="./schnelltest-registrieren.png" title="Schnelltest Registrieren" alt="Schnelltest Registrieren" style="align: center"> <img src="./schnelltest-anzeigen.png" title="Schnelltest Anzeigen" alt="Schnelltest Anzeigen" style="align: center"></div>

--- a/blog/2021-05-11-How-to-Schnelltest-Partner/index_de.md
+++ b/blog/2021-05-11-How-to-Schnelltest-Partner/index_de.md
@@ -25,7 +25,7 @@ Unternehmen, die interessiert sind, ebenfalls als Partner Schnelltest-Ergebnisse
 <div class="text-center"> <img src="./dm-1.jpg" title="Dm Testzentrum auswählen" alt="Dm Testzentrum auswählen" style="align: center"></div>
 <br></br>
 
-- Wählen Sie zunächst ein Datum aus, danach eine Uhrzeit und geben Sie im Anschluss Ihre persönlichen Daten an. Die Mitarbeiter*innen brauchen diese Daten, um sie im Falle eines positiven Tests an das Gesundheitsamt weiterzuleiten. 
+- Wählen Sie zunächst ein Datum aus, danach eine Uhrzeit und geben Sie im Anschluss Ihre persönlichen Daten an. Die Mitarbeiter*innen brauchen diese Daten, um sie im Falle eines positiven Tests an das Gesundheitsamt weiterzuleiten.
 
 
 <br></br>
@@ -54,7 +54,7 @@ Unternehmen, die interessiert sind, ebenfalls als Partner Schnelltest-Ergebnisse
 <div class="text-center"> <img src="./cwa-test-registrieren.jpg" title="Test registrieren" alt="Test registrieren" style="align: center">  <img src="./cwa-code-scannen.jpg" title="QR-Code scannen" alt="QR-Code scannen" style="align: center"></div>
 <br></br>
 
-- Nachdem Sie den Test über den Link oder den QR-Code registriert haben, wird Ihnen auf der Startseite der App der **Bereich „Schnelltest“** angezeigt. Unter Test anzeigen gelangen Sie zu Ihrem registrierten Test. Solange Sie den Test noch nicht gemacht haben, steht dort, dass das Ergebnis noch nicht vorliegt. Nach der Durchführung des Schnelltests können Sie Ihren Test an dieser Stelle aktualisieren, sodass Ihnen das Ergebnis angezeigt wird. 
+- Nachdem Sie den Test über den Link oder den QR-Code registriert haben, wird Ihnen auf der Startseite der App der **Bereich „Schnelltest“** angezeigt. Unter Test anzeigen gelangen Sie zu Ihrem registrierten Test. Solange Sie den Test noch nicht gemacht haben, steht dort, dass das Ergebnis noch nicht vorliegt. Nach der Durchführung des Schnelltests können Sie Ihren Test an dieser Stelle aktualisieren, sodass Ihnen das Ergebnis angezeigt wird.
 
 <br></br>
 <div class="text-center"> <img src="./cwa-testergebnis.jpg" title="Testergebnis" alt="Testergebnis" style="align: center"></div>
@@ -81,19 +81,21 @@ Unternehmen, die interessiert sind, ebenfalls als Partner Schnelltest-Ergebnisse
 <div class="text-center"> <img src="./no-q-4.jpg" title="Test registrieren" alt="Test registrieren" style="align: center">  <img src="./no-q-5.jpg" title="Personalisierung" alt="Personalisierung" style="align: center"></div>
 <br></br>
 
-- Stimmen Sie den Datenschutzbestimmungen und der Einverständniserklärung zu und gehen Sie auf *Buchen* 
+- Stimmen Sie den Datenschutzbestimmungen und der Einverständniserklärung zu und gehen Sie auf *Buchen*
 - Nach der Durchführung des Tests erhalten Sie eine E-Mail mit einem Link zur Seite mit Ihrem Testergebnis.
 - Auf dieser Seite befindet sich der QR-Code, den Sie nun mit der Corona-Warn-App einscannen können, indem Sie auf der Startseite in Ihrer Corona-Warn-App unter "Test registrieren" auf *Nächste Schritte* gehen und anschließend auf *QR-Code scannen*.
 - Ihr Test ist dann registriert und das Testergebnis wird in der Corona-Warn-App bereitgestellt
 
 
-Vereinzelt gibt es Apotheken, die noch **technische Umstellungsmaßnahmen** durchführen müssen, um den hohen Sicherheitsstandards zu genügen, die für die Einbindung in das Corona-Warn-App-System einzuhalten sind. Der Plattform Anbieter No-Q hat dazu die entsprechende technische Unterstützung seitens des Projektteams, um das in den nächsten Tagen abzuschließen. Sollte Ihnen der oben beschriebene Link also nicht angezeigt werden, gehört Ihre ausgewählte Teststelle zu denen, die noch nicht umgestellt haben. 
+Vereinzelt gibt es Apotheken, die noch **technische Umstellungsmaßnahmen** durchführen müssen, um den hohen Sicherheitsstandards zu genügen, die für die Einbindung in das Corona-Warn-App-System einzuhalten sind. Der Plattform Anbieter No-Q hat dazu die entsprechende technische Unterstützung seitens des Projektteams, um das in den nächsten Tagen abzuschließen. Sollte Ihnen der oben beschriebene Link also nicht angezeigt werden, gehört Ihre ausgewählte Teststelle zu denen, die noch nicht umgestellt haben.
 
 ## Ablauf über EcoCare (Lidl)
 
 #### Schritt 1: Einloggen, beziehungsweise Registrieren
 
-- Finden Sie ein Testzentrum in Ihrer Nähe unter: [EcoCare - Bürgertest: EcoCare - Bürgertest](https://buergertest.ecocare.center/#c734)
+*Aktualisierung 6. März 2023: die Webseite `https://buergertest.ecocare.center` zu "EcoCare - Bürgertest" ist nicht mehr im Betrieb.*
+
+- Finden Sie ein Testzentrum in Ihrer Nähe unter: ~~EcoCare - Bürgertest: EcoCare - Bürgertest~~
 - Wählen Sie ein Testzentrum aus
 - Wenn Sie zum ersten Mal einen Termin über EcoCare buchen, können Sie zunächst ein Profil erstellen. Wählen Sie *Registrieren* und geben Sie Ihre persönlichen Daten ein. Danach wählen Sie *Weiter* und, nachdem Sie Ihre Daten noch einmal überprüft haben, *Registrieren*
 - Sie erhalten eine E-Mail mit einem Bestätigungslink. Klicken Sie auf den Link und legen Sie Ihr Passwort fest.
@@ -108,7 +110,7 @@ Vereinzelt gibt es Apotheken, die noch **technische Umstellungsmaßnahmen** durc
 <br></br>
 
 - Wählen Sie den Ort aus und gehen Sie anschließend auf *Termin vereinbaren*
-- Danach können Sie ein Datum und eine Uhrzeit auswählen und auf *Wähle dein Testkit* gehen 
+- Danach können Sie ein Datum und eine Uhrzeit auswählen und auf *Wähle dein Testkit* gehen
 
 <br></br>
 <div class="text-center"> <img src="./ecocare-3.jpg" title="Test bestellen" alt="Test bestellen" style="align: center"></div>
@@ -128,13 +130,13 @@ Vereinzelt gibt es Apotheken, die noch **technische Umstellungsmaßnahmen** durc
 <div class="text-center"> <img src="./ecocare-6.jpg" title="Test in CWA übertragen" alt="Test in CWA übertragen" style="align: center"></div>
 <br></br>
 
-- Sie werden daraufhin automatisch in die **Corona-Warn-App** weitergeleitet. Dort können Sie Ihr Einverständnis geben, dass der Test übertragen werden soll. Im Anschluss ist der Test in der App registriert. 
+- Sie werden daraufhin automatisch in die **Corona-Warn-App** weitergeleitet. Dort können Sie Ihr Einverständnis geben, dass der Test übertragen werden soll. Im Anschluss ist der Test in der App registriert.
 
 <br></br>
 <div class="text-center"> <img src="./cwa-einverständnis.jpg" title="Testergebnis" alt="Testergebnis" style="align: center">  <img src="./cwa-testergebnis-schwarz.jpg" title="Testergebnis" alt="Testergebnis" style="align: center">  </div>
 <br></br>
 
-- Auf der **Startseite der App** wird Ihnen nun der Bereich „Schnelltest“ angezeigt. Über *Test anzeigen* gelangen Sie zu Ihrem registrierten Test. Solange Sie den Test noch nicht gemacht haben, steht dort, dass das Ergebnis noch nicht vorliegt. Nach der Durchführung des Schnelltests können Sie Ihren Test an dieser Stelle aktualisieren, sodass Ihnen das Ergebnis angezeigt wird. 
+- Auf der **Startseite der App** wird Ihnen nun der Bereich „Schnelltest“ angezeigt. Über *Test anzeigen* gelangen Sie zu Ihrem registrierten Test. Solange Sie den Test noch nicht gemacht haben, steht dort, dass das Ergebnis noch nicht vorliegt. Nach der Durchführung des Schnelltests können Sie Ihren Test an dieser Stelle aktualisieren, sodass Ihnen das Ergebnis angezeigt wird.
 
 ## Stornierung eines Termins und Löschen des Tests
 
@@ -145,10 +147,10 @@ Können Sie einen Termin nicht wahrnehmen, sollten Sie ihn stornieren. Für die 
 Damit die Übertragung des Testergebnisses in die Corona-Warn-App über die jeweiligen Links der Partner einwandfrei ablaufen kann, empfehlen wir die folgenden Browser und Einstellungen, wenn Sie Ihr Smartphone nutzen, um einen Termin zu buchen:
 
 Unter Android:
-- Chrome mit der vom Hersteller voreingestellten Konfiguration (default) 
+- Chrome mit der vom Hersteller voreingestellten Konfiguration (default)
 - Samsung Internet mit Anpassung: Nutzer\*innen sollten *Links in anderen Apps öffnen* in den Einstellungen auswählen
 - Firefox mit Anpassung: Nutzer\*innen sollten *Links in Apps öffnen* in den Einstellungen auswählen
-- Edge mit der vom Hersteller voreingestellten Konfiguration (default) 
+- Edge mit der vom Hersteller voreingestellten Konfiguration (default)
 - Opera sollte nicht verwendet werden
 
 Unter iOS:


### PR DESCRIPTION
- This PR resolves the issue reported in https://github.com/corona-warn-app/cwa-website/issues/3415#issuecomment-1455528374.

Dead link to https://buergertest.ecocare.center/#c734 in blogs:

- https://www.coronawarn.app/de/blog/2021-05-11-how-to-rapid-test-integration/
![image](https://user-images.githubusercontent.com/66998419/223157754-1fe37e66-3dc2-4086-851f-ce2c91c4c60a.png)

- https://www.coronawarn.app/de/blog/2021-05-02-corona-warn-app-version-2-1
![image](https://user-images.githubusercontent.com/66998419/223164417-0e1dd70b-3d02-47a5-8c7e-1fa7b9be5afc.png)

- https://www.coronawarn.app/en/blog/2021-05-02-corona-warn-app-version-2-1
![image](https://user-images.githubusercontent.com/66998419/223164674-63d03fde-4fa8-448e-8c94-c1d6f047e600.png)

It removes the link https://buergertest.ecocare.center/#c734 from being actively used and adds a note to say that the website is no longer in operation.

This allows `npm run test:links` and the [weekly link check](https://github.com/corona-warn-app/cwa-website/actions/workflows/test-check_links.yml) to report success again.