### PR TITLE
Add callouts to FAQ entries for updates

### DIFF
--- a/src/assets/scss/_faq.scss
+++ b/src/assets/scss/_faq.scss
@@ -157,6 +157,13 @@ a.no-decoration {
   padding: 5px;
 }
 
+.update {
+  background: #d4eaf7;
+  padding: 5px 20px 5px 20px;
+  margin-top: -10px;
+  border-radius: 5px;
+}
+
 .filterUse {
   // background-color: #d4eaf7;
   padding: 10px;

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -372,8 +372,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated January 31, 2023</b>",
-                                    "This feature of the Corona-Warn-App is no longer available since version 3.0 and cannot be used with the previous versions 2.9 to 2.28 after January 31, 2023, as the verification hotline (TAN hotline) was discontinued on this date.",
-                                    "<hr>",
+                                    "<div class='update'>This feature of the Corona-Warn-App is no longer available since version 3.0 and cannot be used with the previous versions 2.9 to 2.28 after January 31, 2023, as the verification hotline (TAN hotline) was discontinued on this date.</div>",
                                     "As an organizer of an event, starting with version 2.9 and up to version 2.28 of the Corona-Warn-App (until January 31, 2023), you can warn for others, such as for a person who has tested positive and was attending an event but not checked in via the Corona-Warn-App (CWA), upon request by the health department.",
                                     "If a person who has not checked in later tests positive, guests may be alerted if they were in the same room at the same time or up to 30 minutes after the person who tested positive.",
                                     "To alert other guests using the CWA as an event organizer, please follow these steps:",
@@ -707,7 +706,8 @@
                                 "anchor": "cert_eu_travel",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>Please note that the behavior of the certificate validity check has changed with version 2.8. For more information on this change, please see the FAQ entry: <a href='#dcc_no_rules' target='_blank' >Why does the Corona-Warn-App with version 2.8 or newer show that my certificate couldn't be validated although versions 2.6 & 2.7 showed my certificate as valid?</a><hr>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>Please note that the behavior of the certificate validity check has changed with version 2.8. For more information on this change, please see the FAQ entry: <a href='#dcc_no_rules' target='_blank' >Why does the Corona-Warn-App with version 2.8 or newer show that my certificate couldn't be validated although versions 2.6 & 2.7 showed my certificate as valid?</a></div>",
                                     "Starting with version 2.6, you can check before traveling whether your certificates (test, recovery and/or vaccination certificate) are valid in a selected country at the time of your trip. The Corona-Warn-App takes into account the applicable entry rules of the selected travel country and compares them with various parameters of the certificate, such as the date and type of test, test center or date of vaccination.",
                                     "Every European country that supports EU digital COVID certificates has the ability to upload rules that the Corona-Warn-App can match for verification. At the start of this new feature, Ireland, Lithuania, Luxembourg, the Netherlands, Slovenia and Spain, together with Germany, have uploaded rules, with more countries to follow in the coming weeks.",
                                     "If the app shows after checking that there are no entry rules available, you can find out about the rules at <a href='https://reopen.europa.eu/en' target='_blank' rel='noopener noreferrer'>https://reopen.europa.eu/en</a>.",
@@ -1161,12 +1161,14 @@
                                 "anchor": "vac_booster_jj",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE February 2, 2022</b><br/>See this  FAQ article regarding <a href='#vc_2of1' target='_blank'>2/1 Vaccination certificates</a>.",
-                                    "<b>UPDATE December 30, 2021</b> <br/> Recently, the European Commission adapted the rules for the encoding of vaccination certificates. In the future, this will allow vaccination certificates proving the completion of the first vaccination series to always be distinguished from vaccination certificates issued after a <a href='#glossary_booster_vaccination' target='_blank'>booster vaccination</a>. In the future, <a href='#glossary_booster_vaccination' target='_blank'>booster vaccinations</a> will be marked as follows:",
+                                    "<b>UPDATE February 2, 2022</b>",
+                                    "<div class='update'>See this  FAQ article regarding <a href='#vc_2of1' target='_blank'>2/1 Vaccination certificates</a>.</div>",
+                                    "<b>UPDATE December 30, 2021</b>",
+                                    "<div class='update'>Recently, the European Commission adapted the rules for the encoding of vaccination certificates. In the future, this will allow vaccination certificates proving the completion of the first vaccination series to always be distinguished from vaccination certificates issued after a <a href='#glossary_booster_vaccination' target='_blank'>booster vaccination</a>. In the future, <a href='#glossary_booster_vaccination' target='_blank'>booster vaccinations</a> will be marked as follows:",
                                     "• 3/3 for a <a href='#glossary_booster_vaccination' target='_blank'>booster vaccination</a> after a first vaccination series with two single doses.",
                                     "• 2/1 for a <a href='#glossary_booster_vaccination' target='_blank'>booster vaccination</a> after vaccination with a single dose or administration of one dose of a vaccine consisting of two single doses to a recovered person.",
                                     "Adjustments for the app are still pending.",
-                                    "See also the <a href='https://ec.europa.eu/commission/presscorner/detail/en/ip_21_6837' target='_blank' rel='noopener noreferrer'>press release</a> issued by the European Commission on December 21, 2021. <hr/>",
+                                    "See also the <a href='https://ec.europa.eu/commission/presscorner/detail/en/ip_21_6837' target='_blank' rel='noopener noreferrer'>press release</a> issued by the European Commission on December 21, 2021. </div>",
                                     "There are three cases where there may be a report of a fourteen-day waiting period after a <a href='#glossary_booster_vaccination' target='_blank'>booster vaccination</a>:",
                                     "Case 1: <a href='#glossary_basic_immunization' target='_blank'>basic immunization</a> with Johnson & Johnson (J&J) vaccine.",
                                     "Case 2: After recovery from COVID-19, a second <a href='#glossary_booster_vaccination' target='_blank'>booster vaccination</a> is given.",
@@ -1196,7 +1198,10 @@
                                 "anchor": "admission_policy",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Update on September 28, 2022:</b><br><b>The status proof (3G, 3G+, 2G, 2G+) is currently not relevant and therefore not shown by the app</b><hr><b>Updated on March 30, 2022:</b> Starting with version 2.18, the Corona-Warn-App will also show you the 2G+ status proof for 'freshly' vaccinated, 'freshly' recovered, and 'boostered' users if the corresponding COVID digital certificates are stored in the app and also have been issued for the same name as well as date of birth.",
+                                    "<b>Update on September 28, 2022</b>",
+                                    "<div class='update'>The status proof (3G, 3G+, 2G, 2G+) is currently not relevant and therefore not shown by the app</div>",
+                                    "<b>Updated on March 30, 2022</b>",
+                                    "<div class='update'>Starting with version 2.18, the Corona-Warn-App will also show you the 2G+ status proof for 'freshly' vaccinated, 'freshly' recovered, and 'boostered' users if the corresponding COVID digital certificates are stored in the app and also have been issued for the same name as well as date of birth.</div>",
                                     "The Corona-Warn-App shows you an entry for each person for whom you have stored certificates in the overview of certificates. As of version 2.16, the status proof is displayed next to the name of the person in a blue dot, which is achieved by the stored certificates of the respective person. Currently we distinguish between four G-statuses: 3G, 3G+, 2G and 2G+. The Corona-Warn-App always shows you the status that is fulfilled at most by the stored certificates.",
                                     "As of version 2.20, you will be informed by a message whenever your G status has changed. This can be the case, for example, if you have added a certificate or the rules have changed.",
                                     "Since not all combinations of vaccinations and recoveries can be clearly mapped by the numbering scheme, the app indicates the next-higher status in case of doubt: <ul><li>Status proof 2G+: Requirements met to 2G+, 2G, 3G+, 3G.</li><li>Status proof 2G: Requirements fulfilled to 2G, 3G+, 3G.</li><li>Status proof 3G+: Requirements met to 3G+, 3G.</li><li>Status proof 3G: Requirements fulfilled to 3G.</li></ul>",
@@ -1255,10 +1260,11 @@
                                 "anchor": "mask_rules",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Updated, October 21, 2022</b><br/>As of version 2.27, the Corona-Warn-App (CWA) displays the current mask status as a dedicated symbol in the \"Certificates\" area if any federal states define their own more extensive mask obligations.<br>According to the fall/winter plan of the federal government this is divided into the \"federal legislations\" and \"supplemental measures of the federal states\" (cf. sources below).<br><b>Currently, there are no additional measures of the states.</b><hr/>",
+                                    "<b>Updated, October 21, 2022</b>",
+                                    "<div class='update'>As of version 2.27, the Corona-Warn-App (CWA) displays the current mask status as a dedicated symbol in the \"Certificates\" area if any federal states define their own more extensive mask obligations.<br>According to the fall/winter plan of the federal government this is divided into the \"federal legislations\" and \"supplemental measures of the federal states\" (cf. sources below).<br><b>Currently, there are no additional measures of the states.</b><hr/>",
                                     "Additionally, the project team has removed the indication of status proof (3G, 3G+, 2G, 2G+) on the COVID digital certificates, as there are currently no measures or targets associated with G status.",
                                     "The text box in the CWA informs users respectively: \"The status proof is currently not relevant and therefore not shown by the app.\"",
-                                    "Also, from version 2.27 onwards, the \"vaccination status\" info box in the certificate's detail view shows users their vaccination status based on the new Infection Protection Act (Infektionsschutzgesetz, IfSG).",
+                                    "Also, from version 2.27 onwards, the \"vaccination status\" info box in the certificate's detail view shows users their vaccination status based on the new Infection Protection Act (Infektionsschutzgesetz, IfSG).</div>",
                                     "<b>Overview of the legislations (COVID-19 Protection Act, COVID-19-Schutzgesetz)</b>",
                                     "<b>Nationwide regulations</b><br/>Wearing a mask is mandatory across the country only in certain scenarios (see sources):<br/><ul><li>Medical and therapeutic centers</li><li>Hospitals/clinics and care facilities</li><li>in long-distance public transportation (except in aircrafts)</li></ul>There is currently no exemption for the mask requirement in these scenarios. The CWA does not show this legal mask requirement explicitly.<br />",
                                     "<b>Potential further measures by the federal states</b><br>The federal states may respond to changes in the pandemic situation with local amplified rules:<br><ul><li>The states can define a mask requirement for additional use cases (e.g., indoor dining, cultural, or recreational facilities)</li><li>But they may also define exceptions for wearing masks (e.g. for a certain period after a \"recent\" vaccination/recovery or even after a negative test).</li></ul>",
@@ -1278,7 +1284,8 @@
                                 "anchor": "val_service_basics",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE April 12, 2022</b><br/> The Europe-wide requirements for online verification services have already been in place since October 2021. In Germany, <b>no provider of an online verification service has been approved</b>. With version 2.15, however, the CWA is ready to support corresponding verification services.<hr/>",
+                                    "<b>UPDATE April 12, 2022</b>",
+                                    "<div class='update'>The Europe-wide requirements for online verification services have already been in place since October 2021. In Germany, <b>no provider of an online verification service has been approved</b>. With version 2.15, however, the CWA is ready to support corresponding verification services.</div>",
                                     "<b>What is a DCC validation service? </b>",
                                     "Companies must comply with legal requirements to protect the health of employees and customers. In the pandemic, they therefore need reliable access management for business premises, factory halls, aircraft, trams, hotels and restaurants or events for instance. They need to be able to verify the authenticity of Digital COVID Certificates (DCCs) quickly and easily. This is served by a Validation Service."
                                 ]
@@ -1346,7 +1353,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. However, it is still possible to check in with the Corona-Warn-App by scanning luca-QR-Codes.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. However, it is still possible to check in with the Corona-Warn-App by scanning luca-QR-Codes.</div>",
                                     "You can scan the Event QR codes from the luca app with the Corona-Warn-App. It is not possible to scan the event QR codes from other apps. More details in <a href='#check_in_luca' target='_blank' >the section about joint use of luca-QR-codes</a>."
                                 ]
                             },
@@ -1420,8 +1427,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated January 31, 2023</b>",
-                                    "This feature of the Corona-Warn-App is no longer available since version 3.0 and cannot be used with the previous versions 2.9 to 2.28 after January 31, 2023, as the verification hotline (TAN hotline) was discontinued on this date.",
-                                    "<hr>",
+                                    "<div class='update'>This feature of the Corona-Warn-App is no longer available since version 3.0 and cannot be used with the previous versions 2.9 to 2.28 after January 31, 2023, as the verification hotline (TAN hotline) was discontinued on this date.</div>",
                                     "Organizers can warn for others regardless of which QR code they have scanned with the CWA. For more information on warning for others, see the following links:<ul><li><a href='#warn_for_others' target='_blank'>FAQ: How can I warn for others?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App version 2.9: Organizers can use the check-in function to warn guests on behalf of the health department</a></li></ul>"
                                 ]
                             },
@@ -1440,7 +1446,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Even when this functionality was still available in the luca app, it was not possible for the luca app to read and process QR codes from the CWA.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Even when this functionality was still available in the luca app, it was not possible for the luca app to read and process QR codes from the CWA.</div>",
                                     "The luca system transmitted the contact data required for this purpose from visitors to the event or establishment in question to the health authorities as part of contact tracking, which needed to be health authority-compliant. However, the CWA did not provide for the transmission of contact data. Thus, QR codes were needed for this process, which were different from those required by the CWA."
                                 ]
                             },
@@ -1450,7 +1456,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Even when this functionality was still available in the luca app, luca app users were not automatically warned when CWA users tested positive.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Even when this functionality was still available in the luca app, luca app users were not automatically warned when CWA users tested positive.</div>",
                                     "Even if users of both apps scanned the same QR code, no data flowed from one system to the other. Only when the responsible health office was informed about the infection from a test laboratory, for example, it could have personally informed the affected luca users about the possible risk contact. However, the principle of the CWA was based on the fact that users are warned pseudonymously via a 'red tile' (increased risk) in the event of a risk encounter. No interaction with a health department was necessary in this process."
                                 ]
                             },
@@ -1460,7 +1466,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. However, luca QR codes can still be scanned with the Corona-Warn-App.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. However, luca QR codes can still be scanned with the Corona-Warn-App.</div>",
                                     "The luca-QR codes generated as of May 25, 2021 can be read (scanned) by both the Corona-Warn-App and luca app (no longer supported since spring 2022) and processed for the check-in process - provided that the operators have explicitly agreed to this at the time of creation. The support of private luca QR codes is still not possible."
                                 ]
                             }
@@ -1514,7 +1520,8 @@
                                 "anchor": "data_donation_and_EDUS",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>In our <a href='../../science/' target='_blank' >Science Blog</a> we publish the results from the research undertaken by the Robert Koch Institute. This research is based on the data from the data donation and the event-based scientific survey.<hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>In our <a href='../../science/' target='_blank' >Science Blog</a> we publish the results from the research undertaken by the Robert Koch Institute. This research is based on the data from the data donation and the event-based scientific survey.</div>",
                                     "More information on the topics of data donation by the user and event-based scientific survey can be found in this blog entry:",
                                     " <a href='../../blog/2021-03-04-corona-warn-app-version-1-13/' target='_blank' >Users can provide data voluntarily to help improve the Corona-Warn-App further </a>.",
                                     "Further details regarding data protection can be found on this poster:",
@@ -1669,7 +1676,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated January 31, 2023</b>",
-                                    "Please note that since version 3.0 of the Corona-Warn-App, a teleTAN is no longer required to share a positive test result that has not been transmitted to the Corona-Warn-App. Therefore, the operation of the TAN hotline was discontinued as of January 31, 2023. The TAN procedure described in the following text can no longer be used. See <a href='#warn_without_tan' target='_blank' >FAQ: How do I warn without teleTAN?</a>",
+                                    "<div class='update'>Please note that since version 3.0 of the Corona-Warn-App, a teleTAN is no longer required to share a positive test result that has not been transmitted to the Corona-Warn-App. Therefore, the operation of the TAN hotline was discontinued as of January 31, 2023. The TAN procedure described in the following text can no longer be used. See <a href='#warn_without_tan' target='_blank' >FAQ: How do I warn without teleTAN?</a></div>",
                                     "<div class='container'><div class='row'><div class='col-sm'><p><b>Purpose</b></p><p>If you have been tested for the SARS-CoV-2 virus and have received a positive result in the Corona-Warn-App (CWA), you can alert other users utilizing the CWA, helping to break contact chains at an early stage.</p><p>If the result is not transferred to the CWA after scanning the QR code from the Form 10C/OEGD (or equivalent), or you have not received a QR code that is compatible with the Corona-Warn-App, you can still register a positive result in the app to alert others, as long as you receive a TAN from the verification hotline.</p></div><div class='col-sm'><a href='/assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ02_x3b-EN.pdf' target='_blank'><img src='/assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ02_x3b-EN.jpg' alt='Share a positive test result guide PDF'></a></div></div></div>",
                                     "<b>Procedure</b>",
                                     "<ul><li>You can reach the hotline exclusively by telephone.<br>Call the number: [not available anymore] (in Germany) or [not available anymore] (international).<br>You can check the operating hours of the hotline under:<br><a href='#international_phone_numbers' target='_blank'>FAQ: How to reach us</a>.</li><li>Step 1: Answer the questions of the hotline employee.</li><li>Step 2: You will receive a call back from this employee to give you the TAN. This TAN is valid for one hour.</li><li>Step 3: If the test was already registered, remove the test with no result from the Corona-Warn-App.</li><li>Step 4: Under the Status tab of the CWA, select the 'Continue' button in the section 'Manage Your Tests'.<br>Below the question 'Your PCR test was positive?' you will find the function 'Enter TAN for PCR Test'. Select this function and enter the 10-digit TAN that was provided to you.</li><li>Your positive test result is now registered in the app. Now you can warn others via the app.</li></ul>",
