### PR TITLE
Update dashboard: Add annotations for Warning without TAN

### DIFF
--- a/src/assets/js/analyse/chart.js
+++ b/src/assets/js/analyse/chart.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import ApexCharts from 'apexcharts';
 import { Subject } from 'rxjs';
+import { DateTime } from 'luxon';
 
 import chartOptions from './chart/options.js';
 import { update } from './chart/update.js';
@@ -12,8 +13,12 @@ const annotations = {
       key: 'self-test-submission',
       label_de: 'Selbstwarnungen',
       label_en: 'Self-test warnings',
-      dataPoints: ['__18. Jan. 23__', '__KW 03__', '__Jan. 23__'], // Target the daily and weekly datapoints
-      // TODO: Only mark CW 03 of 2023!
+      dataPoints: [
+        `__${DateTime.fromISO('2023-01-18').toLocaleString({ day: '2-digit', month: 'short', year: '2-digit' })}__`,
+        documentLang == 'de' ? '__KW 03 2023__' : '__CW 03 2023__',
+        // TODO: Target correct day, when using more than 1000 datapoints
+        // `__${DateTime.fromISO('2023-01-18').toLocaleString({ month: 'short', year: '2-digit' })}__`,
+      ],
     },
   ],
 };

--- a/src/assets/js/analyse/chart.js
+++ b/src/assets/js/analyse/chart.js
@@ -1,24 +1,57 @@
 import $ from 'jquery';
-import ApexCharts from 'apexcharts'
+import ApexCharts from 'apexcharts';
 import { Subject } from 'rxjs';
 
 import chartOptions from './chart/options.js';
 import { update } from './chart/update.js';
 let chartsAry = [];
 
+const annotations = {
+  xaxis: [
+    {
+      key: 'self-test-submission',
+      label_de: 'Selbstwarnungen',
+      label_en: 'Self-test warnings',
+      dataPoints: ['__18. Jan. 23__', '__KW 03__', '__Jan. 23__'], // Target the daily and weekly datapoints
+      // TODO: Only mark CW 03 of 2023!
+    },
+  ],
+};
+
 window.ApexCharts = ApexCharts;
-Object.assign(Apex, chartOptions); 
+Object.assign(Apex, chartOptions);
 
 $(() => {
-	// loop over all board
-	$(".analyseChart").each(async function(i){
-		// init ApexCharts with base options
-		new ApexCharts(this, Object.assign({}, {chart:{id:`chart${i}`}})).render();
-		
-		const chart$ = new Subject;
-		await chart$.subscribe(e => update(e, i));
-		chartsAry.push(chart$);
-	});
+  // loop over all board
+  $('.analyseChart').each(async function (i) {
+    // init ApexCharts with base options
+    const chart = new ApexCharts(this, Object.assign({}, { chart: { id: `chart${i}` } }));
+    chart.render();
+
+    const chart$ = new Subject();
+    await chart$.subscribe((e) => update(e, i));
+    chartsAry.push(chart$);
+
+    annotations.xaxis.forEach((annotation) => {
+      annotation.dataPoints.forEach((dataPoint) => {
+        chart.addXaxisAnnotation({
+          x: dataPoint,
+          strokeDashArray: 0,
+          borderColor: '#775DD0',
+          label: {
+            orientation: 'horizontal',
+            textAnchor: dataPoint === '__Jan. 23__' ? 'end' : 'start', //TODO: Dynamically choose textAnchor based on the position of the dataPoint
+            offsetX: dataPoint === '__Jan. 23__' ? -4 : 4,
+            offsetY: 5,
+            text: annotation.label_de,
+            style: {
+              background: '#775DD0',
+            },
+          },
+        });
+      });
+    });
+  });
 });
 
 export default chartsAry;

--- a/src/assets/js/analyse/chart.js
+++ b/src/assets/js/analyse/chart.js
@@ -1,27 +1,10 @@
 import $ from 'jquery';
 import ApexCharts from 'apexcharts';
 import { Subject } from 'rxjs';
-import { DateTime } from 'luxon';
 
 import chartOptions from './chart/options.js';
 import { update } from './chart/update.js';
 let chartsAry = [];
-
-const annotations = {
-  xaxis: [
-    {
-      key: 'self-test-submission',
-      label_de: 'Selbstwarnungen',
-      label_en: 'Self-test warnings',
-      dataPoints: [
-        `__${DateTime.fromISO('2023-01-18').toLocaleString({ day: '2-digit', month: 'short', year: '2-digit' })}__`,
-        documentLang == 'de' ? '__KW 03 2023__' : '__CW 03 2023__',
-        // TODO: Target correct day, when using more than 1000 datapoints
-        // `__${DateTime.fromISO('2023-01-18').toLocaleString({ month: 'short', year: '2-digit' })}__`,
-      ],
-    },
-  ],
-};
 
 window.ApexCharts = ApexCharts;
 Object.assign(Apex, chartOptions);
