### PR TITLE
Exclude buergertest.ecocare.center from link test

### DIFF
--- a/cypress/e2e/hybrid/check_links.cy.js
+++ b/cypress/e2e/hybrid/check_links.cy.js
@@ -2,6 +2,7 @@ const { softAssert, softExpect } = chai;
 
 const noCheckHosts = [
   'developer.apple.com',       // HTTP 403 forbidden issue on GitHub
+  'buergertest.ecocare.center', // HTTP 404 not found - testing site removed
   'ec.europa.eu',              // HTTP 502 bad gateway
   'health.ec.europa.eu',       // HTTP 502 bad gateway
   'onlinelibrary.wiley.com',   // HTTP 503 service unavailable


### PR DESCRIPTION
- This PR addresses the issue reported in https://github.com/corona-warn-app/cwa-website/issues/3415#issuecomment-1455528374. It is an alternative resolution to PR https://github.com/corona-warn-app/cwa-website/pull/3417.

- It adds the hostname `buergertest.ecocare.center` to the list `noCheckHosts` in [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js), since https://buergertest.ecocare.center/#c734 responds with a 404 (Not Found) error.

```text
$ curl -I https://buergertest.ecocare.center/#c734
HTTP/2 404
x-ua-compatible: IE=edge
content-type: text/html; charset=utf-8
date: Tue, 07 Mar 2023 08:20:57 GMT
server: Apache
```
