### PR TITLE
Add #ramp_down link check to Cypress tests

### DIFF
--- a/cypress/fixtures/appToWebLinks.json
+++ b/cypress/fixtures/appToWebLinks.json
@@ -1,6 +1,8 @@
 {
     "appVersionFirst": "2.23",
     "appVersionLast": "3.1",
+    "cclVersionFirst": "3.5",
+    "cclVersionLast": "3.6",
     "faqEntry": [
         "#admission_policy",
         "#android_location",
@@ -24,6 +26,7 @@
         "#notification_settings",
         "#part_incompat",
         "#quarantine_measures",
+        "#ramp_down",
         "#red_card_how_to_test",
         "#root_detection_android",
         "#vac_booster_basics",


### PR DESCRIPTION
[CCL v3.6.0](https://github.com/corona-warn-app/cwa-app-ccl/releases/tag/v3.6.0), which is now in productive use, adds `faqAnchor: ramp_down`.

This PR adds `#ramp_down` to the list of anchors for Cypress to test.

To be clearer where this came from

```
    "cclVersionFirst": "3.5",
    "cclVersionLast": "3.6",
```

is also added. This is pure commentary. It is not processed by any test.