### PR TITLE
Update Screenshots 3.1 | Fix date format

### DIFF
--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -9,7 +9,7 @@
         },
         "content": {
             "textblock": [
-                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 3.1 (available since 27th Februar, 2023). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
+                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 3.1 (available since February 27, 2023). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
                 "With this update we are fixing bugs in the app. It does not contain any new features.",
                 "The images provided on this page are available for free use."
             ]


### PR DESCRIPTION
Thanks to @MikeMcC399 for noticing this issue.

We decided on this standard format for English language dates a while ago. Also the month "Februar" is the German spelling, not the English spelling.