### PR TITLE
Update header: Add end of development banner

### DIFF
--- a/src/assets/scss/_header.scss
+++ b/src/assets/scss/_header.scss
@@ -318,6 +318,11 @@
     background: #D4EAF7;
 }
 
+.banner {
+    background: #fdda08;
+    color: black;
+}
+
 .skip-main { 
     left:-999px;
     position:absolute;

--- a/src/data/global.json
+++ b/src/data/global.json
@@ -4,6 +4,10 @@
         "name": "favicon",
         "include": "all"
     },
+    "banner": {
+        "en": "The CWA development ends on May 31, 2023. You still can warn other users until April 30, 2023. More information: <a href='/en/faq/results/#ramp_down' target='_blank'>FAQ</a>",
+        "de": "Die CWA-Entwicklung endet am 31.05.2023. Bis einschließlich 30.04.2023 können Sie andere Anwender warnen. Mehr dazu hier: <a href='/de/faq/results/#ramp_down' target='_blank'>FAQ</a>"
+    },
     "whohelps": {
         "en": {
             "text": "Who helps regarding Corona-Warn-App questions?",

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -1,3 +1,10 @@
+<div class="col-sm-12 text-center banner pt-2 pb-2">
+  {{#if lang_de}}
+    {{{global.banner.de}}}
+  {{else}}
+    {{{global.banner.en}}}
+  {{/if}}
+</div>
 <header class="header{{#unless page-name}}{{#ifpage 'index'}} header_home{{/ifpage}}{{/unless}}{{#ifequal page-name 'index'}} header_home{{/ifequal}}{{#if header-cls}} header-cls{{/if}}">
   <div class="container">
   {{#unless lang_de}}


### PR DESCRIPTION
This PR adds a banner above the header that links to the explanatory FAQ entries about the end of development of the Corona-Warn-App.

![image](https://user-images.githubusercontent.com/88365935/227460799-67f27c00-784f-4ce8-ab74-08399d47ad48.png)

Screenshots:

Desktop EN:
[coronawarn.app/en](https://user-images.githubusercontent.com/88365935/227459551-a7ae939e-da97-4103-98fb-24b3497d2998.png)
[coronawarn.app/en/faq](https://user-images.githubusercontent.com/88365935/227459560-b634ff95-119d-4595-8fe7-f7e1c9535736.png)

Desktop DE:
[coronawarn.app/de](https://user-images.githubusercontent.com/88365935/227459558-8805f04d-1167-4ede-b1f6-1caf222320a5.png)
[coronawarn.app/de/faq](https://user-images.githubusercontent.com/88365935/227459562-fc186656-ca5a-41b7-96f0-2d0d18b69abf.png)

Mobile EN:
[coronawarn.app/en](https://user-images.githubusercontent.com/88365935/227460091-791a1b73-59ca-4371-af91-877578784733.png)
[coronawarn.app/en/faq](https://user-images.githubusercontent.com/88365935/227460112-ea5fea73-1f04-411e-8eed-5a4f2c7cba50.png)

Mobile DE:
[coronawarn.app/de](https://user-images.githubusercontent.com/88365935/227460137-b2d51620-942e-4d29-929a-0057b29e1149.png)
[coronawarn.app/de/faq](https://user-images.githubusercontent.com/88365935/227460156-dc782a07-a62c-4a76-8ba3-d956a654a683.png)

---
Internal Tracking ID: [EXPOSUREAPP-14582](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14582)