@@ -1732,7 +1739,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated January 31, 2023</b>",
-                                    "The operation of the TAN hotline has been discontinued as of January 31, 2023. Please note that since version 3.0 of the Corona-Warn-App, teleTAN is no longer required to share a positive test result that was not submitted to the Corona-Warn-App.",
+                                    "<div class='update'>The operation of the TAN hotline has been discontinued as of January 31, 2023. Please note that since version 3.0 of the Corona-Warn-App, teleTAN is no longer required to share a positive test result that was not submitted to the Corona-Warn-App.</div>",
                                     "If the test result is not available in the Corona-Warn-App, the relevant service personnel, test centre or health authority should be contacted to obtain the test result.  <br/>In order to make it easier for you to find the responsible health authority, the RKI has provided a corresponding tool. By entering the postal code or the city of residence, the responsible health authority (including contact details) is immediately displayed: <a href='https://tools.rki.de/PLZTool/en-GB' target='_blank' rel='noopener noreferrer'>Robert Koch Institute Tool: Health authority by postal code or place</a>",
                                     "Further information on the PCR test QR Code procedure can be found in this FAQ entry: <a href='#qr_test' target='_blank'>I have scanned a PCR test QR code, but the test result could not be retrieved for days.</a>",
                                     "The websites of the Federal Government are offering general information and videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch' target='_blank' rel='noopener noreferrer'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch</a>.",
@@ -1871,7 +1878,8 @@
                                 "anchor": "ios135",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE February 10, 2021</b><br/>The Corona-Warn-App version 1.12 also supports the older iPhone models iPhone 5s, iPhone 6, and iPhone 6 Plus. On these devices, the iOS operating system must be upgraded to at least iOS 12.5.",
+                                    "<b>UPDATE February 10, 2021</b>",
+                                    "<div class='update'>The Corona-Warn-App version 1.12 also supports the older iPhone models iPhone 5s, iPhone 6, and iPhone 6 Plus. On these devices, the iOS operating system must be upgraded to at least iOS 12.5.</div>",
                                     "Apple provides the operating system iOS 13.7 and higher versions for the iPhone SE (1st generation), iPhone 6s, and newer models.",
                                     "As of February 5, 2021, only the Corona-Warn-App (CWA) versions 1.5.3 and later are supported. For this reason, users with older versions will receive a notification to update their app accordingly. iOS users who have previously used iOS 13.5 and CWA version 1.3, for example, must now update the iOS operating system to at least iOS 13.7 in order to continue using the CWA. Only then can the technically correct operation of the app be ensured.",
                                     "<ul><li>Please update your iOS version first. Older smartphones, such as the iPhone SE, 6S or 6S Plus, also support the latest iOS operating system. This allows you to upgrade your iPhone to at least iOS 13.7. For security reasons, however, you should keep your iPhone up-to-date (currently iOS 14.4), as Apple also regularly fixes minor security vulnerabilities with the updates. You can do this on your iPhone under Settings - General - Software Update.</li><li>Subsequently, please update the Corona-Warn-App. The Corona-Warn-App must also be installed at least in version 1.5.3. The version 1.12.1 is already available.</li></ul><hr/>",
@@ -1938,6 +1946,8 @@
                                 "anchor": "interoperability_countries",
                                 "active": false,
                                 "textblock": [
+                                    "<b>Updated February 22, 2023</b>",
+                                    "<div class='update'>The  \"Interoperability Gateway\" (<a href='#glossary_efgs' target='blank'>European Federation Gateway Service</a>; <a href='#glossary_efgs' target='blank'>EFGS</a>) was deactivated EU-wide in February 2023. There is no more exchange of warnings via the gateway and the Corona-Warn-App will therefore no longer report warning messages triggered in apps from other countries.</div>",
                                     "<img src='/assets/img/faq/eu-flag.png' width=100 alt='EU flag'> This project was funded by the European Commission.",
                                     "Together with the European Commission, an infrastructure for secure information exchange has been developed, known as the \"Interoperability Gateway\". This gateway enables the Corona-Warn-App to operate across national borders and to receive potential warning messages abroad. Detailed information about the Gateway is available from the European Commission in <a href='https://ec.europa.eu/commission/presscorner/detail/en/qanda_20_1905#gateway' target='_blank' rel='noopener noreferrer'>Coronavirus: EU interoperability gateway for contact tracing and warning apps – Questions and Answers</a>. In order to also enable warnings between users of the Swiss coronavirus app and the Corona-Warn-App, the RKI also operates another exchange server (deactivated April 1, 2022) together with Switzerland (Federal Office of Public Health of the Swiss Confederation).",
                                     "To view more information in the app, tap",
@@ -2030,7 +2040,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated January 31, 2023</b>",
-                                    "Please note that since version 3.0 of the Corona-Warn-App, a teleTAN is no longer required to share a positive test result that has not been transmitted to the Corona-Warn-App. Therefore, the operation of the TAN hotline was discontinued as of January 31, 2023.",
+                                    "<div class='update'>Please note that since version 3.0 of the Corona-Warn-App, a teleTAN is no longer required to share a positive test result that has not been transmitted to the Corona-Warn-App. Therefore, the operation of the TAN hotline was discontinued as of January 31, 2023.</div>",
                                     "First of all: The app fulfills accessibility requirements (see <a href='https://github.com/corona-warn-app/cwa-documentation/blob/main/scoping_document.md#accessibility' target='_blank' rel='noopener noreferrer'>scoping document</a>) and supports all accessibility features of your phone's operating system.",
                                     "In general, you're not required to make phone calls in connection with the Corona-Warn-App. In case of a positive test result, you will get the result via a PCR test QR code, which you can scan into the app. If the testing facility doesn't support QR codes or if you don't want to use them, you receive a TAN. Only if you have received neither a QR code nor a TAN, would you have to call the TAN hotline, which you might not be able to do without outside help.",
                                     "If you can't make phone calls because you're hard of hearing, you should mention this during the test, because this will affect the whole communication process. You will then receive the TAN, if necessary, in writing.",
@@ -2281,7 +2291,8 @@
                                 "anchor": "android_location",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> If you are using Android 11 and the Corona-Warn-App version 1.5 or above, you don't have to allow location access in order to use the Corona-Warn-App.<hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>If you are using Android 11 and the Corona-Warn-App version 1.5 or above, you don't have to allow location access in order to use the Corona-Warn-App.</div>",
                                     "Corona-Warn-App does not track your location and does not have permission to do this. The reason for this message is an Android requirement: Bluetooth devices in close proximity to your device can only be detected if 'Use location' is activated on your phone (see <a href='https://support.google.com/android/answer/9888358?hl=en' target='_blank' rel='noopener noreferrer'>Use the COVID-19 Exposure Notifications System on your Android phone</a> and <a href='https://support.google.com/android/answer/9930236?hl=en' target='_blank' rel='noopener noreferrer'>About the Exposure Notifications System and Android location settings</a> in the Android help). However, this doesn't mean that apps that use Bluetooth can automatically track your location.",
                                     "Since Corona-Warn-App must be able to detect devices in close proximity, you must activate the general system setting 'Use location'. However: The app will never record your location and will never use GPS. You can verify this yourself:",
                                     "<ol><li>Open 'Settings' on your phone (not the settings of the app).</li><li>Choose 'Security & Location' &gt; 'Location' &gt; 'App level permissions'.</li><li>You see a list of apps that can use your location if you give them permission. Corona-Warn-App is not listed here.</li></ol>",
@@ -2409,7 +2420,8 @@
                                 "anchor": "rapid_test",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>Since version 2.1 it is possible to enter the test result of a rapid antigen test into the app. More information can be found in <a href='../../blog/2021-05-02-corona-warn-app-version-2-1/' target='_blank' >this</a> blog post and in the <a href='#rapid_antigen_test' target='_blank' >FAQs to rapid antigen tests</a>.<hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>Since version 2.1 it is possible to enter the test result of a rapid antigen test into the app. More information can be found in <a href='../../blog/2021-05-02-corona-warn-app-version-2-1/' target='_blank' >this</a> blog post and in the <a href='#rapid_antigen_test' target='_blank' >FAQs to rapid antigen tests</a>.</div>",
                                     "No, entering results from rapid tests is currently not supported by the Corona-Warn-App."
                                 ]
                             },
@@ -2446,7 +2458,8 @@
                                 "anchor": "huawei_honor",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>The problem was solved by the device manufacturers via a patch. Please install the latest updates for your device.<hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>The problem was solved by the device manufacturers via a patch. Please install the latest updates for your device.</div>",
                                     "For devices from Huawei or Honor, in addition to <a href='#no_risk_update' target='_blank'>switching on the Prioritized Background Activity</a>, additional settings may be necessary to improve the reliability of the background update, and to prevent <a href='#app_crash' target='_blank'>unexpected crashes of the Corona-Warn-App when starting</a> the app. This applies in particular to older devices with EMUI 4, but also to newer devices.",
                                     "According to current information, a system update seems to be available for newer Huawei devices that is explicitly intended to fix the problems with Corona-Warn-App.",
                                     "The GitHub community has compiled suggestions for making additional settings and has also linked information about the system update. You can find all the details in <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1053#issuecomment-690615554' target='_blank' rel='noopener noreferrer'>this GitHub issue</a>."
@@ -2457,7 +2470,8 @@
                                 "anchor": "ios_power_save",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>Since February 5, 2021 the minimum required version of the Corona-Warn-App is 1.5.3. This version requires iOS 13.7 or later. When using these iOS versions, the Corona-Warn-App is not negatively affected by activating Low Power Mode.<hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>Since February 5, 2021 the minimum required version of the Corona-Warn-App is 1.5.3. This version requires iOS 13.7 or later. When using these iOS versions, the Corona-Warn-App is not negatively affected by activating Low Power Mode.</div>",
                                     "If your device runs on iOS version 13.6.1 or later, the functionality of the Corona-Warn-App is not negatively affected by the Low Power Mode. On devices with an earlier iOS version, Low Power Mode may cause problems with updating the risk status in the background. <b>We therefore ask you to update the iOS version of your device to 13.6.1 or higher if you want to use the Low Power Mode.</b>"
                                 ]
                             },
@@ -2466,7 +2480,8 @@
                                 "anchor": "ExposureDetectionIsAlreadyRunning",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>This issue has been fixed in version 1.7.1.<hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This issue has been fixed in version 1.7.1.</div>",
                                     "The notification <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497' target='_blank' rel='noopener noreferrer'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633' target='_blank' rel='noopener noreferrer'>can be ignored</a>. The CWA is still working correctly and this issue will be solved with a <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510' target='_blank' rel='noopener noreferrer'>future release</a>."
                                 ]
                             },
@@ -2475,7 +2490,8 @@
                                 "anchor": "expcheck_160",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>This issue has been fixed in version 1.6.1.<hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This issue has been fixed in version 1.6.1.</div>",
                                     "After an update to app version 1.6.0, you might get the error 'Exposure Check Failed', even though there was a successful check in the past 24 hours. We are working on a solution for this error. In the meantime, try restarting your app. This helps in most cases."
                                 ]
                             },
@@ -2492,9 +2508,10 @@
                                 "anchor": "notif_weekly_update",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>The behaviour of the iOS notification regarding exposure notifications has been changed with iOS version 13.7. A notification is now displayed in a monthly interval. It can be deactivated in the iOS settings:<br/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>The behaviour of the iOS notification regarding exposure notifications has been changed with iOS version 13.7. A notification is now displayed in a monthly interval. It can be deactivated in the iOS settings:<br/>",
                                     "<ol><li>'Settings' &gt; 'Exposure Notifications'</li><li>Deactivate 'Monthly Update'.</li></ol>",
-                                    "We therefore ask you to update to the newest iOS release.<hr/>",
+                                    "We therefore ask you to update to the newest iOS release.</div>",
                                     "This is a general notification, which does not mean that risk encounters have been identified. It is <b>not</b> a message or function of the Corona-Warn-App. Apple's Exposure Notification System (ENS) sends this notification and displays the icon. Apple's ENS provides information about any encounters with app users who were tested positive - without making a statement as to whether or not it was a critical encounter according to the Robert Koch Institute's algorithm. For example, encounters are also displayed in case the distance was more than 8 meters or in case it only lasted a few minutes. This means that the 'Weekly Update' only provides information about technical procedures of the ENS that are insufficient for an actual risk calculation. A reliable risk calculation takes place exclusively in the Corona-Warn-App under the scientific framework of the Robert Koch Institute. You can view your current risk status directly in the Corona-Warn-App."
                                 ]
                             },
@@ -2503,9 +2520,10 @@
                                 "anchor": "API39508",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE January 16, 2021</b><br/>The error notification now reads \"Limit already reached\". Please see <a href='#limit_reached' target='_blank'>the corresponding FAQ entry</a> for further information on this issue.",
-                                    "<b>UPDATE</b><br/>This bug has been fixed in version 1.5 of the Corona-Warn-App. We therefore ask you to update the app accordingly.<br/><b>IMPORTANT:</b><br/><b>After updating to version 1.5 it will take up to 24 hours until the error is gone.</b>",
-                                    "If you are still receiving the error after updating to 1.5 and waiting 24 hours, please report it in the <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1459' target='_blank' rel='noopener noreferrer'>associated GitHub issue</a>.<hr/>",
+                                    "<b>UPDATE January 16, 2021</b>",
+                                    "<div class='update'>The error notification now reads \"Limit already reached\". Please see <a href='#limit_reached' target='_blank'>the corresponding FAQ entry</a> for further information on this issue.",
+                                    "This bug has been fixed in version 1.5 of the Corona-Warn-App. We therefore ask you to update the app accordingly.<b>IMPORTANT:</b> <b>After updating to version 1.5 it will take up to 24 hours until the error is gone.</b>",
+                                    "If you are still receiving the error after updating to 1.5 and waiting 24 hours, please report it in the <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1459' target='_blank' rel='noopener noreferrer'>associated GitHub issue</a>.</div>",
                                     "The notification indicates that the Corona-Warn-App has called the Exposure Notification System too often to downloaded the keys from the server and match them with the locally stored random IDs. This is how it can be determined if there were exposures to persons who reported positive.",
                                     "It can be triggered by various other errors, but is always a consequence of them, not the root cause. The error should disappear after 24 hours. Please keep your app closed for this timeframe.",
                                     "If it still occurs afterwards, please comment in the <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1459' target='_blank' rel='noopener noreferrer'>associated GitHub issue</a> and provide the following information about your phone: <ul><li>Device name</li><li>Android version</li><li>CWA App version</li></ul>",
@@ -2517,7 +2535,8 @@
                                 "anchor": "cause9002_timeout",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>This bug has been fixed in version 1.5 of the Corona-Warn-App. We therefore ask you to update the app accordingly.<br/><hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This bug has been fixed in version 1.5 of the Corona-Warn-App. We therefore ask you to update the app accordingly.</div>",
                                     "If, when opening Corona-Warn-App, the current keys of positively tested users are to be downloaded from the server (because automatic data synchronization was not yet carried out on that day) and no internet connection can be established, you may receive the following error message: 'Cause: 9002, Something went wrong. timeout'. A 'java.net.SocketTimeoutException' is given as the cause under 'Details'. There are two different known causes that can lead to this error:",
                                     "<ol><li><b>The internet connection is still being established.</b> If you have just switched on previously deactivated data connections (Wi-Fi or mobile) or restarted your phone and immediately open Corona-Warn-App, the internet connection may not have been fully established yet. There are also special apps that only enable data connections when the screen is switched on. In these cases the error message can occur. <b>Solution:</b> If the internet connection was deactivated or interrupted, wait a few seconds after switching on the internet connection before opening Corona-Warn-App. If you use an app to control data connections, set it up so that data connections in the background are enabled for Corona-Warn-App.</li><li><b>The internet connection is blocked.</b> This can be the case if you have either manually restricted data connections in your phone’s settings or if data connections for Corona-Warn-App have been automatically deactivated by your antivirus app and/or  firewall. <b>Solution:</b> Enable data usage in general as well as background data and unrestricted data usage in the settings of your phone for Corona-Warn-App. If you use an antivirus app and/or firewall on your phone, set it up so that there are no data usage restrictions for Corona-Warn-App.</li></ol>",
                                     "Please refer to <a href='https://github.com/corona-warn-app/cwa-app-android/issues/998' target='_blank' rel='noopener noreferrer'>GitHub issue 998</a> for more information."
