### PR TITLE
disable faq_link_attr test in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,10 +21,10 @@ jobs:
 
     - name: Check if the page builds
       run: npm run-script build
-      
+
     - name: Zip build
       run: zip -r public.zip public -x "public/assets/screenshots/*" "public/assets/img/blog/*" "public/assets/img/science/*"
-      
+
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
@@ -39,8 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          ["app_to_web","applink","blog","check_anchor_links","check_videos","eventRegistration","faq","faq_link_attr","hotline","mime"]
-      
+          ["app_to_web","applink","blog","check_anchor_links","check_videos","eventRegistration","faq","hotline","mime"]
+
 
     steps:
     - name: Check out repository
@@ -58,10 +58,10 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: public
-    
+
     - name: Unzip build
       run: unzip public.zip
-      
+
     - name: Test the website
       run: npx start-server-and-test start-server http://localhost:8000 "cypress run -s 'cypress/e2e/${{ matrix.test }}.cy.js' --e2e --headless --browser chrome"
       env:

--- a/.github/workflows/cypress-test-prod.yml
+++ b/.github/workflows/cypress-test-prod.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm ci
 
       - name: Cypress run
-        run: npx cypress run -s 'cypress/e2e/*.js' -c baseUrl=https://www.coronawarn.app --e2e --headless --browser chrome
+        run: npx cypress run -s 'cypress/e2e/*.js,!cypress/e2e/faq_link_attr.cy.js' -c baseUrl=https://www.coronawarn.app --e2e --headless --browser chrome
         env:
           # See issue https://github.com/cypress-io/cypress/issues/25357
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'


### PR DESCRIPTION
This is a workaround for issue https://github.com/corona-warn-app/cwa-website/issues/3479.

It disables the test [cypress/e2e/faq_link_attr.cy.js](https://github.com/corona-warn-app/cwa-website/blob/master/cypress/e2e/faq_link_attr.cy.js) from running in CI workflows.

Internal Tracking ID: [EXPOSUREAPP-15135](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15135)