### PR TITLE
Update FAQ #ramp_down_stores: Remove second sentence

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -49,8 +49,7 @@
                                 "anchor": "ramp_down_stores",
                                 "active": false,
                                 "textblock": [
-                                    "The CWA will be available in the app stores of Apple and Google until May 31, 2023.",
-                                    "Whether the CWA will still be available and/or downloadable on other platforms is not known by us and is the responsibility of the respective operators of these platforms or software distribution channels."
+                                    "The CWA will be available in the app stores of Apple and Google until May 31, 2023."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -49,8 +49,7 @@
                                 "anchor": "ramp_down_stores",
                                 "active": false,
                                 "textblock": [
-                                    "Die Corona-Warn-App wird noch bis einschließlich 31. Mai 2023 in den Appstores von Apple und Google verfügbar sein.",
-                                    "Ob die CWA danach noch auf anderen Plattformen heruntergeladen werden kann, ist uns nicht bekannt und liegt in der Verantwortung der jeweiligen Plattform-Betreiber."
+                                    "Die Corona-Warn-App wird noch bis einschließlich 31. Mai 2023 in den Appstores von Apple und Google verfügbar sein."
                                 ]
                             },
                             {


### PR DESCRIPTION
This PR removes the sentence: "Whether the CWA will still be available and/or downloadable on other platforms is not known by us and is the responsibility of the respective operators of these platforms or software distribution channels." or "Ob die CWA danach noch auf anderen Plattformen heruntergeladen werden kann, ist uns nicht bekannt und liegt in der Verantwortung der jeweiligen Plattform-Betreiber." from the [#ramp_down_stores](https://www.coronawarn.app/en/faq/results/#ramp_down_stores) FAQ entry

![image](https://user-images.githubusercontent.com/88365935/228448490-f1dd99d9-eef6-471c-9d8e-39d85a3f3158.png)
![image](https://user-images.githubusercontent.com/88365935/228448529-d629e924-99eb-4530-bd6d-1b3e29c945bd.png)

---
Internal Tracking ID: [EXPOSUREAPP-15000](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15000)