@@ -2528,7 +2547,8 @@
                                 "anchor": "cause9002",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>This bug has been fixed in version 1.5 of the Corona-Warn-App. We therefore ask you to update the app accordingly.<br/><hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This bug has been fixed in version 1.5 of the Corona-Warn-App. We therefore ask you to update the app accordingly.</div>",
                                     "On some phones (for example, Huawei P20 Pro), there could be problems when accessing the encrypted area of the app database, where the info for the risk status and the last updates are stored. Usually, this error displays a Cause: 9002 message with hints to the database used, SQLite, sqlite_master, a security exception, or an error with the decryption. It can sometimes be that you can't open the app.",
                                     "We're working on identifying the cause and fixing it then. For details, see <a href='https://github.com/corona-warn-app/cwa-app-android/issues/642' target='_blank' rel='noopener noreferrer'>https://github.com/corona-warn-app/cwa-app-android/issues/642</a>. There, we will keep you updated for fixing the error and additional hints.",
                                     "If your phone type is not yet covered in the GitHub issue, write us the type in a comment. This helps us to determine the cause. If the GitHub issue doesn't cover your cause 9002 error, create a <a href='https://github.com/corona-warn-app/cwa-app-android/issues/new?labels=bug&template=01_bugs.md' target='_blank' rel='noopener noreferrer'>new issue</a>.",
@@ -2540,7 +2560,8 @@
                                 "anchor": "app_crash",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>This bug has been fixed in version 1.5 of the Corona-Warn-App. We therefore ask you to update the app accordingly.<br/><hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This bug has been fixed in version 1.5 of the Corona-Warn-App. We therefore ask you to update the app accordingly.</div>",
                                     "If Corona-Warn-App is unexpectedly terminated due to an error in the operating system or aggressive energy-saving measures taken by the phone, it may happen that the Corona-Warn-App can no longer access its encrypted databases when it is restarted. In this case, it is closed immediately on start. Sometimes the <a href='#cause9002' target='_blank'>error Cause: 9002 Something went wrong (sqlite)</a> was displayed before.",
                                     "We are working flat out to find a solution to the problem.",
                                     "The GitHub community has developed an emergency solution that brings the Corona-Warn-App up and running again without uninstalling it. However, since data can be lost in this case (e.g. registered COVID-19 tests for online querying of the test results), you should only use this emergency solution if no other measures were helpful (in particular suggestions from the technical hotline or from supervisors of the Corona-Warn-App in the Google Play Store), and you have fully taken note of the information on the emergency solution in the GitHub issue.",
@@ -2552,7 +2573,8 @@
                                 "anchor": "status_14",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> This Issue was resolved in version 1.2 of the Corona-Warn-App. Exposures are displayed for up to 14 days (10 days since version 2.20) after you encountered the user who then uploaded a diagnosis key using the Corona-Warn-App. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This Issue was resolved in version 1.2 of the Corona-Warn-App. Exposures are displayed for up to 14 days (10 days since version 2.20) after you encountered the user who then uploaded a diagnosis key using the Corona-Warn-App.</div>",
                                     "For some phones running Android, the exposures currently are displayed for more than 14 days. We're working on fixing this display error. You'll find up-to-date information in <a href='https://github.com/corona-warn-app/cwa-app-android/issues/911' target='_blank' rel='noopener noreferrer'>GitHub issue 911</a>."
                                 ]
                             },
@@ -2561,7 +2583,8 @@
                                 "anchor": "keys0",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> This display error was resolved by a Google Play Services update, see <a href='https://github.com/corona-warn-app/cwa-app-android/issues/744#issuecomment-659255917' target='_blank' rel='noopener noreferrer'>this GitHub comment</a>. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This display error was resolved by a Google Play Services update, see <a href='https://github.com/corona-warn-app/cwa-app-android/issues/744#issuecomment-659255917' target='_blank' rel='noopener noreferrer'>this GitHub comment</a>.</div>",
                                     "This is a known display error. The app still works as intended. We're currently working to solve this problem together with Google."
                                 ]
                             },
@@ -2578,7 +2601,8 @@
                                 "anchor": "iOS_136",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> Apple has now released iOS version 13.6.1, which fixes this error. Please update your phone to iOS 13.6.1. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>Apple has now released iOS version 13.6.1, which fixes this error. Please update your phone to iOS 13.6.1.</div>",
                                     "After updating to the iOS version 13.6, exposure logging couldn't be activated on some iPhones because exposure logging was seemingly not available in their region. For details, see GitHub issue <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/911' target='_blank' rel='noopener noreferrer'>https://github.com/corona-warn-app/cwa-app-ios/issues/911</a>."
                                 ]
                             },
@@ -2595,7 +2619,8 @@
                                 "anchor": "low_risk_text",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> This error has already been corrected. The correction is available with app version 1.2.1. Please update the app. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This error has already been corrected. The correction is available with app version 1.2.1. Please update the app.</div>",
                                     "With the latest update (1.2.0), a misleading explanatory text was introduced for a low risk of infection. If there was an exposure and the app still shows a low risk for you, the risk of infection is still ranked as 'low' and not as 'increased' (as described in the current text)."
                                 ]
                             },
@@ -2604,7 +2629,7 @@
                                 "anchor": "days_active_Apple",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> This display error is resolved by now. Please update the Corona-Warn-App to the latest version. The app will now count up the number of active days, until the 14 active days are reached, as intended. <hr/>",
+                                    "<b>UPDATE</b>","<div class='update'>This display error is resolved by now. Please update the Corona-Warn-App to the latest version. The app will now count up the number of active days, until the 14 active days are reached, as intended.</div>",
                                     "When counting the active days, an error is displayed currently: When '14 of 14 active days' is reached, the number of active days doesn't display 14 out of 14, but keeps displaying 13 out of 14 active days or fewer.",
                                     "This is only a display error. The Corona-Warn-App continues to work as intended, that means, the IDs are still exchanged and the exposure logging still works. No data is lost. Technically, it is a rounding error that displays when the number of active days of the exposure logging does not increase any more, but stays 14 days. When the exposure logging was inactive in any way, even for a short amount of time, the counter stays at a lower number of days, for example, 13 active days.",
                                     "Exposure logging can be deactivated, for example, by the following:",
@@ -2617,7 +2642,8 @@
                                 "anchor": "days_active_Android",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> This display is updated in the meantime. If nonetheless another day count displays, see <a href='#exposure_check' target='_blank'>My exposure log shows checks for less than 14 days</a>. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This display is updated in the meantime. If nonetheless another day count displays, see <a href='#exposure_check' target='_blank'>My exposure log shows checks for less than 14 days</a>.</div>",
                                     "When counting the active days, an error is displayed currently: When '14 of 14 active days' is reached, the number of active days doesn't display 14 out of 14, but keeps displaying 13 out of 14 active days or fewer.",
                                     "This is only a display error. The Corona-Warn-App continues to work as intended, that means, the IDs are still exchanged and the exposure logging still works. No data is lost. Technically, it is a rounding error that displays when the number of active days of the exposure logging does not increase any more, but stays 14 days. When the exposure logging was inactive in any way, even for a short amount of time, the counter stays at a lower number of days, for example, 13 active days.",
                                     "Exposure logging can be deactivated, for example, by the following:",
@@ -2631,7 +2657,8 @@
                                 "anchor": "days_active_explanation",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> This display is updated in the meantime. If nonetheless another day count displays, see <a href='#exposure_check' target='_blank'>My exposure log shows checks for less than 14 days</a>. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This display is updated in the meantime. If nonetheless another day count displays, see <a href='#exposure_check' target='_blank'>My exposure log shows checks for less than 14 days</a>.</div>",
                                     "The Corona-Warn-App logs exposures for the past 14 days. Older exposures are not relevant for the risk assessment and will therefore be discarded. Hence, the app will always show \"14 of 14 days saved\" if it was active for the entire time frame. The count does not start over after 14 days. If exposure logging is active and a risk status is being displayed, the app is working as expected.",
                                     "If you temporarily deactivate the app after 14 days, the displayed number can jump back to 13 (or fewer) active days. This can be triggered by the following activities:<ul><li>Disabling bluetooth</li><li>Disabling the background app refresh so that risk assessment could not be performed</li><li>Enabling flight mode</li><li>Turning off your smartphone</li><li>Restarting your smartphone</li></ul>"
                                 ]
@@ -2641,8 +2668,9 @@
                                 "anchor": "API10",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE January 14, 2021</b><br/>Should you experience this issue, please write a report here: <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1962' target='_blank' rel='noopener noreferrer'>cwa-app-android/issues/1962</a>.<hr/>",
-                                    "<b>UPDATE</b><br/> This error is resolved by version 1.5 of the Exposure Notification System. For details about your ENS version, see <a href='#ENF_version' target='_blank'>Which version of the COVID-19 Exposure Notification System is currently installed?</a>",
+                                    "<b>UPDATE January 14, 2021</b>",
+                                    "<div class='update'>Should you experience this issue, please write a report here: <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1962' target='_blank' rel='noopener noreferrer'>cwa-app-android/issues/1962</a>.</hr>",
+                                    "<br/> This error is resolved by version 1.5 of the Exposure Notification System. For details about your ENS version, see <a href='#ENF_version' target='_blank'>Which version of the COVID-19 Exposure Notification System is currently installed?</a></div>",
                                     "This error, in connection with missing risk identification, is currently fixed together with Google. Exposure logging works as intended. Please do not uninstall the app, because this can remove the logged exposures, see also <a href='#delete_random_ids' target='_blank'>'Are the exposure logs/random IDs removed from my phone when I uninstall the app?'</a>."
                                 ]
                             },
@@ -2651,7 +2679,8 @@
                                 "anchor": "ENError11",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> Although Apple stated that this Issue has been fixed with iOS 13.6, it's currently appearing again on devices which run iOS 14 or higher. To fix it please open the iOS settings and go to 'Exposure Notification', scroll down to the bottom and click 'Turn Off Exposure Notifications' and turn it back on again. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>Although Apple stated that this Issue has been fixed with iOS 13.6, it's currently appearing again on devices which run iOS 14 or higher. To fix it please open the iOS settings and go to 'Exposure Notification', scroll down to the bottom and click 'Turn Off Exposure Notifications' and turn it back on again.</div>",
                                     "The ENErrorDomain 11 error is thrown by Apple's Exposure Notification System, which is used by the Corona-Warn-App."
                                 ]
                             },
@@ -2668,7 +2697,8 @@
                                 "anchor": "iphone_region_change",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> After you updated to iOS version 13.6., this message is gone. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>After you updated to iOS version 13.6., this message is gone.</div>",
                                     "This message is issued directly by the Exposure Notification System of the operating system. You can choose 'OK' to confirm the message, exposure logging works as intended. To check this, you can also navigate to 'Settings' &gt; 'Privacy' &gt; 'Health' &gt; 'COVID-19 Exposure Logging' (iOS 13.7 or higher: 'Settings' &gt; 'Exposure Notifications' &gt; 'Exposure Logging Status') on your device to check the status. This is an iOS bug and Apple is already working on a solution, which is expected to be delivered with the next iOS update. Please open the Corona-Warn-App once again to make sure that the background app refresh continues to work."
                                 ]
                             },
@@ -2677,7 +2707,8 @@
                                 "anchor": "memory",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> This error is raised by the operating system. After you updated to Apple iOS version 13.6., this error should be gone. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This error is raised by the operating system. After you updated to Apple iOS version 13.6., this error should be gone.</div>",
                                     "The Corona-Warn-App uses just about 20 MB of smartphone storage. The size can vary slightly due to updates. In addition, the app caches some data."
                                 ]
                             },
@@ -2686,7 +2717,8 @@
                                 "anchor": "cause_3",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/> This error is fixed in the meantime. <hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>This error is fixed in the meantime.</div>",
                                     "This error can occur when you activate exposure logging for the first time or later in the settings or on the main screen of the app. It means that your device cannot log exposure for one or more of the following reasons:",
                                     "<ul><li>Google Play Services are outdated.</li><li>The app is not available with Google Play for your country. See <a href='#international' target='_blank' >In which international app stores is the app available?</a> for the supported country versions.</li><li>You haven’t installed Corona-Warn-App via the official Google Play Store.</li><li>Your device has been modified (e.g. by rooting).</li><li>You have multiple user accounts on your device and the user that you use Corona-Warn-App with doesn’t have administrator rights.</li><li>The manufacturer of your device hasn’t made Google Play Services and Google Play Store available for your device. This affects some models by Huawei und Xiaomi, for example.</li><li>Google Mobile Services are outdated.</li></ul>",
                                     "<b>Troubleshooting</b>",
@@ -2702,7 +2734,8 @@
                                 "anchor": "no_log_check",
                                 "active": false,
                                 "textblock": [
-                                    "UDPATE: This notification is no longer displayed since the diagnosis keys are available on the server.",
+                                    "<b>UDPATE</b>",
+                                    "<div class='update'>This notification is no longer displayed since the diagnosis keys are available on the server.</div>",
                                     "Exposure logging is working, don’t worry. You can find this iOS note under 'Settings' &gt; 'Privacy' &gt; 'Health' &gt; 'COVID-19 Exposure Logging' (iOS 13.7 or higher: 'Settings' &gt; 'Exposure Notifications' &gt; 'Exposure Logging Status'). It means that the back-end server has not sent any diagnosis keys to your device yet. Thus, the Corona-Warn-App hasn’t received any keys to check against the collected random IDs on your phone. As soon as persons diagnosed with COVID-19 have uploaded their diagnosis keys, this check is triggered."
                                 ]
                             },
@@ -2785,7 +2818,8 @@
                                 "anchor": "mutation",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>Information on the Corona-Warn-App and Omicron can be found in this blog post: <a href='../../blog/2022-01-11-cwa-omikron' target='_blank'>Wird die CWA an die Omikron-Variante angepasst?</a> (German only).",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>Information on the Corona-Warn-App and Omicron can be found in this blog post: <a href='../../blog/2022-01-11-cwa-omikron' target='_blank'>Wird die CWA an die Omikron-Variante angepasst?</a> (German only).</div>",
                                     "To date, the risk assessment was improved and adapted on Feb 23, 2021, on Mar 19, 2021 and on Apr 16, 2021. More information can be found in our blog:",
                                     "<ul><li><a href='../../blog/2021-02-23-corona-warn-app-risk-calculation-optimization/' target='_blank' >Feb 23, 2021 - Corona-Warn-App’s risk calculation further adjusted after detailed tests</a></li><li><a href='../../blog/2021-03-19-risk-calculation-improvement/' target='_blank' >March 19, 2021 - Corona-Warn-App's risk calculation further improved</a></li><li><a href='../../blog/2021-04-16-corona-warn-app-risk-calculation-further-improved/' target='_blank' >April 16, 2021 - Project Team further improves Corona-Warn-App's risk calculation in response to current coronavirus situation</a></li></ul>",
                                     "We will continue to monitor the risk assessment regarding the virus and improve it if necessary.<hr/>",
@@ -3308,7 +3342,8 @@
                                 "anchor": "multiple_exposure_checks",
                                 "active": false,
                                 "textblock": [
-                                    "<b>UPDATE</b><br/>As of version 1.6.0 of the Corona-Warn-App, there are no longer separate checks for each day. Instead, the app performs a single check on all available diagnosis keys from the past 14 days (10 days since version 2.20) when an update is downloaded from the server.<hr/>",
+                                    "<b>UPDATE</b>",
+                                    "<div class='update'>As of version 1.6.0 of the Corona-Warn-App, there are no longer separate checks for each day. Instead, the app performs a single check on all available diagnosis keys from the past 14 days (10 days since version 2.20) when an update is downloaded from the server.</div>",
                                     "When the app downloads the current diagnosis keys from the server, a check of the exposure log is performed. During that process, a separate check is performed for each of the last 14 days (10 days since version 2.20), for which diagnosis keys are available. It is therefore not an error that multiple, seemingly simultaneous entries are visible in the exposure check history. You can further click on the details of each check to see that different amounts of keys were provided for each of them."
                                 ]
                             },
