### PR TITLE
Update #ramp_down_apk: Small text and title changes

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -61,7 +61,7 @@
                                 ]
                             },
                             {
-                                "title": "Will reproducible builds/APKs still be provided? Is a community-operated backend supported?",
+                                "title": "Will reproducible builds/APKs be provided? Is a community-operated backend supported?",
                                 "anchor": "ramp_down_apk",
                                 "active": false,
                                 "textblock": [

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -66,7 +66,7 @@
                                 "active": false,
                                 "textblock": [
                                     "No, no reproducible builds or APKs are provided by the CWA development (APK...Android Package Kit = package format to build the app locally by yourself).",
-                                    "However, it is possible (albeit with considerable effort) to set up the required infrastructure in the community itself and run it productively based on the provided documentation. Please note, support for this setup will not be provided by BMG and RKI."
+                                    "However, it is possible (albeit with considerable effort) to set up the required infrastructure in the community itself and run it productively based on the provided documentation. Please note, support for this setup will not be provided by BMG or RKI."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -66,7 +66,7 @@
                                 "active": false,
                                 "textblock": [
                                     "Nein, von der CWA-Entwicklung werden keine reproduzierbaren Builds oder APKs (Android Package Kit als Paket-Format, um sich die App lokal selbst zu erstellen) bereitgestellt.",
-                                    "Grundsätzlich ist es aber möglich, auf Basis der bereitgestellten Dokumentation die benötigte Infrastruktur in der Community selbst aufzusetzen und produktiv zu betreiben. Support dafür wird es seitens BMG und RKI nicht geben."
+                                    "Grundsätzlich ist es aber möglich, auf Basis der bereitgestellten Dokumentation die benötigte Infrastruktur in der Community selbst aufzusetzen und produktiv zu betreiben. Support dafür wird es seitens BMG oder RKI nicht geben."
                                 ]
                             },
                             {


### PR DESCRIPTION
This PR changes the English FAQ title of #ramp_down_apk to match with the German title by removing the word "still". In addition to that, the last sentence was slightly changed. See https://github.com/corona-warn-app/cwa-website/pull/3455#issuecomment-1490214683

![image](https://user-images.githubusercontent.com/88365935/228844676-f44f7db4-e1e1-4269-ad06-146ecbc3d3c7.png)
![image](https://user-images.githubusercontent.com/88365935/228844688-0baf5503-d14a-4ca5-9456-f81bd436e4f5.png)
