### PR TITLE
Update testing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "apexcharts": "^3.37.1",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.2",
-        "browser-sync": "^2.28.3",
+        "browser-sync": "^2.29.1",
         "cleave.js": "^1.6.0",
         "dayjs": "^1.11.7",
         "google-protobuf": "^3.21.2",
@@ -55,7 +55,7 @@
         "yargs": "^17.7.1"
       },
       "devDependencies": {
-        "cypress": "^10.11.0",
+        "cypress": "^12.8.1",
         "frontmatter": "0.0.3",
         "gulp-debug": "^4.0.0",
         "gulp-replace": "^1.1.4",
@@ -63,7 +63,7 @@
         "marked": "^3.0.8",
         "moment": "^2.29.4",
         "npm-run-all": "^4.1.5",
-        "start-server-and-test": "^1.15.4"
+        "start-server-and-test": "^2.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3480,12 +3480,12 @@
       }
     },
     "node_modules/browser-sync": {
-      "version": "2.28.3",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.28.3.tgz",
-      "integrity": "sha512-gublDeevvAuypnc01SQNGL8fkm4RdIkEagnAJ8Tl9mvr2td3Pl4nVIg5S6fcgoMDEWb8IT7nUHG9YwTATn/k2g==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.29.1.tgz",
+      "integrity": "sha512-WXy9HMJVQaNUTPjmai330E2fnDA6W84l/vBILGkYu9yHXIpWw1gJYjdQWDfEhLFljYUHNTN9jM3GCej2T55m+g==",
       "dependencies": {
-        "browser-sync-client": "^2.28.3",
-        "browser-sync-ui": "^2.28.3",
+        "browser-sync-client": "^2.29.1",
+        "browser-sync-ui": "^2.29.1",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
         "chalk": "4.1.2",
@@ -3524,35 +3524,22 @@
       }
     },
     "node_modules/browser-sync-client": {
-      "version": "2.28.3",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.28.3.tgz",
-      "integrity": "sha512-SMsnGkyXlySVLBWRrXdnTdtQCy0Sl5UoiF8BVtigj9S49DaPWQiesbsyq+uJBUKgpyNve+cvfpBU3KSfIp6oLQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.29.1.tgz",
+      "integrity": "sha512-aESnjt3rU7CZpzjyqzhIC2UJ3MVhzRis7cPKkGbyYWDf/wnbxyRa3fFenF3Qx9061/guY3HHhD67uiTVV26DVg==",
       "dependencies": {
         "etag": "1.8.1",
         "fresh": "0.5.2",
-        "mitt": "^1.1.3",
-        "rxjs": "^5.5.6",
-        "typescript": "^4.6.2"
+        "mitt": "^1.1.3"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/browser-sync-client/node_modules/rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dependencies": {
-        "symbol-observable": "1.0.1"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "node_modules/browser-sync-ui": {
-      "version": "2.28.3",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.28.3.tgz",
-      "integrity": "sha512-Mj5M+O3jroGp5hlO6pDfUo19wzUTIuvGyzaRrJAYUgsSkpFacrX+MLCjN9VbZm9fYXbtHyIsnIUUIlYag87wgQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.29.1.tgz",
+      "integrity": "sha512-MB7SAiUgVUrhipO2xyO1sheC9H0+LKXPQ3L1tQWcZ3AgizBnUNKAqDZPSwe4grNSa8o8ImSAwJp7lMS6XYy1Dw==",
       "dependencies": {
         "async-each-series": "0.1.1",
         "chalk": "4.1.2",
@@ -4637,9 +4624,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "12.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.8.1.tgz",
+      "integrity": "sha512-lIFbKdaSYAOarNLHNFa2aPZu6YSF+8UY4VRXMxJrFUnk6RvfG0AWsZ7/qle/aIz30TNUD4aOihz2ZgS4vuQVSA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4660,7 +4647,7 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -4690,7 +4677,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -14112,9 +14099,9 @@
       }
     },
     "node_modules/start-server-and-test": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.15.4.tgz",
-      "integrity": "sha512-ucQtp5+UCr0m4aHlY+aEV2JSYNTiMZKdSKK/bsIr6AlmwAWDYDnV7uGlWWEtWa7T4XvRI5cPYcPcQgeLqpz+Tg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.0.tgz",
+      "integrity": "sha512-UqKLw0mJbfrsG1jcRLTUlvuRi9sjNuUiDOLI42r7R5fA9dsFoywAy9DoLXNYys9B886E4RCKb+qM1Gzu96h7DQ==",
       "dev": true,
       "dependencies": {
         "arg": "^5.0.2",
@@ -14739,14 +14726,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -15257,18 +15236,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.34",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "apexcharts": "^3.37.1",
     "autoprefixer": "^10.4.14",
     "babel-loader": "^9.1.2",
-    "browser-sync": "^2.28.3",
+    "browser-sync": "^2.29.1",
     "cleave.js": "^1.6.0",
     "dayjs": "^1.11.7",
     "google-protobuf": "^3.21.2",
@@ -77,7 +77,7 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "^10.11.0",
+    "cypress": "^12.8.1",
     "frontmatter": "0.0.3",
     "gulp-debug": "^4.0.0",
     "gulp-replace": "^1.1.4",
@@ -85,6 +85,6 @@
     "marked": "^3.0.8",
     "moment": "^2.29.4",
     "npm-run-all": "^4.1.5",
-    "start-server-and-test": "^1.15.4"
+    "start-server-and-test": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR fixes the warning message:

"Opening Cypress...
Couldn't find tsconfig.json. tsconfig-paths will be skipped"

which appears when using Cypress, for instance in the log files of https://github.com/corona-warn-app/cwa-website/actions/workflows/cypress-test-prod.yml

The error no longer occurs when [browser-sync](https://www.npmjs.com/package/browser-sync) is updated to `2.29.1` (latest), since this version removes the dependency on `"typescript": "^4.6.2"` (see https://github.com/BrowserSync/browser-sync/compare/v2.29.0...v2.29.1 where it persists in `devDependencies` only).

At the same time:

- [start-server-and-test](https://www.npmjs.com/package/start-server-and-test) is updated to `2.0.0` (latest)
- [cypress](https://www.npmjs.com/package/cypress) is updated to [12.8.1](https://docs.cypress.io/guides/references/changelog#12-8-1) (latest)

as part of general maintenance, since these components work together for testing.

## Verification

### Local test

Execute

```bash
npm ci
npm test
```

and confirm successful completion.

There should be no message "Couldn't find tsconfig.json. tsconfig-paths will be skipped" in the logs.

### GitHub test

Run [.github/workflows/build-and-test.yml](https://github.com/corona-warn-app/cwa-website/blob/master/.github/workflows/build-and-test.yml)

Confirm successful completion.

There should be no message "Couldn't find tsconfig.json. tsconfig-paths will be skipped" in the logs after the log message
"Opening Cypress..."

## Note

- Resolves https://github.com/corona-warn-app/cwa-website/issues/3366 (at least the only remaining issue which needs specific action).

---
Internal Tracking ID: [EXPOSUREAPP-14986](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14986)