@@ -3403,7 +3438,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. However, luca QR codes can still be scanned with the Corona-Warn-App.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. However, luca QR codes can still be scanned with the Corona-Warn-App.</div>",
                                     "The Corona-Warn-App can scan QR codes created for event registration with the luca app and perform its own check-in process. The luca app was not able to scan QR codes created by the Corona-Warn-App."
                                 ]
                             },
@@ -3413,7 +3448,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022.</div>",
                                     "The joint use of the luca QR codes by the Corona-Warn-App, which can be used for event registrations and check-ins, does not result in any further changes for users.",
                                     "CWA users will still be able to participate in the CWA system without entering contact information, while luca users' contact information could have been decoded in the case of contact tracing exclusively by the responsible health department."
                                 ]
@@ -3424,7 +3459,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022.</div>",
                                     "The QR codes generated by the luca app for the check-in process can still be read by the Corona-Warn-App (CWA).",
                                     "If users of the Corona-Warn-App scan the QR code, they will automatically be taken to the check-in area of the CWA. More information on the process can be found here: <a href='../../blog/2021-10-11-cwa-most-important-features/' target='_blank'>Why the Corona-Warn-App is important right now (Blog)</a>"
                                 ]
@@ -3435,7 +3470,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.</div>",
                                     "Using the Corona-Warn-App, users can check in to an event, for example. If they later test positive for SARS-CoV-2, they can use the Corona-Warn-App to immediately warn other participants at the same event. It does not matter whether the QR code was originally generated by the Corona-Warn-App or the luca app."
                                 ]
                             },
@@ -3445,7 +3480,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.</div>",
                                     "In order to simplify the event registration (check-in) process, the Corona-Warn-App can 'joint use' QR codes issued by luca. That is, the Corona-Warn-App can read and process the QR code that luca has issued."
                                 ]
                             },
@@ -3455,7 +3490,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.</div>",
                                     "As of fall 2021: In light of rising incidences, and with an eye on the next few weeks and months when life will increasingly take place indoors, it is important to simplify and speed up the check-in process and add a QR code that can be read by both apps.",
                                     "The process of integration took some time to meet the high data protection requirements of the CWA."
                                 ]
@@ -3466,7 +3501,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.</div>",
                                     "The data of CWA users has been and remains secure. Joint use only applies to the QR codes used for event registration and check-in. Corona-Warn-App and luca app continue to be different offerings with different objectives. Scanning a luca-QR-Code using the Corona-Warn-App does not cause any additional data to be collected.",
                                     "The joint use of QR codes was carefully prepared. All security-related aspects were worked out and checked in close cooperation with both the BfDI and the BSI.",
                                     "In addition, the Corona-Warn-App continues to operate in a very data-saving manner."
@@ -3486,7 +3521,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Updated July 15, 2022</b>",
-                                    "Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.<hr>",
+                                    "<div class='update'>Note: The luca app no longer offers event registration (check-in functionality) as of spring 2022. Nevertheless, luca QR codes can still be scanned with the Corona-Warn-App.</div>",
                                     "The Corona-Warn-App and luca are based on different approaches and have different goals.",
                                     "The Corona-Warn-App enables a quick warning of people based on the peer-to-peer principle. This warning is done pseudonymously via the Corona-Warn-App itself.",
                                     "The luca app, on the other hand, was mainly used to digitally collect contact data of the participants of an event. In the event of infection, the contact data of the person who tested positive for SARS-CoV-2 was transferred to the responsible health department. This department then contacts all persons who have scanned the same QR code.",

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -370,8 +370,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 31. Januar 2023</b>",
-                                    "Diese Funktion der Corona-Warn-App steht seit der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem 31. Januar 2023 genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wurde.",
-                                    "<hr>",
+                                    "<div class='update'>Diese Funktion der Corona-Warn-App steht seit der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem 31. Januar 2023 genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wurde.</div>",
                                     "Als Organisator einer Veranstaltung können Sie ab der Version 2.9 bis zu der Version 2.28 der Corona-Warn-App (bis zum 31. Januar 2023) nach Aufforderung durch das Gesundheitsamt Ihre Gäste in Vertretung für eine positiv getestete Person warnen, die an einer Veranstaltung teilgenommen hat, aber nicht über die Corona-Warn-App (CWA) eingecheckt war.",
                                     "Wird eine nicht eingecheckte Person später positiv getestet, können die Gäste gewarnt werden, wenn sie sich zur gleichen Zeit oder bis zu 30 Minuten nach der positiv getesteten Person im gleichen Raum aufgehalten haben.",
                                     "Um als Organisator einer Veranstaltung andere Gäste über die CWA zu warnen, gehen Sie bitte folgendermaßen vor:",
@@ -704,7 +703,8 @@
                                 "anchor": "cert_eu_travel",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Aktuell</b><br/>Bitte beachten Sie das sich das Verhalten der Zertifikatsgültigkeitsprüfung mit Version 2.8 geändert hat. Weitere Informationen zu dieser Änderung finden Sie in dem FAQ-Eintrag: <a href='#dcc_no_rules' target='_blank' >Warum zeigt die Corona-Warn-App ab Version 2.8 an, dass mein Zertifikat nicht prüfbar ist, obwohl mein Zertifikat in Versionen 2.6 & 2.7 als gültig anzeigt wurde?</a><hr>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Bitte beachten Sie das sich das Verhalten der Zertifikatsgültigkeitsprüfung mit Version 2.8 geändert hat. Weitere Informationen zu dieser Änderung finden Sie in dem FAQ-Eintrag: <a href='#dcc_no_rules' target='_blank' >Warum zeigt die Corona-Warn-App ab Version 2.8 an, dass mein Zertifikat nicht prüfbar ist, obwohl mein Zertifikat in Versionen 2.6 & 2.7 als gültig anzeigt wurde?</a></div>",
                                     "Sie können ab der Version 2.6 vor einer Reise prüfen, ob Ihre Zertifikate (Test-, Genesenen-, und/oder Impfzertifikat) in einem ausgewählten Land zum Zeitpunkt Ihrer Reise gültig sind. Die Corona-Warn-App berücksichtigt dafür die geltenden Akzeptanzregeln (in der App 'Einreiseregeln' genannt) des ausgewählten Reiselandes und gleicht sie mit verschiedenen Parametern des Zertifikats, wie Datum und Art des Tests, Testzentrum oder Datum einer Impfung, ab.",
                                     "Jedes europäische Land, das digitale COVID-Zertifikate der EU unterstützt, hat die Möglichkeit Regeln hochzuladen, die die Corona-Warn-App zur Überprüfung abgleichen kann. Zum Start der neuen Funktion haben Irland, Litauen, Luxemburg, die Niederlande, Slowenien und Spanien, zusammen mit Deutschland, Regeln hinterlegt, weitere Länder folgen in den kommenden Wochen.",
                                     "Zeigt die App nach Prüfung an, dass keine Einreiseregeln vorhanden sind, können Sie sich unter <a href='https://reopen.europa.eu/de' target='_blank' rel='noopener noreferrer'>https://reopen.europa.eu/de</a> über die geltenden nationalen Bestimmungen informieren.",
@@ -1158,12 +1158,14 @@
                                 "anchor": "vac_booster_jj",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL 2. Februar 2022</b><br/>Siehe auch diesen FAQ Artikel bezüglich <a href='#vc_2of1' target='_blank'>2/1-Impfzertifikaten</a>.",
-                                    "<b>AKTUELL 30. Dezember 2021</b> <br/> Kürzlich hat die Europäische Kommission die Vorschriften für die Kodierung von Impfzertifikaten angepasst. Dies wird in Zukunft ermöglichen, dass Impfzertifikate, die den Abschluss der ersten Impfserie belegen, immer von Impfzertifikaten unterschieden werden können, die nach einer <a href='#glossary_auffrischimpfung' target='_blank'>Auffrischimpfung</a> ausgestellt wurden. <a href='#glossary_auffrischimpfung' target='_blank'>Auffrischimpfungen</a> werden in Zukunft wie folgt gekennzeichnet:",
+                                    "<b>Aktualisiert am 2. Februar 2022</b>",
+                                    "<div class='update'>Siehe auch diesen FAQ Artikel bezüglich <a href='#vc_2of1' target='_blank'>2/1-Impfzertifikaten</a>.</div>",
+                                    "<b>Aktualisiert am 30. Dezember 2021</b>",
+                                    "<div class='update'Kürzlich hat die Europäische Kommission die Vorschriften für die Kodierung von Impfzertifikaten angepasst. Dies wird in Zukunft ermöglichen, dass Impfzertifikate, die den Abschluss der ersten Impfserie belegen, immer von Impfzertifikaten unterschieden werden können, die nach einer <a href='#glossary_auffrischimpfung' target='_blank'>Auffrischimpfung</a> ausgestellt wurden. <a href='#glossary_auffrischimpfung' target='_blank'>Auffrischimpfungen</a> werden in Zukunft wie folgt gekennzeichnet:",
                                     "• 3/3 für eine <a href='#glossary_auffrischimpfung' target='_blank'>Auffrischimpfung</a> nach einer ersten Impfserie mit zwei Einzeldosen.",
                                     "• 2/1 für eine <a href='#glossary_auffrischimpfung' target='_blank'>Auffrischimpfung</a> nach der Impfung mit einer Einzeldosis oder der Verabreichung einer Dosis eines aus zwei Einzeldosen bestehenden Impfstoffs an eine genesene Person.",
                                     "Die Anpassung der App steht noch aus.",
-                                    "Siehe auch die <a href='https://ec.europa.eu/commission/presscorner/detail/de/ip_21_6837' target='_blank' rel='noopener noreferrer'>Pressemitteilung</a> von der Europäischen Kommission vom 21. Dezember 2021.<hr/>",
+                                    "Siehe auch die <a href='https://ec.europa.eu/commission/presscorner/detail/de/ip_21_6837' target='_blank' rel='noopener noreferrer'>Pressemitteilung</a> von der Europäischen Kommission vom 21. Dezember 2021.</div>",
                                     "Es gibt drei Fälle, in denen es zu einer Anzeige von einer vierzehntägigen Wartezeit nach einer <a href='#glossary_auffrischimpfung' target='_blank'>Auffrischimpfung</a> kommen kann:",
                                     "Fall 1: Die <a href='#glossary_basic_immunization' target='_blank'>Grundimmunisierung</a> erfolgt mit dem Impfstoff von Johnson & Johnson (J&J).",
                                     "Fall 2: Nach einer Genesung von COVID-19 erfolgt eine zweite <a href='#glossary_auffrischimpfung' target='_blank'>Auffrischimpfung</a>",
@@ -1193,7 +1195,10 @@
                                 "anchor": "admission_policy",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Aktualisiert am 28. September 2022:</b><br><b>Der Status-Nachweis (3G, 3G+, 2G, 2G+) ist zurzeit nicht relevant und wird daher nicht von der App ausgewiesen</b><hr>Seit Version 2.18 zeigt Ihnen die Corona-Warn-App den Status-Nachweis 2G+ auch für „frisch“-geimpfte, “frisch”-genesene und „geboosterte“ Benutzer an, wenn die entsprechenden digitalen COVID-Zertifikate in der App abgelegt werden und auch auf den gleichen Namen sowie Geburtsdatum ausgestellt worden sind.",
+                                    "<b>Aktualisiert am 28. September 2022</b>",
+                                    "<div class='update'>Der Status-Nachweis (3G, 3G+, 2G, 2G+) ist zurzeit nicht relevant und wird daher nicht von der App ausgewiesen</div>",
+                                    "<b>Aktualisiert am 30. März 2022</b>",
+                                    "<div class='update'>Seit Version 2.18 zeigt Ihnen die Corona-Warn-App den Status-Nachweis 2G+ auch für „frisch“-geimpfte, “frisch”-genesene und „geboosterte“ Benutzer an, wenn die entsprechenden digitalen COVID-Zertifikate in der App abgelegt werden und auch auf den gleichen Namen sowie Geburtsdatum ausgestellt worden sind.</div>",
                                     "Die Corona-Warn-App zeigt Ihnen in der Übersicht der Zertifikate für jede Person, für die Sie Zertifikate hinterlegt haben, einen Eintrag an. Seit Version 2.16 wird neben dem Namen der Person in einem blauen Punkt der Status-Nachweis angezeigt, welcher durch die abgelegten Zertifikate der jeweiligen Person erreicht wird. Derzeit unterscheiden wir vier G-Status: 3G, 3G+, 2G und 2G+. Die Corona-Warn-App zeigt Ihnen immer den Status an, der durch die hinterlegten Zertifikate höchstens erfüllt wird.",
                                     "Ab Version 2.20 werden Sie immer dann durch eine Nachricht informiert, wenn sich Ihr G-Status geändert hat. Das kann zum Beispiel der Fall sein, wenn Sie ein Zertifikat hinzugefügt haben oder die Regeln sich geändert haben.",
                                     "Da nicht alle Kombinationen von Impfungen und Genesungen durch das Nummerierungsschema eindeutig abgebildet werden können, weist die App im Zweifelsfall den nächst-höherwertigen Status aus: <ul><li>Status-Nachweis 2G+: Anforderungen erfüllt zu 2G+, 2G, 3G+, 3G.</li><li>Status-Nachweis 2G: Anforderungen erfüllt zu 2G, 3G+, 3G.</li><li>Status-Nachweis 3G+: Anforderungen erfüllt zu 3G+, 3G.</li><li>Status-Nachweis 3G: Anforderungen erfüllt zu 3G.</li></ul>",
@@ -1252,9 +1257,10 @@
                                 "anchor": "mask_rules",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Aktualisiert am 21. Oktober 2022</b><br/>Ab Version 2.27 zeigt Ihnen die Corona-Warn-App (CWA) im Bereich \"Zertifikate\" den aktuellen Maskenstatus als entsprechendes Symbol, falls Bundesländer von der Möglichkeit Gebrauch machen, eigene weitergehende Maskenpflichten festzulegen.<br>Dabei wird in die \"bundesweiten Regelungen\" und \"weitergehenden Maßnahmen der Länder\" laut dem Herbst-/Winterplan der Bundesregierung unterteilt (vgl. Quellen).<br><b>Aktuell existieren keine weitergehenden Maßnahmen der Bundesländer.</b><hr/>",
+                                    "<b>Aktualisiert am 21. Oktober 2022</b>",
+                                    "<div class='update'>Ab Version 2.27 zeigt Ihnen die Corona-Warn-App (CWA) im Bereich \"Zertifikate\" den aktuellen Maskenstatus als entsprechendes Symbol, falls Bundesländer von der Möglichkeit Gebrauch machen, eigene weitergehende Maskenpflichten festzulegen.<br>Dabei wird in die \"bundesweiten Regelungen\" und \"weitergehenden Maßnahmen der Länder\" laut dem Herbst-/Winterplan der Bundesregierung unterteilt (vgl. Quellen).<br><b>Aktuell existieren keine weitergehenden Maßnahmen der Bundesländer.</b>",
                                     "Außerdem hat das Projektteam die Anzeige des Status-Nachweises (3G, 3G+, 2G, 2G+) auf den digitalen COVID-Zertifikaten entfernt, da es derzeit keine Maßnahmen und Vorgaben gibt, die an den G-Status gekoppelt sind. Die Textbox in der CWA informiert Nutzer*innen entsprechend: „Der Status-Nachweis ist zurzeit nicht relevant und wird daher nicht von der App ausgewiesen.“",
-                                    "Des Weiteren zeigt die Infobox zum Impfstatus in der Detailansicht des Zertifikats-Bereich Nutzer*innen ab Version 2.27 ihren Impfstatus auf Grundlage des neuen Infektionsschutzgesetzes an.",
+                                    "Des Weiteren zeigt die Infobox zum Impfstatus in der Detailansicht des Zertifikats-Bereich Nutzer*innen ab Version 2.27 ihren Impfstatus auf Grundlage des neuen Infektionsschutzgesetzes an.</div>",
                                     "<b>Überblick der gesetzlichen Regelungen (COVID-19-Schutzgesetz)</b>",
                                     "<b>Bundesweite Regelungen</b><br/>Das Tragen einer Maske ist bundesweit nur in bestimmten Szenarien verpflichtend (vgl. Quellen):<br/><ul><li>Medizinische und therapeutische Praxen</li><li>Krankenhäuser/Kliniken und Pflegeeinrichtungen</li><li>Verkehrsmittel im öffentlichen Personenfernverkehr (außer in Flugzeugen)</li></ul>Eine Maskenpflichtbefreiung für diese Szenarien ist aktuell nicht vorgesehen. Die CWA zeigt diese gesetzliche Maskenpflicht nicht extra an.<br />",
                                     "<b>Mögliche weitergehende Maßnahmen der Länder</b><br>Die Bundesländer können auf Veränderungen im Pandemie-Geschehen mit lokalen erweiterten Regeln reagieren:<br><ul><li>Die Länder können eine Maskenpflicht für weitere Anwendungsfälle festlegen (z.&nbsp;B. Innenräume in gastronomischen, kulturellen oder Freizeit-Einrichtungen).</li><li>Sie können aber auch Ausnahmen für das Tragen von Masken definieren (z.&nbsp;B. für einen bestimmten Zeitraum nach einer „frischen“ Impfung/Genesung oder auch nach einem negativen Test).</li></ul>",