@@ -36,26 +19,6 @@ $(() => {
     const chart$ = new Subject();
     await chart$.subscribe((e) => update(e, i));
     chartsAry.push(chart$);
-
-    annotations.xaxis.forEach((annotation) => {
-      annotation.dataPoints.forEach((dataPoint) => {
-        chart.addXaxisAnnotation({
-          x: dataPoint,
-          strokeDashArray: 0,
-          borderColor: '#775DD0',
-          label: {
-            orientation: 'horizontal',
-            textAnchor: dataPoint === '__Jan. 23__' ? 'end' : 'start', //TODO: Dynamically choose textAnchor based on the position of the dataPoint
-            offsetX: dataPoint === '__Jan. 23__' ? -4 : 4,
-            offsetY: 5,
-            text: annotation.label_de,
-            style: {
-              background: '#775DD0',
-            },
-          },
-        });
-      });
-    });
   });
 });
 

--- a/src/assets/js/analyse/chart/update.js
+++ b/src/assets/js/analyse/chart/update.js
@@ -19,8 +19,6 @@ const selfWarningAnnotation = {
   dataPoints: {
     daily: `__${DateTime.fromISO('2023-01-18').toLocaleString({ day: '2-digit', month: 'short', year: '2-digit' })}__`,
     weekly: documentLang == 'de' ? '__KW 03 2023__' : '__CW 03 2023__',
-    // If there are more than 1000 datapoints present the annotation is placed on 01.01.23
-    daily1000: `__${DateTime.fromISO('2023-01-18').toLocaleString({ month: 'short', year: '2-digit' })}__`,
   },
 };
 
