### PR TITLE
Change app removal date in FAQ entry `ramp_down_stores`

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -60,7 +60,7 @@
                                 "anchor": "ramp_down_stores",
                                 "active": false,
                                 "textblock": [
-                                    "The CWA will be available in the app stores of Apple and Google until May 31, 2023."
+                                    "The CWA will be available in the app stores of Apple and Google until mid June 2023."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -60,7 +60,7 @@
                                 "anchor": "ramp_down_stores",
                                 "active": false,
                                 "textblock": [
-                                    "Die Corona-Warn-App wird noch bis einschließlich 31. Mai 2023 in den Appstores von Apple und Google verfügbar sein."
+                                    "Die Corona-Warn-App wird noch bis Mitte Juni 2023 in den Appstores von Apple und Google verfügbar sein."
                                 ]
                             },
                             {


### PR DESCRIPTION
## Description

This PR changes the date of the app removal, as the app will continue to be available until mid-June, in the FAQ entry `ramp_down_stores`

## Screenshots

| English | German |
|---|---|
| ![Bildschirmfoto 2023-05-31 um 15 04 03](https://github.com/corona-warn-app/cwa-website/assets/67682506/d0b5f22c-fd42-4209-ba9e-7b02cac7aef9) | ![Bildschirmfoto 2023-05-31 um 15 03 39](https://github.com/corona-warn-app/cwa-website/assets/67682506/f1928f02-e15b-4ff3-b04b-e571d6c6d3d2) |