@@ -1274,7 +1280,8 @@
                                 "anchor": "val_service_basics",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL 12. April 2022</b><br/>Bereits seit Oktober 2021 liegen die europaweit gültigen Anforderungen an Onlineverifikationsdienste vor. In Deutschland ist <b>kein Anbieter eines Onlineverifikationsdienstes zugelassen</b> worden. Mit Version 2.15 ist die CWA aber bereit, entsprechende Verifikationsdienste zu unterstützen.<hr/>",
+                                    "<b>Aktualisiert am 12. April 2022</b>",
+                                    "<div class='update'>Bereits seit Oktober 2021 liegen die europaweit gültigen Anforderungen an Onlineverifikationsdienste vor. In Deutschland ist <b>kein Anbieter eines Onlineverifikationsdienstes zugelassen</b> worden. Mit Version 2.15 ist die CWA aber bereit, entsprechende Verifikationsdienste zu unterstützen.</div>",
                                     "<b>Was ist ein DCC-Validierungsservice?</b>",
                                     "Unternehmen müssen gesetzliche Vorgaben zum Schutz der Gesundheit von Belegschaft und Kund*innen einhalten. Sie benötigen daher in der Pandemie ein verlässliches Zutrittsmanagement für beispielsweise Geschäftsräume, Werkshallen, Flugzeuge, Straßenbahnen, Hotels und Restaurants oder Veranstaltungen. Sie müssen schnell und unkompliziert die Echtheit von Digitalen COVID-Zertifikaten (DCCs) überprüfen können. Dem dient ein Corona Validation Service."
                                 ]
@@ -1342,7 +1349,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch kann mit der Corona-Warn-App durch Scannen von luca-QR-Codes weiterhin eingecheckt werden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch kann mit der Corona-Warn-App durch Scannen von luca-QR-Codes weiterhin eingecheckt werden.</div>",
                                     "Sie können die Event-QR-Codes der luca-App mit der Corona-Warn-App scannen. Es ist derzeit nicht möglich die Event-QR-Codes von anderen Kontaktverfolgungs-Apps zu scannen. Genauere Informationen dazu im <a href='#check_in_luca' target='_blank' >Abschnitt zur Mitnutzung der luca-QR-Codes</a>"
                                 ]
                             },
@@ -1416,8 +1423,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 31. Januar 2023</b>",
-                                    "Diese Funktion der Corona-Warn-App steht seit der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem 31. Januar 2023 genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.",
-                                    "<hr>",
+                                    "<div class='update'>Diese Funktion der Corona-Warn-App steht seit der Version 3.0 nicht mehr zur Verfügung und kann auch mit den vorherigen Versionen 2.9 bis 2.28 nicht mehr nach dem 31. Januar 2023 genutzt werden, da die Verifikations-Hotline (TAN-Hotline) zu diesem Datum eingestellt wird.</div>",
                                     "Veranstalter*innen können unabhängig davon, welchen QR-Code sie mit der CWA eingescannt haben, die sogenannte Stellvertreter-Warnung verwenden. Weitere Informationen zur Stellvertreter-Warnung finden Sie unter den folgenden Links: <ul><li><a href='#warn_for_others' target='_blank'>FAQ: Wie kann ich in Vertretung warnen?</a></li><li><a href='../../blog/2021-09-08-cwa-version-2-9/' target='_blank'>Blog: Corona-Warn-App Version 2.9: Veranstalter*innen können Gäste im Auftrag des Gesundheitsamtes über die Check-in-Funktion warnen</a></li></ul>"
                                 ]
                             },
@@ -1436,7 +1442,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Auch als diese Funktionalität in der luca-App noch gegeben war, war es der luca-App nicht möglich QR-Codes der CWA zu lesen und zu verarbeiten.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Auch als diese Funktionalität in der luca-App noch gegeben war, war es der luca-App nicht möglich QR-Codes der CWA zu lesen und zu verarbeiten.</div>",
                                     "Das luca-System übermittelte den Gesundheitsämtern im Rahmen einer Kontaktnachverfolgung die hierzu benötigten Kontaktdaten von Besuchenden der betreffenden Veranstaltung oder des Betriebs, die Gesundheitsamt-konform sein mussten. Bei der CWA ist eine Übermittlung von Kontaktdaten aber nicht vorgesehen. Für diesen Vorgang waren also QR-Codes nötig, die sich von denen der CWA unterschieden."
                                 ]
                             },
@@ -1446,7 +1452,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Auch als diese Funktionalität in der luca-App noch gegeben war, wurden Nutzer der luca-App nicht automatisch gewarnt, wenn CWA-Nutzer positiv getestet wurden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Auch als diese Funktionalität in der luca-App noch gegeben war, wurden Nutzer der luca-App nicht automatisch gewarnt, wenn CWA-Nutzer positiv getestet wurden.</div>",
                                     "Selbst wenn Nutzende der beiden Apps den gleichen QR-Code scannten, flossen keine Daten von einem System in das andere. Erst wenn das zuständige Gesundheitsamt beispielsweise von einem Testlabor von der Infektion erfuhr, konnte es die betroffenen luca-Nutzenden persönlich über den möglichen Risikokontakt informieren. Aber: Das Prinzip der CWA basierte darauf, dass Nutzende via „roter Kachel“ (erhöhtes Risiko) im Falle einer Risiko-Begegnung pseudonym gewarnt werden. Hierbei war keine Interaktion mit einem Gesundheitsamt nötig."
                                 ]
                             },
@@ -1456,7 +1462,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App noch luca-Qr-Codes gescannt werden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App noch luca-Qr-Codes gescannt werden.</div>",
                                     "Die ab dem 25. Mai 2021 erzeugten luca-QR-Codes können sowohl von der Corona-Warn-App als auch von luca-App (seit Frühjahr 2022 nicht mehr) gelesen (eingescannt) und für den Check-in-Prozess verarbeitet werden – sofern die Betreibenden dem bei der Erstellung explizit zugestimmt haben. Die Unterstützung privater luca-QR-Codes ist weiterhin nicht möglich."
                                 ]
                             }
@@ -1510,7 +1516,8 @@
                                 "anchor": "data_donation_and_EDUS",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/>In unserem <a href='../../science/' target='_blank'>Science-Blog</a> veröffentlichen wir die Ergebnisse der wissenschaftlichen Evaluation durch das Robert Koch-Institut. Diese Evaluation findet auf Grundlage der Daten der Datenspende und der ereignisbasierten wissenschaftlichen Befragung statt.<hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>In unserem <a href='../../science/' target='_blank'>Science-Blog</a> veröffentlichen wir die Ergebnisse der wissenschaftlichen Evaluation durch das Robert Koch-Institut. Diese Evaluation findet auf Grundlage der Daten der Datenspende und der ereignisbasierten wissenschaftlichen Befragung statt.</div>",
                                     "Mehr Informationen zu den Themen Datenspende durch den Nutzer und ereignisbasierte wissenschaftliche Befragung finden Sie in diesem Blog-Eintrag:",
                                     "<a href='../../blog/2021-03-04-corona-warn-app-version-1-13/' target='_blank' >Corona-Warn-App nun mit Datenspende und Link zu wissenschaftlicher Befragung</a>.",
                                     "Weitere Details bezüglich des Datenschutzes finden Sie auf diesem Poster:",
@@ -1663,7 +1670,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 31. Januar 2023</b>",
-                                    "Beachten Sie bitte, dass seit der Version 3.0 der Corona-Warn-App keine teleTAN mehr benötigt wird, um ein positives Testergebnis zu teilen, welches nicht in die Corona-Warn-App übermittelt wurde. Daher wurde der Betrieb der TAN-Hotline zum 31. Januar 2023 eingestellt. Das im folgenden Text beschriebene TAN-Verfahren kann nicht mehr genutzt werden. Siehe stattdessen <a href='#warn_without_tan' target='_blank' >FAQ: Wie warne ich ohne teleTAN?</a>",
+                                    "<div class='update'>Beachten Sie bitte, dass seit der Version 3.0 der Corona-Warn-App keine teleTAN mehr benötigt wird, um ein positives Testergebnis zu teilen, welches nicht in die Corona-Warn-App übermittelt wurde. Daher wurde der Betrieb der TAN-Hotline zum 31. Januar 2023 eingestellt. Das im folgenden Text beschriebene TAN-Verfahren kann nicht mehr genutzt werden. Siehe stattdessen <a href='#warn_without_tan' target='_blank' >FAQ: Wie warne ich ohne teleTAN?</a></div>",
                                     "<div class='container'><div class='row'><div class='col-sm'><p><b>Zweck</b></p><p>Wenn Sie auf das SARS-CoV-2-Virus getestet werden und das Ergebnis digital in der Corona-Warn-App (CWA) empfangen haben, können Sie bei einem positiven Befund in der CWA andere Nutzer*innen warnen und so helfen, ggf. Kontaktketten frühzeitig zu unterbrechen.</p><p>Wird nach dem Einscannen des QR-Codes vom Formular 10C/OEGD (oder ein äquivalentes Formular) das Ergebnis nicht in die CWA übertragen, oder Sie haben keinen für die Corona-Warn-App kompatiblen QR-Code erhalten, können Sie den positiven Befund trotzdem in der App registrieren und damit andere warnen, sofern Sie eine TAN von der Verifikations-Hotline empfangen.</p></div><div class='col-sm'><a href='/assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ04_x3b.pdf' target='_blank'><img src='/assets/documents/BPA_Corona-Warn-App_RKI-Plakat_Testcenter_A1_ICv2_RZ04_x3b.jpg' alt='Positives Testergebnis teilen Anleitung PDF'></a></div></div></div>",
                                     "<b>Ablauf</b>",
                                     "<ul><li>Sie erreichen die Hotline ausschließlich telefonisch.<br>Rufnummer: nicht mehr verfügbar (in Deutschland) bzw. nicht mehr verfügbar (international).<br>Wann Sie die Hotline erreichen, prüfen Sie bitte hier:<br><a href='#international_phone_numbers' target='_blank'>FAQ: So erreichen Sie uns</a>.</li><li>Schritt 1: Beantworten Sie die Fragen des Hotline-Mitarbeiters.</li><li>Schritt 2: Sie erhalten einen Rückruf von diesem Mitarbeiter, um Ihnen die TAN mitzuteilen. Diese TAN ist eine Stunde lang gültig.</li><li>Schritt 3: Entfernen Sie, falls registriert, den Test ohne Ergebnis aus der Corona-Warn-App.</li><li>Schritt 4: Unter Status der CWA wählen Sie die Schaltfläche „Weiter“ in der Funktion „Sie lassen sich testen?“.<br>Unter der Frage „Ihr PCR-Test war positiv?“ finden Sie die Funktion „TAN für PCR-Test eingeben“, wählen Sie diese Funktion und geben Sie die 10-stellige TAN ein, die Ihnen mitgeteilt wurde.</li><li>Ihr positives Testergebnis ist nun in der App registriert. Nun können Sie über die App andere warnen.</li></ul>",
@@ -1726,7 +1733,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 31. Januar 2023</b>",
-                                    "Der Betrieb der TAN-Hotline wurde zum 31. Januar 2023 eingestellt. Beachten Sie bitte, dass seit der Version 3.0 der Corona-Warn-App keine teleTAN mehr benötigt wird, um ein positives Testergebnis zu teilen, welches nicht in die Corona-Warn-App übermittelt wurde.",
+                                    "<div class='update'>Der Betrieb der TAN-Hotline wurde zum 31. Januar 2023 eingestellt. Beachten Sie bitte, dass seit der Version 3.0 der Corona-Warn-App keine teleTAN mehr benötigt wird, um ein positives Testergebnis zu teilen, welches nicht in die Corona-Warn-App übermittelt wurde.</div>",
                                     "Falls das Testergebnis nicht in der Corona-Warn-App abrufbar ist, sollte das zuständige Fachpersonal, Testcenter oder Gesundheitsamt kontaktiert werden, um das Testergebnis zu erhalten. <br/>Um Ihnen die Suche nach dem zuständigen Gesundheitsamt zu erleichtern, hat das RKI ein entsprechendes Tool zur Verfügung gestellt. Durch die Angabe der Postleitzahl oder des Wohnortes, wird sofort das zuständige Gesundheitsamt inklusive der Kontaktdaten angezeigt: <a href='https://tools.rki.de/PLZTool' target='_blank' rel='noopener noreferrer'>Robert Koch-Institut Tool: Gesundheitsamt nach Postleitzahl oder Ort</a>",
                                     "Weitere Hinweise zum PCR-Test-QR-Code Verfahren finden Sie in diesem FAQ Eintrag: <a href='#qr_test' target='_blank'>Ich habe einen PCR-Test-QR-Code eingescannt, aber das Testergebnis konnte über Tage nicht abgerufen werden.</a>",
                                     "Die Webseiten der Bundesregierung bieten allgemeine Informationen und Videos: <a href='https://www.bundesregierung.de/breg-de/themen/corona-warn-app' target='_blank' rel='noopener noreferrer'>https://www.bundesregierung.de/breg-de/themen/corona-warn-app</a>.",
@@ -1847,7 +1854,7 @@
                                 "anchor": "minimum_requirements",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL 10. Februar 2021</b>",
+                                    "<b>Aktualisiert am 10. Februar 2021</b>",
                                     "<b>iOS - Mindestvoraussetzungen für das Betriebssystem</b>",
                                     "Für die Geräte iPhone 5s, iPhone 6 bzw. iPhone 6 Plus wird mindestens iOS Version 12.5 benötigt. Das iPhone SE (1. Generation), iPhone 6s, iPhone 6s Plus und neuere iOS-Geräte benötigen mindestens iOS Version 13.7. Diese Versionen des iOS-Betriebssystems beinhalten auch die benötigte Version v2 des Apple Exposure Notification Framework.",
                                     "Siehe auch <a href='#ios135' target='_blank' >[Apple/iOS]: Warum ist iOS 13.7 Mindestvoraussetzung?</a> und die Blog Artikel <a href='../../blog/2020-12-15-ios-12-5' target='_blank' >Telekom und SAP werden die Corona-Warn-App für iOS 12.5 verfügbar machen</a> und <a href='../../blog/2021-02-10-corona-warn-app-version-1-12/' target='_blank' >Corona-Warn-App Version 1.12 mit zwei Neuerungen</a>.",
@@ -1864,7 +1871,8 @@
                                 "anchor": "ios135",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL 10. Februar 2021</b><br/>Mit der Corona-Warn-App Version 1.12 werden zusätzlich auch die älteren iPhone Modelle iPhone 5s, iPhone 6, und iPhone 6 Plus unterstützt. Voraussetzung ist auf diesen Geräten das iOS Betriebssystem mindestens auf die Version iOS 12.5 zu aktualisieren.",
+                                    "<b>Aktualisiert am 10. Februar 2021</b>",
+                                    "<div class='update'>Mit der Corona-Warn-App Version 1.12 werden zusätzlich auch die älteren iPhone Modelle iPhone 5s, iPhone 6, und iPhone 6 Plus unterstützt. Voraussetzung ist auf diesen Geräten das iOS Betriebssystem mindestens auf die Version iOS 12.5 zu aktualisieren.</div>",
                                     "Apple stellt für die Modelle iPhone SE (1. Generation), iPhone 6s, und neuere Modelle die Betriebssystem-Version iOS 13.7 und höher bereit.",
                                     "Seit dem 5. Februar 2021 werden nur die Corona-Warn-App (CWA) Versionen 1.5.3 und höher unterstützt. Aus diesem Grund erhalten Nutzer mit älteren Versionen einen Hinweis, ihre App entsprechend zu aktualisieren. iOS Nutzer, die bisher beispielsweise iOS 13.5 und CWA Version 1.3 genutzt haben, müssen ihr iOS Betriebssystem nun zwingend auf mindestens iOS 13.7 aktualisieren, um die CWA weiterhin zu nutzen. Nur in diesem Fall kann eine technisch korrekte Funktion der App sichergestellt werden.",
                                     "<ul><li>Bitte führen Sie zunächst ein Update Ihrer iOS-Version durch. Auch ältere Smartphones, wie bspw. das iPhone SE, 6S oder 6S Plus unterstützen das neueste iOS Betriebssystem. Sie können Ihr iPhone somit mindestens auf iOS 13.7 aktualisieren. Aus Sicherheitsgründen sollten Sie Ihr iPhone immer aktuell halten, da Apple auch regelmäßig kleinere Sicherheitslücken mit den Updates behebt. Sie können dies auf Ihrem iPhone unter Einstellungen – Allgemein – Softwareupdate durchführen.</li><li>Im Anschluss aktualisieren Sie bitte die Corona-Warn-App. Die Corona-Warn-App muss zudem mindestens in der Version 1.5 installiert sein. Inzwischen ist bereits Version 1.12 verfügbar. Wir bitten Sie daher, Ihre Corona-Warn-App zu aktualisieren.</li> </ul>",
