### PR TITLE
Display German version of screenshots archive

### DIFF
--- a/src/pages/de/screenshots-archive/3-0.html
+++ b/src/pages/de/screenshots-archive/3-0.html
@@ -6,4 +6,4 @@ page-name: 3-0
 lightbox: true
 screenshotsarchive: true
 ---
-{{> page-screenshots page-contents=screenshots-archive-3-0}}
+{{> page-screenshots page-contents=screenshots-archive-3-0_de}}

--- a/src/pages/de/screenshots-archive/3-1.html
+++ b/src/pages/de/screenshots-archive/3-1.html
@@ -6,4 +6,4 @@ page-name: 3-1
 lightbox: true
 screenshotsarchive: true
 ---
-{{> page-screenshots page-contents=screenshots-archive-3-1}}
+{{> page-screenshots page-contents=screenshots-archive-3-1_de}}


### PR DESCRIPTION
## Description
This PR displays the German version of the screenshots archive of version 3.0 and 3.1.

## What was changed?
- https://github.com/corona-warn-app/cwa-website/blob/master/src/pages/de/screenshots-archive/3-0.html
- https://github.com/corona-warn-app/cwa-website/blob/master/src/pages/de/screenshots-archive/3-1.html

---

**This PR fixes #3501**