### PR TITLE
Add link back to the footnote (SB 2)

### DIFF
--- a/science/2021-07-08-science-blog-2/index.md
+++ b/science/2021-07-08-science-blog-2/index.md
@@ -2902,4 +2902,4 @@ The RKI intends to publish further articles based on the data gathered with the 
 
 <div id="footnote1"></div>
 
-[1] [CWA data donation](../2021-06-15-science-blog-1/#data-donation) refers to the voluntary provision of usage data (Privacy Preserving Analytics, PPA) by the users of the Corona-Warn-App
+[[1]](#2-the-balancing-act-between-minimising-data-collection-and-the-need-for-data-for-research) The [CWA data donation](../2021-06-15-science-blog-1/#data-donation) refers to the voluntary provision of usage data (Privacy Preserving Analytics, PPA) by the users of the Corona-Warn-App.

--- a/science/2021-07-08-science-blog-2/index_de.md
+++ b/science/2021-07-08-science-blog-2/index_de.md
@@ -2913,4 +2913,4 @@ Das RKI wird in den nächsten Wochen weitere Beiträge aus EDUS veröffentlichen
 
 <div id="footnote1"></div>
 
-[1] [CWA-Datenspende](../2021-06-15-science-blog-1/#datenspende) bezieht sich auf das freiwillige Zurverfügungstellen von Nutzungsdaten (Privacy Preserving Analytics, PPA) durch die Nutzenden der Corona-Warn-App.
+[[1]](#2-der-spagat-zwischen-datensparsamkeit-und-wissenschaftlichen-erkenntnissen) Die [CWA-Datenspende](../2021-06-15-science-blog-1/#datenspende) bezieht sich auf das freiwillige Zurverfügungstellen von Nutzungsdaten (Privacy Preserving Analytics, PPA) durch die Nutzenden der Corona-Warn-App.


### PR DESCRIPTION
## Description

After review with the team we agreed that there needs to be a way to jump back to the text where the footnote is linked to. This PR implements this.

