### PR TITLE
fix: apk can be installed locally

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -65,7 +65,7 @@
                                 "anchor": "ramp_down_apk",
                                 "active": false,
                                 "textblock": [
-                                    "No, no reproducible builds or APKs are provided by the CWA development (APK...Android Package Kit = package format to build the app locally by yourself).",
+                                    "No, no reproducible builds or APKs are provided by the CWA development (APK...Android Package Kit = package format to install the app locally by yourself).",
                                     "However, it is possible (albeit with considerable effort) to set up the required infrastructure in the community itself and run it productively based on the provided documentation. Please note, support for this setup will not be provided by BMG or RKI."
                                 ]
                             },

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -65,7 +65,7 @@
                                 "anchor": "ramp_down_apk",
                                 "active": false,
                                 "textblock": [
-                                    "Nein, von der CWA-Entwicklung werden keine reproduzierbaren Builds oder APKs (Android Package Kit als Paket-Format, um sich die App lokal selbst zu erstellen) bereitgestellt.",
+                                    "Nein, von der CWA-Entwicklung werden keine reproduzierbaren Builds oder APKs (Android Package Kit als Paket-Format, um die App lokal selbst zu installieren) bereitgestellt.",
                                     "Grundsätzlich ist es aber möglich, auf Basis der bereitgestellten Dokumentation die benötigte Infrastruktur in der Community selbst aufzusetzen und produktiv zu betreiben. Support dafür wird es seitens BMG oder RKI nicht geben."
                                 ]
                             },


### PR DESCRIPTION
This PR corrects the definition of an Android APK, which is a single file containing all of the app code and which can be installed independently of access to the Google Play Store.

It resolves one aspect of issue #3449 and changes:

- https://www.coronawarn.app/en/faq/results/#ramp_down_apk
- https://www.coronawarn.app/de/faq/results/#ramp_down_apk

---
Internal Tracking ID: [EXPOSUREAPP-15017](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15017)
