### PR TITLE
Exclude corona-schnelltest-zentren.dm.de from link test

### DIFF
--- a/cypress/e2e/hybrid/check_links.cy.js
+++ b/cypress/e2e/hybrid/check_links.cy.js
@@ -3,6 +3,7 @@ const { softAssert, softExpect } = chai;
 const noCheckHosts = [
   'developer.apple.com',       // HTTP 403 forbidden issue on GitHub
   'buergertest.ecocare.center', // HTTP 404 not found - testing site removed
+  'corona-schnelltest-zentren.dm.de', // HTTP 404 not found - testing site removed
   'ec.europa.eu',              // HTTP 502 bad gateway
   'health.ec.europa.eu',       // HTTP 502 bad gateway
   'onlinelibrary.wiley.com',   // HTTP 503 service unavailable


### PR DESCRIPTION
- This PR addresses the link test failure in job [4401083360](https://github.com/corona-warn-app/cwa-website/actions/runs/4401083360)

"AssertionError: Link: https://corona-schnelltest-zentren.dm.de/o/dm/login: expected false to equal true"

arising from using the link in blog articles.

- It adds the hostname `corona-schnelltest-zentren.dm.de` to the list `noCheckHosts` in [cypress/e2e/hybrid/check_links.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/hybrid/check_links.cy.js), since https://corona-schnelltest-zentren.dm.de/o/dm/login responds with a 404 (Not Found) error.

```text
curl -I https://corona-schnelltest-zentren.dm.de/o/dm/login
HTTP/2 404
content-type: text/plain; charset=utf-8
x-content-type-options: nosniff
content-length: 19
date: Mon, 13 Mar 2023 09:12:05 GMT
```

- Due to legal changes in [TestV](https://www.buzer.de/gesetz/14991/v292062-2023-03-01.htm) also mentioned in https://github.com/corona-warn-app/cwa-website/issues/3415 many test centers shut down with effect from March 1, 2023.
