### PR TITLE
Update deploy-master.yml: Remove cron jobs

### DIFF
--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -6,9 +6,12 @@ name: Deploy Website
 on:
   push:
     branches: ["master"]
-  schedule:
-    - cron: '0 11 * * *'
-    - cron: '0 17 * * *'
+#  cron jobs are not necessary anymore: 
+#  they were done to update the fallback file for the dashboard, in case the TSI server dwas down
+#  Dashboard is now using static files on website server
+#  schedule:
+#    - cron: '0 11 * * *'
+#    - cron: '0 17 * * *'
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "prod"


### PR DESCRIPTION
Cron jobs are not necessary anymore:
They were done to update the fallback file for the dashboard, in case the TSI server was down.
Dashboard is now using static files on website server.