### PR TITLE
Fix Blog 3.2 | Invalid link

### DIFF
--- a/blog/2023-04-19-cwa-3-2/index.md
+++ b/blog/2023-04-19-cwa-3-2/index.md
@@ -9,6 +9,6 @@ layout: blog
 
 The project team of the Robert Koch Institute, Deutsche Telekom, and SAP have **released version 3.2 of the Corona-Warn-App (CWA)**. Version 3.2, like previous versions, will be rolled out to all users in stages over 48 hours. iOS users can now download the latest app version manually from the Apple Store. The Google Play Store does not offer the option of triggering a manual update. The new version of the Corona-Warn-App will be available to users here within the next 48 hours.
 
-**Important:** You will only be able to warn others via the CWA until April 30, 2023. All questions and answers on this topic can be found [here](../../faq/results/#ramp_down).
+**Important:** You will only be able to warn others via the CWA until April 30, 2023. All questions and answers on this topic can be found [here](../../../en/faq/results/#ramp_down).
 
 <!-- overview -->

--- a/blog/2023-04-19-cwa-3-2/index_de.md
+++ b/blog/2023-04-19-cwa-3-2/index_de.md
@@ -9,6 +9,6 @@ layout: blog
 
 Das Projektteam aus Robert Koch-Institut (RKI), Deutscher Telekom und SAP hat **Version 3.2 der Corona-Warn-App (CWA) veröffentlicht**. Version 3.2 wird, wie vorherige Versionen auch, schrittweise über 48 Stunden an alle Nutzer\*innen ausgerollt. iOS-Nutzer\*innen können sich die aktuelle App-Version ab sofort aus dem Store von Apple manuell herunterladen. Der Google Play Store bietet keine Möglichkeit, ein manuelles Update anzustoßen. Hier steht Nutzer\*innen die neue Version der Corona-Warn-App innerhalb der nächsten 48 Stunden zur Verfügung.
 
-**Wichtig:** Es wird nur noch bis zum 30. April 2023 möglich sein, andere Personen über die CWA zu warnen. Alle Fragen und Antworten zu diesem Thema finden Sie [hier](../../faq/results/#ramp_down).
+**Wichtig:** Es wird nur noch bis zum 30. April 2023 möglich sein, andere Personen über die CWA zu warnen. Alle Fragen und Antworten zu diesem Thema finden Sie [hier](../../../de/faq/results/#ramp_down).
 
 <!-- overview -->


### PR DESCRIPTION
This PR fixes an issue where the FAQ link inside the blog wouldn't link to the FAQ when clicking on it from the blog overview.