### PR TITLE
Add information to screenshots page

### DIFF
--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -9,7 +9,7 @@
         },
         "content": {
             "textblock": [
-                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 3.2 (available since April, 19 2023). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
+                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 3.2 (available since April 19, 2023). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
                 "With this update we are fixing bugs in the app. It does not contain any new features. The screenshots page displays the implementation prior to the function reduction on May 1, 2023. For more information, please refer to the <a href='../blog/2023-05-02-reduction-of-functions/' target='_blank'>blog</a>.",
                 "The images provided on this page are available for free use."
             ]

--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -10,7 +10,7 @@
         "content": {
             "textblock": [
                 "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 3.2 (available since 19. April, 2023). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
-                "With this update we are fixing bugs in the app. It does not contain any new features.",
+                "With this update we are fixing bugs in the app. It does not contain any new features. The screenshots page displays the implementation prior to the function reduction on May 1, 2023. For more information, please refer to the <a href='../blog/2023-05-02-reduction-of-functions/' target='_blank'>blog</a>.",
                 "The images provided on this page are available for free use."
             ]
         },

--- a/src/data/screenshots.json
+++ b/src/data/screenshots.json
@@ -9,7 +9,7 @@
         },
         "content": {
             "textblock": [
-                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 3.2 (available since 19. April, 2023). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
+                "Browse through the screenshots to get an overview of the features offered by the Corona-Warn-App with the release of Version 3.2 (available since April, 19 2023). Please note that the screenshots may vary slightly between Android and iOS due to technical reasons.",
                 "With this update we are fixing bugs in the app. It does not contain any new features. The screenshots page displays the implementation prior to the function reduction on May 1, 2023. For more information, please refer to the <a href='../blog/2023-05-02-reduction-of-functions/' target='_blank'>blog</a>.",
                 "The images provided on this page are available for free use."
             ]

--- a/src/data/screenshots_de.json
+++ b/src/data/screenshots_de.json
@@ -11,7 +11,7 @@
         "content": {
             "textblock": [
                 "Verschaffen Sie sich mithilfe von Screenshots einen Überblick über die Funktionen, die die Corona-Warn-App mit Version 3.2 (verfügbar seit 19. April 2023) bietet. Bitte beachten Sie, dass die Screenshots für Android und iOS designbedingt leicht voneinander abweichen können.",
-                "Mit diesem Update beheben wir Fehler in der App. Es enthält keine neuen Funktionen.",
+                "Mit diesem Update beheben wir Fehler in der App. Es enthält keine neuen Funktionen. Die Screenshots-Seite zeigt die Implementation vor der Funktionsreduzierung am 01. Mai 2023 an. Weitere Infos dazu finden Sie im <a href='../blog/2023-05-02-reduction-of-functions/' target='_blank'>Blog</a>.",
                 "Die auf dieser Seite zur Verfügung gestellten Bilder stehen zur freien Nutzung bereit."
             ]
         },


### PR DESCRIPTION
## Description

This PR adds an informational disclaimer to the screenshots page, stating that it shows the screenshots prior to function reduction on May 1.

## What was changed

- https://github.com/corona-warn-app/cwa-website/blob/master/src/data/screenshots.json
- https://github.com/corona-warn-app/cwa-website/blob/master/src/data/screenshots_de.json

## Screenshots
| English | German |
|---|---|
| <img src="https://user-images.githubusercontent.com/67682506/235779972-55374d7d-5eee-4920-8cb7-43faff470ba9.png" width="300"> | <img src="https://user-images.githubusercontent.com/67682506/235779996-2a14f74a-215a-4abb-9b2c-c908fb5ab077.png" width="300"> |

---

**Fixes https://github.com/corona-warn-app/cwa-website/issues/3481**

---
Internal Tracking ID: [EXPOSUREAPP-14634](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14634)
