### PR TITLE
Update FAQ #end_of_development: Suppress warnings in build

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -37,7 +37,10 @@
                             {
                                 "title": "General topics about the end of development of the Corona-Warn-App will soon be published here.",
                                 "anchor": "ramp_down",
-                                "active": false
+                                "active": false,
+                                "textblock": [
+                                    ""
+                                ]
                             }
                         ]
                     },
@@ -49,7 +52,10 @@
                             {
                                 "title": "Here we will inform you about the functional impacts of the end of development work on the CWA.",
                                 "anchor": "ramp_down_effects",
-                                "active": false
+                                "active": false,
+                                "textblock": [
+                                    ""
+                                ]
                             }
                         ]
                     },
@@ -61,7 +67,10 @@
                             {
                                 "title": "Here we are preparing answers to questions about what options there will be after the end of development work on the CWA.",
                                 "anchor": "ramp_down_alternatives",
-                                "active": false
+                                "active": false,
+                                "textblock": [
+                                    ""
+                                ]
                             }
                         ]
                     }

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -37,7 +37,10 @@
                             {
                                 "title": "Hier werden bald generelle Themen zum Ende der Entwicklung der Corona-Warn-App publiziert.",
                                 "anchor": "ramp_down",
-                                "active": false
+                                "active": false,
+                                "textblock": [
+                                    ""
+                                ]
                             }
                         ]
                     },
@@ -49,7 +52,10 @@
                             {
                                 "title": "Hier werden wir darüber informieren, welche funktionalen Auswirkungen das Ende der Entwicklungsarbeiten an der CWA hat.",
                                 "anchor": "ramp_down_effects",
-                                "active": false
+                                "active": false,
+                                "textblock": [
+                                    ""
+                                ]
                             }
                         ]
                     },
@@ -61,7 +67,10 @@
                             {
                                 "title": "Hier bereiten wir Antworten zu Fragen vor, welche Möglichkeiten es nach Ende der Entwicklungsarbeiten an der CWA künftig noch gibt.",
                                 "anchor": "ramp_down_alternatives",
-                                "active": false
+                                "active": false,
+                                "textblock": [
+                                    ""
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
As there are no textblocks in the recently added FAQ articles about the end of development of the Corona-Warn-App, `gulp-json-transform` prints a warning in the build process for each file (German and English). This can be seen [here](https://github.com/corona-warn-app/cwa-website/actions/runs/4466163815/jobs/7844002388#step:5:79).

```
gulp-json-transform: Cannot read properties of undefined (reading 'join')
```

To prevent this, this PR adds textblocks to the FAQ articles. As seen [here](https://github.com/corona-warn-app/cwa-website/actions/runs/4466163815/jobs/7844002388#step:5:79), this PR is working as intended.

---
Internal Tracking ID: [EXPOSUREAPP-14972](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14972)