### PR TITLE
Event QR Code pages: Explanation about outdated page info in blue box 

### DIFF
--- a/src/data/event-qr-code-guide.json
+++ b/src/data/event-qr-code-guide.json
@@ -1,4 +1,9 @@
 {
+    "section-notice": {
+        "textblock": [
+            "<div class='update'>Since it is no longer possible to warn other users through the Corona-Warn-App regarding an increased risk of infection as of May 1, 2023, you can no longer use the QR codes created on this page or other tools to register for events and locations. As such, the information on this page is related to features of the app that are no longer available as of May 1, 2023. For more information, click here: <a href='../faq/results/#ramp_down' target='_blank'> What is the background for the end of the development of the CWA?</a></div>"
+        ]
+    },
     "section-main": {
         "headline": {
             "title": "How do I use the official Corona-Warn-App QR code tool?"

--- a/src/data/event-qr-code-guide.json
+++ b/src/data/event-qr-code-guide.json
@@ -1,7 +1,7 @@
 {
     "section-notice": {
         "textblock": [
-            "<div class='update'>Since it is no longer possible to warn other users through the Corona-Warn-App regarding an increased risk of infection as of May 1, 2023, you can no longer use the QR codes created on this page or other tools to register for events and locations. As such, the information on this page is related to features of the app that are no longer available as of May 1, 2023. For more information, click here: <a href='../faq/results/#ramp_down' target='_blank'> What is the background for the end of the development of the CWA?</a></div>"
+            "<div class='update'>Since it is no longer possible to warn other users through the Corona-Warn-App regarding an increased risk of infection as of May 1, 2023, you can no longer use the QR codes created on this page or with other tools to register for events and locations. As such, the information on this page is related to features of the app that are no longer available as of May 1, 2023. For more information, click here: <a href='../faq/results/#ramp_down' target='_blank'> What is the background for the end of the development of the CWA?</a></div>"
         ]
     },
     "section-main": {

--- a/src/data/event-qr-code-guide_de.json
+++ b/src/data/event-qr-code-guide_de.json
@@ -1,4 +1,9 @@
 {
+    "section-notice": {
+        "textblock": [
+            "<div class='update'>Da es seit dem 1. Mai 2023 nicht mehr möglich ist, andere Nutzerinnen und Nutzer durch die Corona-Warn-App hinsichtlich eines erhöhten Infektionsrisikos zu warnen, können Sie mit den auf dieser Seite oder anderen Werkzeugen erstellten QR-Codes keine Registrierung für Events und Orte mehr durchführen. Die Informationen auf dieser Seite stehen also im Zusammenhang mit Funktionen der App, die seit dem 1. Mai 2023 nicht mehr zur Verfügung stehen, und sind daher nicht mehr aktuell. Weitere Informationen finden Sie hier: <a href='../faq/results/#ramp_down' target='_blank'>Was ist der Hintergrund für das Ende der Entwicklung der CWA?</a></div>"
+        ]
+    },
     "section-main": {
         "headline": {
             "title": "Wie benutze ich das offizielle Corona-Warn-App QR-Code-Werkzeug?"

--- a/src/data/eventregistration.json
+++ b/src/data/eventregistration.json
@@ -1,4 +1,9 @@
 {
+    "section-notice": {
+        "textblock": [
+            "<div class='update'>Since it is no longer possible to warn other users through the Corona-Warn-App regarding an increased risk of infection as of May 1, 2023, you can no longer use the QR codes created on this page or other tools to register for events and locations. As such, the information on this page is related to features of the app that are no longer available as of May 1, 2023. For more information, click here: <a href='../faq/results/#ramp_down' target='_blank'> What is the background for the end of the development of the CWA?</a></div>"
+        ]
+    },
     "section-main": {
         "headline": {
             "title": "Create QR code for event check-in"

--- a/src/data/eventregistration.json
+++ b/src/data/eventregistration.json
@@ -1,7 +1,7 @@
 {
     "section-notice": {
         "textblock": [
-            "<div class='update'>Since it is no longer possible to warn other users through the Corona-Warn-App regarding an increased risk of infection as of May 1, 2023, you can no longer use the QR codes created on this page or other tools to register for events and locations. As such, the information on this page is related to features of the app that are no longer available as of May 1, 2023. For more information, click here: <a href='../faq/results/#ramp_down' target='_blank'> What is the background for the end of the development of the CWA?</a></div>"
+            "<div class='update'>Since it is no longer possible to warn other users through the Corona-Warn-App regarding an increased risk of infection as of May 1, 2023, you can no longer use the QR codes created on this page or with other tools to register for events and locations. As such, the information on this page is related to features of the app that are no longer available as of May 1, 2023. For more information, click here: <a href='../faq/results/#ramp_down' target='_blank'> What is the background for the end of the development of the CWA?</a></div>"
         ]
     },
     "section-main": {

--- a/src/data/eventregistration_de.json
+++ b/src/data/eventregistration_de.json
@@ -1,4 +1,9 @@
 {
+    "section-notice": {
+        "textblock": [
+            "<div class='update'>Da es seit dem 1. Mai 2023 nicht mehr möglich ist, andere Nutzerinnen und Nutzer durch die Corona-Warn-App hinsichtlich eines erhöhten Infektionsrisikos zu warnen, können Sie mit den auf dieser Seite oder anderen Werkzeugen erstellten QR-Codes keine Registrierung für Events und Orte mehr durchführen. Die Informationen auf dieser Seite stehen also im Zusammenhang mit Funktionen der App, die seit dem 1. Mai 2023 nicht mehr zur Verfügung stehen, und sind daher nicht mehr aktuell. Weitere Informationen finden Sie hier: <a href='../faq/results/#ramp_down' target='_blank'>Was ist der Hintergrund für das Ende der Entwicklung der CWA?</a></div>"
+        ]
+    },
     "section-main": {
         "headline": {
             "title": "QR-Code für Event Check-in erstellen"

--- a/src/partials/page-event-qr-code-guide.html
+++ b/src/partials/page-event-qr-code-guide.html
@@ -2,6 +2,11 @@
 <section class="section component qrgenerator">
   <div class="container">
     <div class="container-inner container-inner_lg">
+      <div>
+        {{#each page-contents.section-notice.textblock}}
+        <p>{{{.}}}</p>
+        {{/each}}
+      </div>
       <h1 class="h2 headline">{{{page-contents.section-main.headline.title}}}</h1>
       <p>{{{page-contents.section-main.intro}}}</p>
 

--- a/src/partials/page-eventregistration.html
+++ b/src/partials/page-eventregistration.html
@@ -2,6 +2,11 @@
 <section class="section component qrgenerator comment">
   <div class="container">
     <div class="container-inner container-inner_lg">
+      <div>
+        {{#each page-contents.section-notice.textblock}}
+        <p>{{{.}}}</p>
+        {{/each}}
+      </div>
       <h1 class="h2 headline">{{page-contents.section-main.headline.title}}</h1>
 
       <p>{{page-contents.section-main.intro}}</p>


### PR DESCRIPTION
See https://github.com/corona-warn-app/cwa-website/issues/3484

Blue info-box added to:

1. https://www.coronawarn.app/de/eventregistration/
2.  https://www.coronawarn.app/en/eventregistration/
3.  https://www.coronawarn.app/en/event-qr-code-guide/
4. https://www.coronawarn.app/de/event-qr-code-guide/

**- DE info box**
<img width="769" alt="image" src="https://user-images.githubusercontent.com/1409741/236258787-edfde7a5-a755-41f5-a5d5-534c05e649f0.png">

**- EN info box**
<img width="752" alt="image" src="https://user-images.githubusercontent.com/1409741/236259027-a4bc5b34-fe65-4dcc-9a3c-466afa2b9771.png">

---
Internal Tracking ID: [EXPOSUREAPP-15169](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15169)
