### PR TITLE
Update blog: Add "Read more" button alternative

### DIFF
--- a/src/data/blog.json
+++ b/src/data/blog.json
@@ -27,6 +27,7 @@
     "baseSlug": "blog",
     "dateFormat": "MMMM Do YYYY",
     "readMore": "Read more",
+    "toBlog": "To the blog",
     "backToIndexButton": {
       "title": "Back to Blog",
       "url": "/en/blog",
@@ -65,6 +66,7 @@
     },
     "baseSlug": "blog",
     "readMore": "Weiterlesen",
+    "toBlog": "Zum Blog",
     "backToIndexButton": {
       "title": "Zurück zum Blog",
       "url": "/de/blog",

--- a/src/services/blog-processor.js
+++ b/src/services/blog-processor.js
@@ -37,10 +37,13 @@ const getAuthors = (authors) => {
   }
 }
 
-const generateBlogEntry = (blog, content, lang, showButton = false) => {
+const generateBlogEntry = (blog, content, lang, showButton) => {
   let button = '', headline = '';
-  if (showButton) {
+  if (showButton === 'read-more') {
     button = `<p><a href="${blog.slug}" class="btn btn-lg btn-secondary blog-read-more">${data[lang].readMore}</a></p>`;
+    headline = `<h2 class="headline">${blog.title}</h2>`;
+  } else if (showButton === 'to-blog') {
+    button = `<p><a href="${blog.slug}" class="btn btn-lg btn-secondary blog-read-more">${data[lang].toBlog}</a></p>`;
     headline = `<h2 class="headline">${blog.title}</h2>`;
   } else {
     headline = `<h1 class="headline headline-heavy">${blog.title}</h1>`;
@@ -99,6 +102,13 @@ const createPageEntry =  (folderName, mdData, lang) => {
   const pageName = mdData.data['page-name'];
   validatePageName(folderName, pageName);
 
+  if (mdData.content.includes('<!-- overview -->')) {
+    const contentBelowOverview = mdData.content.split('<!-- overview -->')[1];
+    if (contentBelowOverview.trim().length === 0) {
+      entryType = 'short';
+    }
+  }
+  
   const entry = {
     date,
     dateFormatted: formatDate(date, lang),
@@ -106,13 +116,18 @@ const createPageEntry =  (folderName, mdData, lang) => {
     folderName,
     pageDescription: mdData.data['page-description'],
     slug: `${date}-${pageName}`,
+    type: mdData.data.type || entryType,
     author: mdData.data.author,
     redirect: mdData.data.redirect,
     htmlOverview: replaceImagePaths(marked(mdData.content.split('<!-- overview -->')[0]), folderName),
     htmlContent: replaceImagePaths(marked(mdData.content), folderName)
   };
 
-  entry.blogOverview = generateBlogEntry(entry, entry.htmlOverview, lang, true);
+  if (entry.type === 'short') {
+    entry.blogOverview = generateBlogEntry(entry, entry.htmlOverview, lang, 'to-blog');
+  } else {
+    entry.blogOverview = generateBlogEntry(entry, entry.htmlOverview, lang, 'read-more');
+  }
   entry.blogContent = generateBlogEntry(entry, entry.htmlContent, lang);
   return entry;
 }

--- a/src/services/blog-processor.js
+++ b/src/services/blog-processor.js
@@ -102,10 +102,11 @@ const createPageEntry =  (folderName, mdData, lang) => {
   const pageName = mdData.data['page-name'];
   validatePageName(folderName, pageName);
 
+  let entryType = 'short';
   if (mdData.content.includes('<!-- overview -->')) {
     const contentBelowOverview = mdData.content.split('<!-- overview -->')[1];
-    if (contentBelowOverview.trim().length === 0) {
-      entryType = 'short';
+    if (contentBelowOverview.trim().length > 0) {
+    entryType = 'long';
     }
   }
   
@@ -125,7 +126,7 @@ const createPageEntry =  (folderName, mdData, lang) => {
 
   if (entry.type === 'short') {
     entry.blogOverview = generateBlogEntry(entry, entry.htmlOverview, lang, 'to-blog');
-  } else {
+  } else if (entry.type === 'long') {
     entry.blogOverview = generateBlogEntry(entry, entry.htmlOverview, lang, 'read-more');
   }
   entry.blogContent = generateBlogEntry(entry, entry.htmlContent, lang);


### PR DESCRIPTION
This PR updates the blog overview on https://www.coronawarn.app/en/blog/ to show either "Read more" if there's more content in a blog than what's shown in the overview, or "To blog" if there is no more content after the overview. "Read more" would be misleading in the last case, as there is nothing more to be read. 

EN:
![image](https://user-images.githubusercontent.com/88365935/227565200-9773adc1-994b-4705-ba03-9992db410ea5.png)

DE:
![image](https://user-images.githubusercontent.com/88365935/227565202-bbcb6609-428d-4862-8d5d-e9a17fec97ed.png)

---
Internal Tracking ID: [EXPOSUREAPP-14990](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14990)