### PR TITLE
Fix timeout on faq_link_attr.cy.js

### DIFF
--- a/cypress/e2e/faq_link_attr.cy.js
+++ b/cypress/e2e/faq_link_attr.cy.js
@@ -7,6 +7,11 @@ describe("Check attributes of FAQ links", () => {
     const faqResultsUrl = '/faq/results/';
     const languages = ["en", "de"];
 
+    // This works around some timeout issues
+    beforeEach(() => {
+        cy.visit('/')
+    })
+
     describe("Check links are using _blank to open in new frame", () => {
 
         const containers = [


### PR DESCRIPTION
This PR adds a workaround to [cypress/e2e/faq_link_attr.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/faq_link_attr.cy.js) to resolve https://github.com/corona-warn-app/cwa-website/issues/3479.

Before each sub-test the root `\` of the website under test is visited. This seems to work around a timeout issue where web contents was sometimes not displayed.

This is a problem with the website, not with the test, however it is now unlikely that there will be a fix for the website, so the workaround is added to the Cypress test.