@@ -1933,6 +1941,8 @@
                                 "anchor": "interoperability_countries",
                                 "active": false,
                                 "textblock": [
+                                    "<b>Aktualisiert am 22. Februar 2023</b>",
+                                    "<div class='update'>Das \"Interoperability Gateway\" (<a href='#glossary_efgs' target='blank'>European Federation Gateway Service</a>; <a href='#glossary_efgs' target='blank'>EFGS</a>) wurde im Februar 2023 EU-weit abgeschaltet. Es findet kein Austausch der Warnmeldungen über das Gateway mehr statt und die Corona-Warn-App meldet Ihnen somit auch keine Warnungen mehr, die in Apps anderer Länder ausgelöst wurden.</div>",
                                     "<img src='/assets/img/faq/eu-flag.png' width=100 alt='EU flag'> Dieses Vorhaben wurde mit Mitteln der Europäischen Kommission gefördert.",
                                     "Gemeinsam mit der EU-Kommission wurde eine Infrastruktur für einen sicheren Informationsaustausch entwickelt, die als sog. \"Interoperability Gateway\" bezeichnet wird. Dieses Gateway ermöglicht, dass die Corona-Warn-App über Landesgrenzen hinaus funktioniert und auch im Ausland potentielle Warnmeldungen empfangen werden können. Detaillierte Informationen zum Gateway bietet die EU-Kommission unter <a href='https://ec.europa.eu/commission/presscorner/detail/de/qanda_20_1905#gateway' target='_blank' rel='noopener noreferrer'>Coronavirus: EU-Datenabgleichsdienst für Kontaktnachverfolgungs- und Warn-Apps – Fragen und Antworten</a>. Damit auch Warnungen zwischen Nutzern der Schweizer Corona-App und der Corona-Warn-App möglich sind, betreibt das RKI zudem gemeinsam mit der Schweiz (Bundesamt für Gesundheit der Schweizerischen Eidgenossenschaft) einen weiteren Austausch-Server (deaktiviert am 1.04.2022).",
                                     "Um weitere Informationen in der App zu sehen, klicken Sie",
@@ -2025,7 +2035,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 31. Januar 2023</b>",
-                                    "Beachten Sie bitte, dass seit der Version 3.0 der Corona-Warn-App keine teleTAN mehr benötigt wird, um ein positives Testergebnis zu teilen, welches nicht in die Corona-Warn-App übermittelt wurde. Daher wurde der Betrieb der TAN-Hotline zum 31. Januar 2023 eingestellt.",
+                                    "<div class='update'>Beachten Sie bitte, dass seit der Version 3.0 der Corona-Warn-App keine teleTAN mehr benötigt wird, um ein positives Testergebnis zu teilen, welches nicht in die Corona-Warn-App übermittelt wurde. Daher wurde der Betrieb der TAN-Hotline zum 31. Januar 2023 eingestellt.</div>",
                                     "Grundsätzlich: Die App ist barrierefrei entwickelt worden (siehe <a href='https://github.com/corona-warn-app/cwa-documentation/blob/main/translations/scoping_document.de.md#barrierefreiheit' target='_blank' rel='noopener noreferrer'>Scoping-Dokument</a>) und unterstützt die gängigen Bedienungshilfen des Smartphone-Betriebssystems.",
                                     "In der Regel ist eine Kommunikation per Telefon nicht notwendig. Im Falle eines positiven Befunds erhalten Sie das Testergebnis standardmäßig über einen PCR-Test-QR-Code, den Sie mit der App einscannen. Wenn das Testzentrum bzw. das Labor diesen Weg nicht unterstützt oder Sie den QR-Code nicht scannen möchten, erhalten Sie eine TAN. Nur wenn Sie mit einem positiven Befund weder einen QR-Code noch eine TAN erhalten, müssten Sie die TAN-Hotline anrufen, was nicht direkt aus der App möglich ist.",
                                     "Sollten Sie wegen einer Hörschwäche nicht telefonieren können, empfiehlt es sich, darauf gleich beim Test hinzuweisen, da auch hier für die weitere Kommunikation besondere Maßnahmen einzuhalten sind. So kann sichergestellt werden, dass Sie die TAN - wenn benötigt - gleich schriftlich erhalten.",
@@ -2275,7 +2285,8 @@
                                 "anchor": "android_location",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Wenn Sie Android 11 und die Corona-Warn-App ab Version 1.5 benutzen, müssen Sie die Standortverwendung nicht mehr aktivieren, um die Corona-Warn-App zu nutzen.<hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Wenn Sie Android 11 und die Corona-Warn-App ab Version 1.5 benutzen, müssen Sie die Standortverwendung nicht mehr aktivieren, um die Corona-Warn-App zu nutzen.</div>",
                                     "Die Corona-Warn-App fragt Ihren Standort nicht ab und hat auch keine Berechtigung zur Standortabfrage. Die Meldung geht auf eine Besonderheit von Android zurück: Bluetooth-Geräte in Ihrer Nähe können grundsätzlich nur gefunden werden, wenn die Standortverwendung allgemein auf Ihrem Gerät aktiviert ist (siehe <a href='https://support.google.com/android/answer/9888358?hl=de' target='_blank' rel='noopener noreferrer'>COVID-19-Benachrichtigungen auf Ihrem Android-Smartphone aktivieren</a> und <a href='https://support.google.com/android/answer/9930236?hl=de' target='_blank' rel='noopener noreferrer'>COVID-19-Benachrichtigungssystem und Android-Standorteinstellungen</a> in der Android-Hilfe). Das bedeutet aber nicht, dass Apps, die Bluetooth nutzen, auch automatisch Ihren Standort erfassen.",
                                     "Da die Corona-Warn-App Geräte in Ihrer Nähe über Bluetooth erkennt, muss die allgemeine Systemeinstellung 'Standort verwenden' als Voraussetzung aktiviert sein. Allerdings wird die App zu keiner Zeit Ihren Standort erfassen oder GPS verwenden. Sie können das gerne selbst folgendermaßen nachprüfen:",
                                     "<ol><li>Öffnen Sie die Einstellungen Ihres Smartphones (nicht die Einstellungen in der App!).</li><li>Wählen Sie 'Sicherheit & Standort' &gt; 'Standort' &gt; 'Berechtigungen auf App-Ebene'.</li><li>Sehen Sie sich die Liste der Apps an, die auf Ihren Standort zugreifen können, wenn Sie es zulassen. Sie sehen: Die Corona-Warn-App ist nicht aufgeführt.</li></ol>",
@@ -2402,7 +2413,8 @@
                                 "anchor": "rapid_test",
                                 "active": false,
                                 "textblock": [
-                                    "<b>Aktuell</b><br/>Seit Version 2.1 ist es möglich das Testergebnis eines Corona-Schnelltests in die App einzutragen. Weitere Informationen finden Sie in <a href='../../blog/2021-05-02-corona-warn-app-version-2-1/' target='_blank' >diesem</a> Blog Post und in den <a href='#rapid_antigen_test' target='_blank' >FAQs zum Schnelltest</a>.<hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Seit Version 2.1 ist es möglich das Testergebnis eines Corona-Schnelltests in die App einzutragen. Weitere Informationen finden Sie in <a href='../../blog/2021-05-02-corona-warn-app-version-2-1/' target='_blank' >diesem</a> Blog Post und in den <a href='#rapid_antigen_test' target='_blank' >FAQs zum Schnelltest</a>.</div>",
                                     "Nein, die Eingabe von Schnelltests wird von der Corona-Warn-App zurzeit nicht unterstützt."
                                 ]
                             },
@@ -2439,7 +2451,8 @@
                                 "anchor": "huawei_honor",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Das Problem wurde von den Geräteherstellern durch einen Patch behoben. Bitte installieren Sie die neusten Updates für Ihr Gerät.<hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Das Problem wurde von den Geräteherstellern durch einen Patch behoben. Bitte installieren Sie die neusten Updates für Ihr Gerät.</div>",
                                     "Für Geräte von Huawei oder Honor können neben dem <a href='#no_risk_update' target='_blank'>Einschalten der priorisierten Hintergrundaktivität</a> zusätzliche Einstellungen notwendig sein, um die Zuverlässigkeit der Hintergrundaktualisierung zu verbessern und unerwarteten <a href='#app_crash' target='_blank'>Abstürzen der Corona-Warn-App beim Öffnen</a> der App möglicherweise vorzubeugen. Dies gilt insbesondere für ältere Geräte mit EMUI 4, aber auch für neuere Geräte.",
                                     "Nach aktuellen Informationen scheint für neuere Huawei-Geräte ein System-Update verfügbar zu sein, das explizit die Probleme mit der Corona-Warn-App beheben soll.",
                                     "Die GitHub-Community hat Vorschläge zum Vornehmen zusätzlicher Einstellungen zusammengetragen, und auch Informationen über das System-Update verlinkt. Sie finden alle Details in diesem <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1053#issuecomment-690615368' target='_blank' rel='noopener noreferrer'>GitHub-Issue</a>."
@@ -2450,7 +2463,8 @@
                                 "anchor": "ios_power_save",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/>Seit dem 5. Februar 2021 ist die Mindestversion der Corona-Warn-App die Version 1.5.3. Diese Version benötigt mindestens iOS 13.7 oder höher. Mit dieser iOS-Version wird die Funktion der Corona-Warn-App durch Aktivierung der Stromsparfunktion nicht beeinträchtigt.<hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Seit dem 5. Februar 2021 ist die Mindestversion der Corona-Warn-App die Version 1.5.3. Diese Version benötigt mindestens iOS 13.7 oder höher. Mit dieser iOS-Version wird die Funktion der Corona-Warn-App durch Aktivierung der Stromsparfunktion nicht beeinträchtigt.</div>",
                                     "Wenn Sie auf Ihrem Gerät iOS Version 13.6.1 oder höher verwenden, ist die Funktion der Corona-Warn-App im Stromsparmodus nicht beeinträchtigt. Auf Geräten mit einer früheren iOS Version kann es zu Problemen mit der Hintergrundaktualisierung kommen. <b>Wir bitten Sie daher, die iOS Version Ihres Geräts auf 13.6.1 oder höher zu aktualisieren, falls Sie den Stromsparmodus verwenden wollen.</b>"
                                 ]
                             },
@@ -2459,7 +2473,8 @@
                                 "anchor": "multiple_exposure_checks",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/>Seit Version 1.6.0 der Corona-Warn-App gibt es keine separaten Überprüfungen für die einzelnen Tage mehr. Stattdessen wird nach dem Download der aktuellen Diagnoseschlüssel vom Server eine einzelne Überprüfung von allen vorhandenen Diagnoseschlüsseln durchgeführt.<hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Seit Version 1.6.0 der Corona-Warn-App gibt es keine separaten Überprüfungen für die einzelnen Tage mehr. Stattdessen wird nach dem Download der aktuellen Diagnoseschlüssel vom Server eine einzelne Überprüfung von allen vorhandenen Diagnoseschlüsseln durchgeführt.</div>",
                                     "Sobald die App die aktuellen Diagnoseschlüssel vom Server lädt, wird eine Überprüfung der Begegnungsaufzeichnungen durchgeführt. Dabei wird für jeden der letzte 14 Tage (10 Tage ab Version 2.20), für den Diagnoseschlüssel vorhanden sind, eine separate Überprüfung der Begegnungsaufzeichnungen durchgeführt. Es ist also daher kein Fehler, dass pro Tag mehrere Einträge in der Überprüfungs-Historie vorhanden sind. Sie können zudem auf die Überprüfungseinträge klicken und sehen, dass immer unterschiedlich viele Schlüssel geprüft werden."
                                 ]
                             },
@@ -2468,7 +2483,8 @@
                                 "anchor": "ExposureDetectionIsAlreadyRunning",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Das Problem ist in Version 1.7.1 behoben worden.<hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Das Problem ist in Version 1.7.1 behoben worden.</div>",
                                     "Die Meldung <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1497' target='_blank' rel='noopener noreferrer'>'ExposureDetectionIsAlreadyRunning'</a> <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/1512#issuecomment-727206633' target='_blank' rel='noopener noreferrer'>kann ignoriert werden</a>. Die CWA funktioniert korrekt und dieses Problem wird in einem <a href='https://github.com/corona-warn-app/cwa-app-ios/pull/1510' target='_blank' rel='noopener noreferrer'> bevorstehenden Update korrigiert</a>."
                                 ]
                             },
@@ -2477,7 +2493,8 @@
                                 "anchor": "expcheck_160",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Das Problem ist in Version 1.6.1 behoben worden.<hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Das Problem ist in Version 1.6.1 behoben worden.</div>",
                                     "Nach einem Update auf Version 1.6.0 kann es vorkommen, dass Sie die Nachricht 'Risiko-Überprüfung fehlgeschlagen' erhalten, obwohl die letzte Überprüfung noch keine 24 Stunden her ist. Wir arbeiten gerade an einer Behebung dieses Problems. Bis das Update zur Verfügung steht, können Sie das Problem in den meisten Fällen mit einem Neustart Ihrer App beheben."
                                 ]
                             },
@@ -2494,9 +2511,10 @@
                                 "anchor": "notif_weekly_update",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Das Verhalten der iOS Benachrichtigung zur Begegnungsmitteilung wurde mit iOS Version 13.7 geändert. Eine Benachrichtigung wird jetzt nur noch monatlich angezeigt. Die Funktion kann in den iOS Einstellungen zudem vollständig deaktiviert werden:<br/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Das Verhalten der iOS Benachrichtigung zur Begegnungsmitteilung wurde mit iOS Version 13.7 geändert. Eine Benachrichtigung wird jetzt nur noch monatlich angezeigt. Die Funktion kann in den iOS Einstellungen zudem vollständig deaktiviert werden:<br/>",
                                     "<ol><li>'Einstellungen' &gt; 'Begegnungsmitteilungen'</li><li>'Monatliches Update' ausschalten.</li></ol>",
-                                    "Wir bitten Sie daher, ein Update auf die aktuelle iOS Version durchzuführen.<hr/>",
+                                    "Wir bitten Sie daher, ein Update auf die aktuelle iOS Version durchzuführen.</div>",
                                     "Das ist eine allgemeine Benachrichtigung, die nicht bedeutet, dass Risiko-Begegnungen erkannt worden sind. Es handelt sich dabei <b>nicht</b> um eine Meldung oder Funktion der Corona-Warn-App. Das Exposure Notification System (ENS) von Apple sendet diese Benachrichtigung und zeigt das Icon an. Die ENS-Schnittstelle von Apple informiert an dieser Stelle über jegliche Begegnungen mit App-Nutzern, die positiv getestet wurden - ohne eine Aussage darüber zu treffen, ob es sich um eine nach dem Schema des Robert Koch-Instituts kritische Begegnung handelte oder nicht. Es werden beispielsweise auch Begegnungen angezeigt, bei denen der Abstand mehr als 8 Meter betrug oder die nur wenige Minuten dauerten. Das heißt: Das 'Wöchentliche Update' informiert lediglich über technische Vorgänge des ENS, die für eine tatsächliche Risiko-Ermittlung unzureichend sind. Eine zuverlässige Risiko-Ermittlung findet ausschließlich in der Corona-Warn-App unter den wissenschaftlichen Rahmenbedingungen des Robert Koch-Instituts statt. Sie können Ihren aktuellen Risikostatus direkt in der Corona-Warn-App einsehen."
                                 ]
                             },
@@ -2505,9 +2523,10 @@
                                 "anchor": "API39508",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL 16. Januar 2021</b><br/>Die Fehlermeldung lautet nun \"Limit bereits erreicht\". Bitte lesen Sie <a href='#limit_reached' target='_blank'>den dazugehörigen FAQ-Eintrag</a> für weitere Informationen.",
