### PR TITLE
Fix past tense and make German text clearer (ramp down FAQs)

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -125,7 +125,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Even after the end of the development work on the CWA, you can still access your already scanned digital certificates and you can use the contact diary. However, you will not be able to scan any more certificates or to renew existing certificates. You will also no longer receive notifications about the certificates. Additionally, you can still view statistics of the Pandemic Radar; you can find a corresponding link on the status screen of the app.",
-                                    "In Release 3.2, functionality has been reduced, but this will not be activated until May 1, 2023. Up to and including April 30, 2023, releases 3.1 and 3.2 of the app will therefore not differ in functionality."
+                                    "A reduction in functionality will be implemented in Release 3.2, but this will not be activated until May 1, 2023. Up to and including April 30, 2023, releases 3.1 and 3.2 of the app will therefore not differ in functionality."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -125,7 +125,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Auch nach dem 1. Juni 2023 können Sie noch auf Ihre bereits eingescannten Zertifikate zugreifen und das Kontakt-Tagebuch benutzen. Sie können allerdings keine weiteren Zertifikate hinzufügen oder bestehende Zertifikate erneuern. Sie erhalten auch keine Benachrichtigungen zu Ihren Zertifikaten mehr. Außerdem können Sie noch Statistiken des Pandemieradars einsehen; einen entsprechenden Link finden sie auf der Status-Seite der App.",
-                                    "Im Release 3.2 wurde eine Reduktion der Funktionalität umgesetzt, die aber erst zum 1. Mai 2023 aktiviert wird. Bis einschließlich 30. April 2023 werden sich die Releases 3.1 und 3.2 der App daher funktional nicht unterscheiden."
+                                    "Im Release 3.2 wird eine Reduktion der Funktionalität umgesetzt, die aber erst zum 1. Mai 2023 aktiviert wird. Bis einschließlich 30. April 2023 unterscheiden sich die Releases 3.1 und 3.2 der App daher funktional nicht."
                                 ]
                             },
                             {
@@ -133,7 +133,7 @@
                                 "anchor": "ramp_down_tests",
                                 "active": false,
                                 "textblock": [
-                                    "Dies wird nur noch bis 19. April 2023 möglich sein, wenn die Infrastruktur abgeschaltet wird. Bitte erkundigen Sie sich für den Abruf von Testergebnissen und Laborbefunden bei dem jeweiligen Anbieter."
+                                    "Dies wird nur noch bis 19. April 2023 möglich sein, da dann die Infrastruktur abgeschaltet wird. Bitte erkundigen Sie sich für den Abruf von Testergebnissen und Laborbefunden bei dem jeweiligen Anbieter."
                                 ]
                             },
                             {


### PR DESCRIPTION
## Description
This PR fixes a wrong past tense in "ramp_down_functionality" and fixes the German text in "ramp_down_tests".

## What was changed?
- src/data/faq.json
- src/data/faq_de.json

## Screenshots
This is a minor change only, if you want I can still provide screenshots for it. 