@@ -104,7 +102,7 @@ const update = async function (
   // update and set annotations
   const calculateAnnotationPosition = () => {
     const dataPointIndex = categories.findIndex((category) =>
-      ['__Jan. 23__', '__CW 03 2023__', '__KW 03 2023__', '__18. Jan. 23__'].includes(category)
+      Object.values(selfWarningAnnotation.dataPoints).includes(category)
     );
     const magicNum = (dataPointIndex / categories.length) * 100;
     return {
@@ -118,12 +116,7 @@ const update = async function (
   ApexCharts.exec(id, 'clearAnnotations');
 
   ApexCharts.exec(id, 'addXaxisAnnotation', {
-    x:
-      mode === 'weekly'
-        ? selfWarningAnnotation.dataPoints.weekly
-        : mode === 'daily' && categories.length > 1000
-        ? selfWarningAnnotation.dataPoints.daily1000
-        : selfWarningAnnotation.dataPoints.daily,
+    x: mode === 'weekly' ? selfWarningAnnotation.dataPoints.weekly : selfWarningAnnotation.dataPoints.daily,
     strokeDashArray: 0,
     borderColor: '#775DD0',
     label: {

--- a/src/assets/js/analyse/chart/update.js
+++ b/src/assets/js/analyse/chart/update.js
@@ -1,4 +1,4 @@
-import ApexCharts from 'apexcharts'
+import ApexCharts from 'apexcharts';
 import _get from 'lodash/get';
 import _set from 'lodash/set';
 
@@ -8,101 +8,140 @@ import { debugLog, debugTime, debugTimeEnd } from '../debug.js';
 
 import { checkLegendReset, renderLegend } from './legend.js';
 import chartConfig from './config.js';
+import { DateTime } from 'luxon';
 
+const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
-
-const delay = ms => new Promise(res => setTimeout(res, ms));
-
-const update = async function({
-		barthreshold, 
-		categories,
-		data, 
-		date, 
-		keys, 
-		mode, 
-		range, 
-		reallabels, 
-		switchId, 
-		tabs1, 
-		tabs2, 
-		tooltipDate,
-		updated
-	},
-	i
-)
-{
-	const id = `chart${i}`;
-
-	$(`.analyseBoard-loading[data-id="${id}"]`).addClass("active");
-	await delay(100);
-	debugTime('updateOptions' + id)
-	
-	if(i == 1){
-		// switch title on chart1 tabs 
-		$(`.${id}`).find(".analyseBoard-title .analyseBoard-title-title").html(translate(["analyseBoardTitleTitle", i, tabs1]));
-	}
-
-	if(i == 1 || i == 2){
-		// update total values based on selected tabs
-		totalValuesUpdate($(`.${id}`).find(".analyseBoard-total-value"), i, ((i == 1)? tabs1: (i == 2)? tabs2: 0));
-	}
-
-	
-	let chartConfigObj = _get(chartConfig, [id, switchId], []);
-	if(Array.isArray(chartConfigObj)){
-		chartConfigObj = _get(chartConfigObj, [(id == "chart1")? tabs1: (id == "chart2")? tabs2: []], []);
-	}
-
-	const chartType = _get(chartConfigObj, ["type"], "line");
-	const type = (chartType == "bar")? (barthreshold)? chartType: "area": chartType;
-
-	
-	let opt = {
-		chart: {
-			id,
-			type,
-			stacked: _get(chartConfigObj, ["stacked"], false)
-		},
-		seriesall: _get(chartConfigObj, ["series"], []).map(obj => {
-			return {
-				ghost: obj.ghost,
-				color: (obj.color)? obj.color: undefined,
-				type: (obj.type)? (barthreshold)? obj.type: "line": type,
-				name: (obj.name)? translate(obj.name): translate(obj.data),
-				data: (keys.indexOf(obj.data) >= 0)? data.map(m => m[keys.indexOf(obj.data)]): [],
-				key: obj.data
-			}
-		})
-	};
-
-	// add only if needed
-	if(updated){
-		opt = Object.assign(opt, {mode, reallabels, tooltipDate, xaxis: {categories}})
-	}
-
-	// set series without the ghosts
-	_set(opt, ["series"], opt.seriesall.filter(e => !e.ghost));
-
-	// set dasharray for legend and switch 4
-	_set(opt, ["stroke", "dashArray"], (switchId == 4)? opt.seriesall.filter(e => !e.ghost).map(obj => (!!~obj.key.indexOf("_daily"))? 5: 0): new Array(opt.series.length).fill(0));
-
-	//Only reset series if necessary
-	checkLegendReset(opt, () => {
-		ApexCharts.exec(id, "resetSeries", true, false);
-	});
-
-	
-	// update chart options
-	ApexCharts.exec(id, "updateOptions", opt, true, false, false);
-	
-	
-
-	// render custom legend
-	renderLegend(opt);
-	debugTimeEnd('updateOptions'+id)
-	debugLog("chart update", id, opt);
+const selfWarningAnnotation = {
+  key: 'self-test-submission',
+  label_de: 'Warnen ohne TAN',
+  label_en: 'Warning without TAN',
+  dataPoints: {
+    daily: `__${DateTime.fromISO('2023-01-18').toLocaleString({ day: '2-digit', month: 'short', year: '2-digit' })}__`,
+    weekly: documentLang == 'de' ? '__KW 03 2023__' : '__CW 03 2023__',
+    // If there are more than 1000 datapoints present the annotation is placed on 01.01.23
+    daily1000: `__${DateTime.fromISO('2023-01-18').toLocaleString({ month: 'short', year: '2-digit' })}__`,
+  },
 };
 
-export {
-	update
-}
+const update = async function (
+  { barthreshold, categories, data, date, keys, mode, range, reallabels, switchId, tabs1, tabs2, tooltipDate, updated },
+  i
+) {
+  const id = `chart${i}`;
+
+  $(`.analyseBoard-loading[data-id="${id}"]`).addClass('active');
+  await delay(100);
+  debugTime('updateOptions' + id);
+
+  if (i == 1) {
+    // switch title on chart1 tabs
+    $(`.${id}`)
+      .find('.analyseBoard-title .analyseBoard-title-title')
+      .html(translate(['analyseBoardTitleTitle', i, tabs1]));
+  }
+
+  if (i == 1 || i == 2) {
+    // update total values based on selected tabs
+    totalValuesUpdate($(`.${id}`).find('.analyseBoard-total-value'), i, i == 1 ? tabs1 : i == 2 ? tabs2 : 0);
+  }
+
+  let chartConfigObj = _get(chartConfig, [id, switchId], []);
+  if (Array.isArray(chartConfigObj)) {
+    chartConfigObj = _get(chartConfigObj, [id == 'chart1' ? tabs1 : id == 'chart2' ? tabs2 : []], []);
+  }
+
+  const chartType = _get(chartConfigObj, ['type'], 'line');
+  const type = chartType == 'bar' ? (barthreshold ? chartType : 'area') : chartType;
+
+  let opt = {
+    chart: {
+      id,
+      type,
+      stacked: _get(chartConfigObj, ['stacked'], false),
+    },
+    seriesall: _get(chartConfigObj, ['series'], []).map((obj) => {
+      return {
+        ghost: obj.ghost,
+        color: obj.color ? obj.color : undefined,
+        type: obj.type ? (barthreshold ? obj.type : 'line') : type,
+        name: obj.name ? translate(obj.name) : translate(obj.data),
+        data: keys.indexOf(obj.data) >= 0 ? data.map((m) => m[keys.indexOf(obj.data)]) : [],
+        key: obj.data,
+      };
+    }),
+  };
+
+  // add only if needed
+  if (updated) {
+    opt = Object.assign(opt, { mode, reallabels, tooltipDate, xaxis: { categories } });
+  }
+
+  // set series without the ghosts
+  _set(
+    opt,
+    ['series'],
+    opt.seriesall.filter((e) => !e.ghost)
+  );
+
+  // set dasharray for legend and switch 4
+  _set(
+    opt,
+    ['stroke', 'dashArray'],
+    switchId == 4
+      ? opt.seriesall.filter((e) => !e.ghost).map((obj) => (!!~obj.key.indexOf('_daily') ? 5 : 0))
+      : new Array(opt.series.length).fill(0)
+  );
+
+  //Only reset series if necessary
+  checkLegendReset(opt, () => {
+    ApexCharts.exec(id, 'resetSeries', true, false);
+  });
+
+  // update chart options
+  ApexCharts.exec(id, 'updateOptions', opt, true, false, false);
+
+  // update and set annotations
+  const calculateAnnotationPosition = () => {
+    const dataPointIndex = categories.findIndex((category) =>
+      ['__Jan. 23__', '__CW 03 2023__', '__KW 03 2023__', '__18. Jan. 23__'].includes(category)
+    );
+    const magicNum = (dataPointIndex / categories.length) * 100;
+    return {
+      textAnchor: magicNum < 60 ? 'start' : 'end',
+      offsetX: magicNum < 60 ? 4 : -4,
+    };
+  };
+
+  const annotationPosition = calculateAnnotationPosition();
+
+  ApexCharts.exec(id, 'clearAnnotations');
+
+  ApexCharts.exec(id, 'addXaxisAnnotation', {
+    x:
+      mode === 'weekly'
+        ? selfWarningAnnotation.dataPoints.weekly
+        : mode === 'daily' && categories.length > 1000
+        ? selfWarningAnnotation.dataPoints.daily1000
+        : selfWarningAnnotation.dataPoints.daily,
+    strokeDashArray: 0,
+    borderColor: '#775DD0',
+    label: {
+      orientation: 'horizontal',
+      textAnchor: annotationPosition.textAnchor,
+      offsetX: annotationPosition.offsetX,
+      offsetY: 5,
+      text: documentLang == 'de' ? selfWarningAnnotation.label_de : selfWarningAnnotation.label_en,
+      style: {
+        background: '#775DD0',
+      },
+    },
+  });
+
+  // render custom legend
+  renderLegend(opt);
+  debugTimeEnd('updateOptions' + id);
+  debugLog('chart update', id, opt);
+};
+
+export { update };

--- a/src/assets/js/analyse/chart/update.js
+++ b/src/assets/js/analyse/chart/update.js
@@ -16,6 +16,7 @@ const selfWarningAnnotation = {
   key: 'self-test-submission',
   label_de: 'Warnen ohne TAN',
   label_en: 'Warning without TAN',
+  targetCharts: ['chart2', 'chart3'],
   dataPoints: {
     daily: `__${DateTime.fromISO('2023-01-18').toLocaleString({ day: '2-digit', month: 'short', year: '2-digit' })}__`,
     weekly: documentLang == 'de' ? '__KW 03 2023__' : '__CW 03 2023__',
@@ -111,25 +112,27 @@ const update = async function (
     };
   };
 
-  const annotationPosition = calculateAnnotationPosition();
+  if (selfWarningAnnotation.targetCharts.includes(id)) {
+    const annotationPosition = calculateAnnotationPosition();
 
-  ApexCharts.exec(id, 'clearAnnotations');
+    ApexCharts.exec(id, 'clearAnnotations');
 
-  ApexCharts.exec(id, 'addXaxisAnnotation', {
-    x: mode === 'weekly' ? selfWarningAnnotation.dataPoints.weekly : selfWarningAnnotation.dataPoints.daily,
-    strokeDashArray: 0,
-    borderColor: '#775DD0',
-    label: {
-      orientation: 'horizontal',
-      textAnchor: annotationPosition.textAnchor,
-      offsetX: annotationPosition.offsetX,
-      offsetY: 5,
-      text: documentLang == 'de' ? selfWarningAnnotation.label_de : selfWarningAnnotation.label_en,
-      style: {
-        background: '#775DD0',
+    ApexCharts.exec(id, 'addXaxisAnnotation', {
+      x: mode === 'weekly' ? selfWarningAnnotation.dataPoints.weekly : selfWarningAnnotation.dataPoints.daily,
+      strokeDashArray: 0,
+      borderColor: '#775DD0',
+      label: {
+        orientation: 'horizontal',
+        textAnchor: annotationPosition.textAnchor,
+        offsetX: annotationPosition.offsetX,
+        offsetY: 5,
+        text: documentLang == 'de' ? selfWarningAnnotation.label_de : selfWarningAnnotation.label_en,
+        style: {
+          background: '#775DD0',
+        },
       },
-    },
-  });
+    });
+  }
 
   // render custom legend
   renderLegend(opt);

--- a/src/assets/js/analyse/index.js
+++ b/src/assets/js/analyse/index.js
@@ -144,9 +144,7 @@ function filterData(dataOrg, date, mode){
 	out.barthreshold = (out.range <= barThreshold[mode]);
 	out.categories = out.reallabels.map(e => {
 		let d = DateTime.fromISO(e);
-		//our.range is changed from 28 to 1000 
-		//Due to this issue https://github.com/corona-warn-app/cwa-website/issues/2414
-		d = (mode == "daily")? d.toLocaleString((out.range <= 1000 )? { day: "2-digit", month: 'short' , year: '2-digit'}: { month: 'short', year: '2-digit' }): d.toFormat((documentLang == "de")? "'KW' WW yyyy": "'CW' WW yyyy"); 
+		d = (mode == "daily")? d.toLocaleString({ day: "2-digit", month: 'short' , year: '2-digit'}): d.toFormat((documentLang == "de")? "'KW' WW yyyy": "'CW' WW yyyy"); 
 		return  `__${d}__`;
 	});
 	out.tooltipDate = out.reallabels.map(o => (mode == "weekly")? DateTime.fromISO(o).toFormat((documentLang == "de")? "'KW' WW": "'CW' WW") + " - " + DateTime.fromISO(o).toLocaleString(DateTime.DATE_HUGE): DateTime.fromISO(o).toLocaleString(DateTime.DATE_HUGE));

--- a/src/assets/js/analyse/index.js
+++ b/src/assets/js/analyse/index.js
@@ -146,7 +146,7 @@ function filterData(dataOrg, date, mode){
 		let d = DateTime.fromISO(e);
 		//our.range is changed from 28 to 1000 
 		//Due to this issue https://github.com/corona-warn-app/cwa-website/issues/2414
-		d = (mode == "daily")? d.toLocaleString((out.range <= 1000 )? { day: "2-digit", month: 'short' , year: '2-digit'}: { month: 'short', year: '2-digit' }): d.toFormat((documentLang == "de")? "'KW' WW": "'CW' WW"); 
+		d = (mode == "daily")? d.toLocaleString((out.range <= 1000 )? { day: "2-digit", month: 'short' , year: '2-digit'}: { month: 'short', year: '2-digit' }): d.toFormat((documentLang == "de")? "'KW' WW yyyy": "'CW' WW yyyy"); 
 		return  `__${d}__`;
 	});
 	out.tooltipDate = out.reallabels.map(o => (mode == "weekly")? DateTime.fromISO(o).toFormat((documentLang == "de")? "'KW' WW": "'CW' WW") + " - " + DateTime.fromISO(o).toLocaleString(DateTime.DATE_HUGE): DateTime.fromISO(o).toLocaleString(DateTime.DATE_HUGE));

--- a/src/assets/scss/_analyse.scss
+++ b/src/assets/scss/_analyse.scss
@@ -1095,6 +1095,12 @@
 
 }
 
+.apexcharts-xaxis-annotations {
+	.apexcharts-xaxis-annotation-label {
+		fill: #fff !important;
+	}
+}
+
 .info-textblock {
 	position: relative;
     top: -1px


### PR DESCRIPTION
This PR adds an annotation to the dashboard to show when "Warning without TAN" was implemented into the app. This will help to understand why the statistics in the lower two tiles have significantly changed after this date.

![image](https://user-images.githubusercontent.com/88365935/226868063-afcada93-5e85-4edf-a781-3e78c00d74ce.png)

---
Internal Tracking ID: [EXPOSUREAPP-14711](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14711)