### PR TITLE
update ramp_down_info FAQ EN

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -49,7 +49,7 @@
                                 "anchor": "ramp_down_info",
                                 "active": false,
                                 "textblock": [
-                                    "After April 30, 2023, the Corona-Warn-App is going to trigger the technical instruction to stop the ENF (Exposure Notification Framework). This command will cause the smartphone’s operating system to stop exchanging random IDs and to delete all encounter information. ",
+                                    "After April 30, 2023, the Corona-Warn-App will deactivate the ENF (Exposure Notification Framework). This command will cause the smartphone’s operating system to stop exchanging random IDs and to delete all encounter information. ",
                                     "The ENF can also be deactivated manually; your guidance on this can be found in the <a href='#ramp_down_exchange' target='_blank'>FAQ on random IDs</a>.",
                                     "At the end of the Corona-Warn-App development and the cutback of the functions you can still back up your entries and certificates (see also the advice in the <a href='#ramp_down_backup' target='_blank'>FAQ on backup of data</a>).",
                                     "The exported data falls outside the scope of CWA and is therefore the responsibility of the user.  This data must be carefully handled by the user and manually deleted if deemed necessary or requested."

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -49,7 +49,7 @@
                                 "anchor": "ramp_down_info",
                                 "active": false,
                                 "textblock": [
-                                    "After April 30, 2023, the Corona-Warn-App will deactivate the ENF (Exposure Notification Framework). This command will cause the smartphone’s operating system to stop exchanging random IDs and to delete all encounter information. ",
+                                    "After April 30, 2023, the Corona-Warn-App will deactivate the ENF (Exposure Notification Framework). This will cause the smartphone’s operating system to stop exchanging random IDs and to delete all encounter information. ",
                                     "The ENF can also be deactivated manually; your guidance on this can be found in the <a href='#ramp_down_exchange' target='_blank'>FAQ on random IDs</a>.",
                                     "At the end of the Corona-Warn-App development and the cutback of the functions you can still back up your entries and certificates (see also the advice in the <a href='#ramp_down_backup' target='_blank'>FAQ on backup of data</a>).",
                                     "The exported data falls outside the scope of CWA and is therefore the responsibility of the user.  This data must be carefully handled by the user and manually deleted if deemed necessary or requested."


### PR DESCRIPTION
Simplification of English text for ENF deactivation.

This follows on from the suggestion in https://github.com/corona-warn-app/cwa-website/pull/3457#discussion_r1162449312.

The English text is better aligned to the German text and thereby also simplified.

https://www.coronawarn.app/en/faq/results/#ramp_down_info reads:

"After April 30, 2023, the Corona-Warn-App will deactivate the ENF (Exposure Notification Framework)."