-                                    "<b>AKTUELL</b><br/> Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.<br/><b>WICHTIG:</b><br/><b>Nach dem Aktualisieren auf die Version 1.5 kann es bis zu 24 Stunden dauern bis das Problem behoben ist.</b>",
-                                    "Falls der Fehler nach dem Update auf 1.5 und 24 Stunden Wartezeit immer noch auftritt, schreiben Sie bitte einen Kommentar in das <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1459' target='_blank' rel='noopener noreferrer'>dazugehörige GitHub Issue</a>.<hr/>",
+                                    "<b>Aktualisiert am 16. Januar 2021</b>",
+                                    "<div class='update'>Die Fehlermeldung lautet nun \"Limit bereits erreicht\". Bitte lesen Sie <a href='#limit_reached' target='_blank'>den dazugehörigen FAQ-Eintrag</a> für weitere Informationen.<hr/>",
+                                    "Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.<br/><b>WICHTIG: Nach dem Aktualisieren auf die Version 1.5 kann es bis zu 24 Stunden dauern bis das Problem behoben ist.</b>",
+                                    "Falls der Fehler nach dem Update auf 1.5 und 24 Stunden Wartezeit immer noch auftritt, schreiben Sie bitte einen Kommentar in das <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1459' target='_blank' rel='noopener noreferrer'>dazugehörige GitHub Issue</a>.</div>",
                                     "Die Meldung besagt, dass die Corona-Warn-App das Exposure Notification System zu oft aufgerufen hat, um die vom Server geladenen Schlüssel mit den lokal eingesammelten Zufalls-IDs abzugleichen und damit festzustellen, ob es Risiko-Begegnungen mit positiv Gemeldeten gab.",
                                     "Dieses Verhalten kann durch verschiedene andere Fehler ausgelöst werden, ist jedoch immer nur eine Folgeerscheinung. Die Meldung sollte nach 24 Stunden nicht mehr angezeigt werden. Bitte halten sie die App für diesen Zeitraum geschlossen.",
                                     "Wenn der Fehler danach immer noch auftritt schreiben Sie bitte einen Kommentar in das <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1459' target='_blank' rel='noopener noreferrer'>dazugehörige GitHub Issue</a> und geben Sie die folgenden Informationen zu Ihrem Telefon an: <ul><li>Device name</li><li>Android version</li><li>CWA App version</li></ul>",
@@ -2519,7 +2538,8 @@
                                 "anchor": "cause9002_timeout",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/>Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.<br/><hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.</div>",
                                     "Wenn beim Öffnen der Corona-Warn-App aktuelle Schlüssel positiv getesteter Nutzer vom Server heruntergeladen werden sollen (weil an diesem Tag noch kein automatischer Datenabgleich erfolgt war) und dabei keine Internetverbindung hergestellt werden kann, wird Ihnen möglicherweise eine Fehlermeldung 'Ursache: 9002, Etwas ist schiefgelaufen. timeout' angezeigt. Unter 'Details' wird als Ursache eine 'java.net.SocketTimeoutException' angegeben. Es sind zwei unterschiedliche Ursachen bekannt, die zu diesem Fehler führen können:",
                                     "<ol><li><b>Die Internetverbindung befindet sich noch im Aufbau.</b> Wenn Sie deaktivierte Datenverbindungen (WLAN oder mobil) gerade eingeschaltet oder Ihr Smartphone neu gestartet haben und sogleich die Corona-Warn-App öffnen, wurde die Internetverbindung möglicherweise noch nicht vollständig hergestellt. Zudem gibt es spezielle Apps, die Datenverbindungen erst dann freigeben, wenn der Bildschirm angeschaltet wird. In diesen Fällen ist das Auftreten des Fehlers möglich. <b>Lösung:</b> War die Internetverbindung deaktiviert oder unterbrochen, warten Sie nach dem Einschalten der Internetverbindung einige Sekunden, bevor Sie die Corona-Warn-App öffnen. Falls Sie eine App zur Kontrolle von Datenverbindungen nutzen, stellen Sie sie so ein, dass Datenverbindungen im Hintergrund für die Corona-Warn-App freigegeben sind.</li><li><b>Die Internetverbindung wird blockiert.</b> Dies kann der Fall sein, wenn Sie entweder Datenverbindungen in den Einstellungen Ihres Smartphones manuell eingeschränkt haben oder wenn Datenverbindungen für die Corona-Warn-App von einer Antivirus-App und/oder einer Firewall automatisch deaktiviert wurden. <b>Lösung:</b> Geben Sie in den Einstellungen Ihres Smartphones (Netzwerk und Internet, Mobile Daten und WLAN) für die Corona-Warn-App die Datennutzung im Allgemeinen, sowie Hintergrunddaten und uneingeschränkte Datennutzung frei. Falls Sie eine Antivirus-App und/oder eine Firewall auf Ihrem Smartphone nutzen, stellen Sie sie so ein, dass für die Corona-Warn-App keine Einschränkungen in der Datennutzung bestehen.</li></ol>",
                                     "In dem <a href='https://github.com/corona-warn-app/cwa-app-android/issues/998' target='_blank' rel='noopener noreferrer'>GitHub-Issue 998</a> finden Sie weitere Informationen (englisch)."
@@ -2530,7 +2550,8 @@
                                 "anchor": "cause9002",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/>Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.<br/><hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.</div>",
                                     "Es kommt auf einzelnen Geräten (z.&nbsp;B. dem Huawei P20 Pro) zu Problemen beim Zugriff auf den verschlüsselten Bereich der App-Datenbank, in der Informationen zum Risiko-Status und der letzten Aktualisierung abgelegt sind. In der Regel zeigt sich dieser Fehler durch die Ursache 9002 und Hinweise auf die verwendete Datenbank (database), SQLite, sqlite_master, eine Security-Exception oder einen Fehler bei der Entschlüsselung (decryption). Das kann manchmal dazu führen, dass Sie die App nicht mehr öffnen können.",
                                     "Wir arbeiten daran, die Ursache zu finden und zu beheben. Details dazu finden Sie im GitHub-Issue <a href='https://github.com/corona-warn-app/cwa-app-android/issues/642' target='_blank' rel='noopener noreferrer'>https://github.com/corona-warn-app/cwa-app-android/issues/642</a>. Dort werden wir auch Fehlerbehebungen und weitere Hinweise veröffentlichen.",
                                     "Wenn Ihr Smartphone-Typ in diesem GitHub-Issue noch nicht genannt ist, schreiben Sie uns bitte den Typ in einem Kommentar. Das hilft uns, die Ursache zu bestimmen. Wenn das GitHub-Issue nicht auf Ihren Fehler mit der Ursache 9002 zutrifft, legen Sie gerne einen <a href='https://github.com/corona-warn-app/cwa-app-android/issues/new?labels=bug&template=01_bugs.md' target='_blank' rel='noopener noreferrer'>neuen Issue</a> an.",
@@ -2542,7 +2563,8 @@
                                 "anchor": "app_crash",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/>Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.<br/><hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Dieser Fehler wurde in Version 1.5 der Corona-Warn-App behoben. Wir bitten Sie daher, die App entsprechend zu aktualisieren.</div>",
                                     "Wenn die Corona-Warn-App durch einen Fehler im Betriebssystem oder durch aggressive Energiesparmaßnahmen des Telefons unerwartet beendet wird, kann es vorkommen, dass bei einem erneuten Start die Corona-Warn-App nicht mehr auf ihre verschlüsselten Datenbanken zugreifen kann. In diesem Fall schließt sie sich sofort wieder. Manchmal wurde vorher der <a href='#cause9002' target='_blank'>Fehler Ursache: 9002 Etwas ist schiefgelaufen (sqlite)</a> angezeigt.",
                                     "Wir arbeiten mit Hochdruck an einer Lösung des Problems.",
                                     "Die GitHub-Community hat eine Notfall-Lösung erarbeitet, die die Corona-Warn-App ohne Deinstallation wieder zum Laufen bringt. Da hierbei jedoch Daten verloren gehen können (z.&nbsp;B. registrierte COVID-19-Tests zur Online-Abfrage der Testergebnisse), sollten Sie diese Notfall-Lösung nur dann anwenden, wenn keine anderen Maßnahmen (insbesondere Vorschläge von der technischen Hotline oder von Betreuern der Corona-Warn-App im Google Play Store) geholfen haben, und Sie die Hinweise zur Notfall-Lösung im GitHub-Issue vollständig zur Kenntnis genommen haben.",
@@ -2554,7 +2576,8 @@
                                 "anchor": "status_14",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Dieser Fehler wurde in Version 1.2 der Corona-Warn-App behoben. Risiko-Begegnungen werden Ihnen bis zu 14 Tage (10 Tage ab Version 2.20) nach dem Zeitpunkt der Begegnung mit dem Nutzer, der dann ein positives COVID-19-Testergebnis in der Corona-Warn-App gemeldet hat, angezeigt. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Dieser Fehler wurde in Version 1.2 der Corona-Warn-App behoben. Risiko-Begegnungen werden Ihnen bis zu 14 Tage (10 Tage ab Version 2.20) nach dem Zeitpunkt der Begegnung mit dem Nutzer, der dann ein positives COVID-19-Testergebnis in der Corona-Warn-App gemeldet hat, angezeigt.</div>",
                                     "Bei einigen Android-Smartphones kommt es aktuell vor, dass die Risiko-Begegnungen länger als 14 Tage angezeigt werden. Wir arbeiten an der Behebung dieses Anzeigefehlers. Aktuelle Informationen finden Sie auf Englisch im <a href='https://github.com/corona-warn-app/cwa-app-android/issues/911' target='_blank' rel='noopener noreferrer'>GitHub-Issue 911</a>."
                                 ]
                             },
@@ -2563,7 +2586,8 @@
                                 "anchor": "keys0",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Dieser Anzeigefehler wurde über ein Update der Google Play Services behoben, siehe <a href='https://github.com/corona-warn-app/cwa-app-android/issues/744#issuecomment-659255917' target='_blank' rel='noopener noreferrer'>diesen GitHub-Kommentar</a> in englischer Sprache. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Dieser Anzeigefehler wurde über ein Update der Google Play Services behoben, siehe <a href='https://github.com/corona-warn-app/cwa-app-android/issues/744#issuecomment-659255917' target='_blank' rel='noopener noreferrer'>diesen GitHub-Kommentar</a> in englischer Sprache.</div>",
                                     "Das ist ein bekannter Anzeigefehler. Die App funktioniert nach wie vor. Wir arbeiten gerade gemeinsam mit Google an der Lösung."
                                 ]
                             },
@@ -2580,7 +2604,8 @@
                                 "anchor": "iOS_136",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Mittlerweile hat Apple die iOS-Version 13.6.1 veröffentlicht, die dieses Problem behebt. Bitte aktualisieren Sie Ihr Smartphone auf iOS 13.6.1. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Mittlerweile hat Apple die iOS-Version 13.6.1 veröffentlicht, die dieses Problem behebt. Bitte aktualisieren Sie Ihr Smartphone auf iOS 13.6.1.</div>",
                                     "In der iOS-Version 13.6 konnte auf einigen Geräten die Risiko-Ermittlung nicht mehr aktiviert werden, da Begegnungsaufzeichnungen in ihrer Region nicht verfügbar seien. Details dazu finden Sie im GitHub-Issue <a href='https://github.com/corona-warn-app/cwa-app-ios/issues/911' target='_blank' rel='noopener noreferrer'>https://github.com/corona-warn-app/cwa-app-ios/issues/911</a>."
                                 ]
                             },
@@ -2597,7 +2622,8 @@
                                 "anchor": "low_risk_text",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Dieser Fehler ist bereits korrigiert. Die Korrektur ist ab App-Version 1.2.1 verfügbar. Bitte aktualisieren Sie die App. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Dieser Fehler ist bereits korrigiert. Die Korrektur ist ab App-Version 1.2.1 verfügbar. Bitte aktualisieren Sie die App.</div>",
                                     "In dem erklärenden Text für ein niedriges Infektionsrisiko wurde mit dem letzten Update eine sich widersprechende Beschreibung eingefügt. Wenn Sie eine Risiko-Begegnung hatten, die App aber weiter ein niedriges Risiko für Sie anzeigt, dann wird die Infektionswahrscheinlichkeit für Sie als niedrig eingestuft und nicht wie im Text derzeit geschrieben als erhöht."
                                 ]
                             },
@@ -2606,7 +2632,8 @@
                                 "anchor": "days_active_Apple",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Dieser Anzeigefehler ist inzwischen behoben. Bitte aktualisieren Sie die Corona-Warn-App auf die neueste Version. Die App zählt jetzt die aktiven Tage weiter, bis sie, wie vorgesehen, 14 erreicht hat. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Dieser Anzeigefehler ist inzwischen behoben. Bitte aktualisieren Sie die Corona-Warn-App auf die neueste Version. Die App zählt jetzt die aktiven Tage weiter, bis sie, wie vorgesehen, 14 erreicht hat.</div>",
                                     "Bei der Zählung der aktiven Tage gibt es derzeit einen Fehler, der dazu führt, dass bei Erreichen von '14 von 14 Tagen aktiv' die Anzeige der Anzahl aktiver Tage nicht bei 14 von 14 Tagen bleibt, sondern statisch auf „13 von 14 Tagen aktiv“ oder weniger stehen bleibt.",
                                     "Dieser Fehler betrifft nur die Anzeige der aktiven Tage in der Corona-Warn-App. Die Funktion selbst ist nicht eingeschränkt, das heißt, die Schlüssel werden weiterhin ausgetauscht und die Risiko-Ermittlung wird weiterhin durchgeführt. Es gehen keine Daten verloren. Technisch gesehen handelt es sich hier um einen Rundungsfehler, der auftritt, wenn die Anzahl aktiver Tage der Risiko-Ermittlung nicht mehr zunimmt, sondern statisch bei 14 Tagen bleibt. Wenn die Risiko-Ermittlung auch nur kurzfristig in irgendeiner Form nicht aktiv war, bleibt der Zähler bei einem niedrigeren Wert, also etwa bei 13 Tagen stehen.",
                                     "Mögliche Ursachen für eine Deaktivierung der Risiko-Ermittlung:",
@@ -2619,7 +2646,8 @@
                                 "anchor": "days_active_Android",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Diese Anzeige ist inzwischen aktualisiert. Sollte dennoch eine andere Zahl der Tagen angezeigt werden, siehe <a href='#exposure_check' target='_blank'> Aufzeichnungen von weniger als 14 Tagen gespeichert</a>. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Diese Anzeige ist inzwischen aktualisiert. Sollte dennoch eine andere Zahl der Tagen angezeigt werden, siehe <a href='#exposure_check' target='_blank'> Aufzeichnungen von weniger als 14 Tagen gespeichert</a>.</div>",
                                     "Bei der Zählung der aktiven Tage gibt es derzeit einen Fehler, der dazu führt, dass bei Erreichen von '14 von 14 Tagen aktiv' die Anzeige der Anzahl aktiver Tage nicht bei 14 von 14 Tagen bleibt, sondern statisch auf „13 von 14 Tagen aktiv“ oder weniger stehen bleibt.",
                                     "Dieser Fehler betrifft nur die Anzeige der aktiven Tage in der Corona-Warn-App. Die Funktion selbst ist nicht eingeschränkt, das heißt, die Schlüssel werden weiterhin ausgetauscht und die Risiko-Ermittlung wird weiterhin durchgeführt. Es gehen keine Daten verloren. Technisch gesehen handelt es sich hier um einen Rundungsfehler, der auftritt, wenn die Anzahl aktiver Tage der Risiko-Ermittlung nicht mehr zunimmt, sondern statisch bei 14 Tagen bleibt. Wenn die Risiko-Ermittlung auch nur kurzfristig in irgendeiner Form nicht aktiv war, bleibt der Zähler bei einem niedrigeren Wert, also etwa bei 13 Tagen stehen.",
                                     "Mögliche Ursachen für eine Deaktivierung der Risiko-Ermittlung:",
@@ -2633,7 +2661,8 @@
                                 "anchor": "days_active_explanation",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Diese Anzeige ist inzwischen aktualisiert. Sollte dennoch eine andere Zahl der Tagen angezeigt werden, siehe <a href='#exposure_check' target='_blank'> Aufzeichnungen von weniger als 14 Tagen gespeichert</a>. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Diese Anzeige ist inzwischen aktualisiert. Sollte dennoch eine andere Zahl der Tagen angezeigt werden, siehe <a href='#exposure_check' target='_blank'> Aufzeichnungen von weniger als 14 Tagen gespeichert</a>.</div>",
                                     "Die Corona-Warn-App sammelt immer die Kontakte der letzten 14 Tage. Alle älteren Kontakte sind für die Risiko-Ermittlung nicht relevant und werden daher auch gelöscht. Somit wird Ihnen immer \"14 von 14 Tagen aktiv\" angezeigt werden, wenn die App im gesamten Zeitraum aktiv war. Die Zählung beginnt nach 14 Tagen nicht von vorn. Sofern also Ihre Risiko-Ermittlung aktiv ist und auch ein Risiko-Status angezeigt wird, funktioniert die Corona-Warn-App so, wie sie soll.",
                                     "Sollten sie die App nach Erreichen der 14 Tage deaktivieren, kann die Anzeige auch zurückspringen auf 13 (oder weniger) aktive Tage. Dies kann z.&nbsp;B. durch eine der folgenden Aktionen ausgelöst werden:<ul><li>Bluetooth deaktivieren</li><li>Hintergrundaktualisierung für die App abschalten, sodass nicht immer eine Risiko-Ermittlung durchgeführt wurde</li><li>Einschalten des Flugmodus</li><li>Ausschalten des Smartphones</li><li>Neustart des Smartphones</li></ul>"
                                 ]
@@ -2643,8 +2672,9 @@
                                 "anchor": "API10",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL 14. Januar 2021</b><br/>Sollten Sie dieses Problem haben, schreiben Sie bitte Ihren Bericht hier: <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1962' target='_blank' rel='noopener noreferrer'>cwa-app-android/issues/1962</a>.<hr/>",
-                                    "<b>AKTUELL</b><br/> Dieser Fehler ist mit der Version 1.5 des Exposure Notification Systems behoben. So sehen Sie nach, welche Version Sie installiert haben: <a href='#ENF_version' target='_blank'>Welche Version des COVID-19-Benachrichtigungen habe ich?</a>",
+                                    "<b>Aktualisiert am 14. Januar 2021</b>",
+                                    "<div class='update'>Sollten Sie dieses Problem haben, schreiben Sie bitte Ihren Bericht hier: <a href='https://github.com/corona-warn-app/cwa-app-android/issues/1962' target='_blank' rel='noopener noreferrer'>cwa-app-android/issues/1962</a>.<hr/>",
+                                    "Dieser Fehler ist mit der Version 1.5 des Exposure Notification Systems behoben. So sehen Sie nach, welche Version Sie installiert haben: <a href='#ENF_version' target='_blank'>Welche Version des COVID-19-Benachrichtigungen habe ich?</a></div>",
                                     "Der Fehler (10) in Zusammenhang mit der fehlenden Risiko-Überprüfung wird aktuell gemeinsam mit Google behoben. Wir können Ihnen aber bestätigen, dass Ihre Kontakte weiterhin aufgezeichnet werden. Daher würden wir Sie bitten, die App nicht zu löschen, da hierbei Ihre aufgezeichneten Kontaktereignisse verloren gehen können, siehe auch <a href='#delete_random_ids' target='_blank'>'Werden die gesammelten Zufalls-IDs beim Deinstallieren der App entfernt?'</a>."
                                 ]
                             },
@@ -2661,7 +2691,8 @@
                                 "anchor": "ENError11",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Obwohl nach Apples Angaben dieser Fehler mit iOS 13.6 behoben wurde, taucht er nun wieder auf Geräten, welche iOS 14 oder neuer installiert haben, auf. Um den Fehler zu beheben, gehen Sie bitte in die iOS Einstellungen und klicken dort auf den Punkt: 'Begegnungsmitteilungen', scrollen ganz nach unten und klicken auf 'Begegnungsmitteilungen deaktivieren'. Warten Sie einen Moment und schalten Sie Begegnungsmitteilungen wieder an. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Obwohl nach Apples Angaben dieser Fehler mit iOS 13.6 behoben wurde, taucht er nun wieder auf Geräten, welche iOS 14 oder neuer installiert haben, auf. Um den Fehler zu beheben, gehen Sie bitte in die iOS Einstellungen und klicken dort auf den Punkt: 'Begegnungsmitteilungen', scrollen ganz nach unten und klicken auf 'Begegnungsmitteilungen deaktivieren'. Warten Sie einen Moment und schalten Sie Begegnungsmitteilungen wieder an.</div>",
                                     "Der Fehler ENErrorDomain 11 kommt aus dem Exposure Notification System, das von Apple bereitgestellt und von der App genutzt wird."
                                 ]
                             },
@@ -2670,7 +2701,8 @@
                                 "anchor": "iphone_region_change",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Wenn Sie auf iOS-Version 13.6. aktualisiert haben, ist diese Meldung behoben. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Wenn Sie auf iOS-Version 13.6. aktualisiert haben, ist diese Meldung behoben.</div>",
                                     "Diese Nachricht wird direkt vom Betriebssystem bzw. dem Exposure Notification System ausgelöst. Sie können die Meldung mit 'OK' bestätigen, die Kontaktermittlung funktioniert ganz normal. Um dies zu prüfen, können Sie in den Geräte-Einstellungen unter 'Datenschutz' &gt; 'Health' &gt; 'COVID-19-Kontaktprotokoll' (iOS 13.7 und höher: 'Einstellungen' &gt; 'Begegnungsmitteilungen' &gt; 'Status von Begegnungsaufzeichnungen') den Status der Kontaktermittlung überprüfen. Es handelt sich um einen iOS-Fehler. Apple arbeitet bereits an einer Lösung, die voraussichtlich mit dem nächsten iOS-Update ausgeliefert wird.",
                                     "Bitte öffnen Sie die Corona-Warn-App noch ein Mal kurz, um sicherzustellen, dass die Hintergrundaktualisierung weiter arbeitet."
                                 ]
@@ -2680,7 +2712,8 @@
                                 "anchor": "memory",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Diese Fehlermeldung kommt aus dem Betriebssystem. Wenn Sie auf Apple iOS-Version 13.6. aktualisiert haben, sollte der Fehler weniger häufig auftreten. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Diese Fehlermeldung kommt aus dem Betriebssystem. Wenn Sie auf Apple iOS-Version 13.6. aktualisiert haben, sollte der Fehler weniger häufig auftreten.</div>",
                                     "Die Corona-Warn-App benötigt nur ca. 20 MB Speicherplatz auf dem Handy. Die Größe kann sich durch eventuelle Updates laufend verändern (wenn auch nur minimal). Zusätzlich fallen weitere Speicherkapazitäten durch die von der App zwischengespeicherten Daten an."
                                 ]
                             },
@@ -2689,7 +2722,8 @@
                                 "anchor": "cause_3",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Dieser Fehler ist inzwischen behoben. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Dieser Fehler ist inzwischen behoben.</div>",
                                     "Dieser Fehler kann bei der ersten Aktivierung der Risiko-Ermittlung oder auch später in den App-Einstellungen oder auf dem Hauptbildschirm auftreten. Der Fehler bedeutet, dass Ihr Gerät aus einem oder mehreren der folgenden Gründe die Risiko-Ermittlung nicht durchführen kann:",
                                     "<ul><li>Ihre Google Play-Dienste sind veraltet.</li><li>Die App ist nicht in der Landesversion Ihres Google Play verfügbar. <a href='#international' target='_blank' >Diese FAQ</a> nennt die unterstützten Landesversionen.</li><li>Sie haben die Corona-Warn-App nicht über den offiziellen Google Play Store installiert.</li><li>Ihr Gerät wurde modifiziert (z.&nbsp;B. gerootet).</li><li>Sie haben mehrere Benutzerkonten auf Ihrem Gerät, und die App wird für einen nicht-primären Nutzer (ohne Administrationsrechte) ausgeführt.</li><li>Der Hersteller Ihres Geräts hat die Google Play-Dienste und den Google Play Store für Ihr Gerät nicht zur Verfügung gestellt (betrifft z.&nbsp;B. einige Modelle von Huawei und Xiaomi).</li><li>Die Google Mobile Services sind veraltet.</li></ul>",
                                     "<b>Fehlerbehebung</b>",
@@ -2705,7 +2739,8 @@
                                 "anchor": "no_log_check",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/> Diese Meldung wird nicht mehr angezeigt, seitdem Positivkennungen auf dem Server verfügbar sind. <hr/>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Diese Meldung wird nicht mehr angezeigt, seitdem Positivkennungen auf dem Server verfügbar sind.</div>",
                                     "Doch, die Risiko-Ermittlung funktioniert. Dieser Hinweis steht unter 'Einstellungen' &gt; 'Datenschutz' &gt; 'Health' &gt; 'COVID-19-Begegnungsaufzeichnungen' (iOS 13.7 und höher: 'Einstellungen' &gt; 'Begegnungsmitteilungen' &gt; 'Status von Begegnungsaufzeichnungen'). Er kommt von iOS und bedeutet, dass der Backend-Server noch keine Diagnoseschlüssel (Positivkennungen) an Ihr Gerät versendet hat. Die Corona-Warn-App hat deswegen noch keinen Abgleich mit den gesammelten Zufalls-IDs durchgeführt. Sobald Corona-positiv getestete Personen ihren Diagnoseschlüssel (Positivkennung) hochgeladen haben, wird dieser Abgleich ausgelöst."
                                 ]
                             },
@@ -2788,7 +2823,8 @@
                                 "anchor": "mutation",
                                 "active": false,
                                 "textblock": [
-                                    "<b>AKTUELL</b><br/>Informationen zur Corona-Warn-App und Omikron finden Sie in diesem Blog-Post: <a href='../../blog/2022-01-11-cwa-omikron' target='_blank'>Wird die CWA an die Omikron-Variante angepasst?</a>",
+                                    "<b>AKTUELL</b>",
+                                    "<div class='update'>Informationen zur Corona-Warn-App und Omikron finden Sie in diesem Blog-Post: <a href='../../blog/2022-01-11-cwa-omikron' target='_blank'>Wird die CWA an die Omikron-Variante angepasst?</a></div>",
                                     "Bisher wurde die Risiko-Ermittlung am 23.02.2021, am 19.03.2021 und am 16.04.2021 verbessert und angepasst. Weitere Informationen finden Sie in unserem Blog:",
                                     "<ul><li><a href='../../blog/2021-02-23-corona-warn-app-risk-calculation-optimization/' target='_blank' >23.02.2021 - Risikoberechnung der Corona-Warn-App nach detaillierten Tests weiter angepasst</a></li><li><a href='../../blog/2021-03-19-risk-calculation-improvement/' target='_blank' >19.03.2021 - Die Risikoberechnung der Corona-Warn-App wird weiter verbessert</a></li><li><a href='../../blog/2021-04-16-corona-warn-app-risk-calculation-further-improved/' target='_blank' >16.04.2021 - Das Projektteam verbessert die Risikoberechnung der Corona-Warn-App in Reaktion auf die Infektionslage</a></li></ul>",
                                     "Wir werden auch weiterhin die Risiko-Ermittlung in Bezug auf das Virus überwachen und sie, falls nötig, verbessern.<hr/>",
@@ -3398,7 +3434,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App noch luca-Qr-Codes gescannt werden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App noch luca-Qr-Codes gescannt werden.</div>",
                                     "Die Corona-Warn-App kann QR-Codes, die für die Eventregistrierung mit der luca-App erstellt wurden, scannen und einen eigenen Check-in-Prozess durchführen. Die luca-App konnte die QR-Codes der Corona-Warn-App nicht einlesen."
                                 ]
                             },
@@ -3408,7 +3444,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an.</div>",
                                     "Die Mitnutzung der luca-QR-Codes durch die Corona-Warn-App, die für Eventregistrierungen und Check-ins eingesetzt werden kann, bringt keine weiteren Änderungen für die Nutzenden mit sich.",
                                     "CWA-Nutzende können weiterhin ohne Eingabe von Kontaktdaten am CWA-System teilnehmen, während die Kontaktdaten von luca-Nutzenden im Fall einer Kontaktnachverfolgung ausschließlich vom zuständigen Gesundheitsamt entschlüsselt werden konnten."
                                 ]
@@ -3419,7 +3455,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an.</div>",
                                     "Die von der luca-App generierten QR-Codes für den Check-in-Prozess können weiterhin von der Corona-Warn-App (CWA) eingelesen werden.",
                                     "Scannen Nutzende der Corona-Warn-App den QR-Code, werden sie automatisch in den Check-in-Bereich der CWA geführt. Weitere Informationen zu dem Prozess finden Sie hier: <a href='../../blog/2021-10-11-cwa-most-important-features/' target='_blank'>Warum die Corona-Warn-App gerade jetzt wichtig ist (Blog)</a>"
                                 ]
@@ -3430,7 +3466,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.</div>",
                                     "Mit Hilfe der Corona-Warn-App können Nutzende sich z.&nbsp;B. bei einer Veranstaltung einchecken. Werden sie später positiv auf SARS-CoV-2 getestet, können sie mit Hilfe der Corona-Warn-App andere Teilnehmende der gleichen Veranstaltung unverzüglich warnen. Dabei ist es egal, ob der QR-Code ursprünglich von der Corona-Warn-App oder der luca-App erzeugt wurde."
                                 ]
                             },
@@ -3440,7 +3476,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.</div>",
                                     "Um den Prozess der Eventregistrierung (Check-in) zu vereinfachen, kann die Corona-Warn-App QR-Codes, die luca ausgestellt hat, 'mitnutzen'. Das heißt: Die Corona-Warn-App kann den QR-Code, den luca ausgestellt hat, lesen und verarbeiten."
                                 ]
                             },
@@ -3450,7 +3486,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.</div>",
                                     "Stand Herbst 2021: Angesichts steigender Inzidenzen und mit Blick auf die nächsten Wochen und Monate, in denen sich das Leben vermehrt in Innenräumen abspielt, ist es wichtig, den Check-in-Prozess zu vereinfachen, zu beschleunigen und mit einem QR-Code zu versehen, der von beiden Apps eingelesen werden kann.",
                                     "Der Prozess der Integration hatte einige Zeit in Anspruch genommen, um den hohen Datenschutzansprüchen der CWA gerecht zu werden."
                                 ]
@@ -3461,7 +3497,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.</div>",
                                     "Die Daten der Corona-Warn-App waren und sind sicher. Die Mitnutzung bezieht sich nur auf die QR-Codes, die für Eventregistrierung und Check-in genutzt werden. Corona-Warn-App und luca-App sind weiterhin unterschiedliche Angebote mit unterschiedlichen Zielsetzungen. Beim Scannen eines luca-QR-Codes mit der Corona-Warn-App werden keine zusätzlichen Daten erfasst.",
                                     "Die Mitnutzung der QR-Codes wurde sorgfältig vorbereitet. Alle sicherheitsrelevanten Aspekte wurden in enger Zusammenarbeit sowohl mit dem BfDI als auch mit dem BSI ausgearbeitet und geprüft.",
                                     "Zudem arbeitet die Corona-Warn-App weiterhin sehr datensparsam."
@@ -3481,7 +3517,7 @@
                                 "active": false,
                                 "textblock": [
                                     "<b>Aktualisiert am 15.07.2022</b>",
-                                    "Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.<hr>",
+                                    "<div class='update'>Anmerkung: Die luca-App bietet seit dem Frühjahr 2022 keine Eventregistrierung (Check-In-Funktionalität) mehr an. Dennoch können mit der Corona-Warn-App weiterhin luca-QR-Codes gescannt werden.</div>",
                                     "Die Corona-Warn-App und luca basieren auf unterschiedlichen Ansätzen und verfolgen unterschiedliche Ziele.",
                                     "Die Corona-Warn-App ermöglicht eine schnelle Warnung von Personen nach dem Peer-to-Peer-Prinzip. Diese Warnung erfolgt pseudonym über die Corona-Warn-App selbst.",
                                     "Die luca-App hingegen dient zum damaligen Zeitpunkt hauptsächlich der digitalen Erfassung von Kontaktdaten der Teilnehmenden einer Veranstaltung. Im Infektionsfall hat sie die Kontaktdaten der positiv auf SARS-CoV-2 getesteten Person an das zuständige Gesundheitsamt übergeben. Dieses kontaktiert dann alle Personen, die denselben QR-Code gescannt haben.",


### PR DESCRIPTION
Where an update text was available, there are now callouts for the updated FAQ entries
![image](https://user-images.githubusercontent.com/12231155/224982923-de0d6f99-a452-46df-91b4-f1e2cdb6728f.png)

There are no callouts for entries, where there was no update text already provided, example:
![image](https://user-images.githubusercontent.com/12231155/224983160-ed88ce7c-a30c-4aa3-b7d5-786ebc572cfc.png)

There are also no callouts for texts that are structured like this: "Since version 2.5 [..], and since version 2.6" and contain a lot of text. As that would essentially make the whole entry a callout. Callouts are meant to highlight changes to the faq entry, not necessarily the app version.

(merging this soon already, but if there is feedback, please don't hesitate to write it into the already closed pr)
