### PR TITLE
Remove last section on main page: "Download the app"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          ["app_to_web","applink","blog","check_anchor_links","check_videos","eventRegistration","faq","faq_link_attr","mime"]
+          ["app_to_web","blog","check_anchor_links","check_videos","eventRegistration","faq","faq_link_attr","mime"]
 
 
     steps:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -65,7 +65,6 @@ The command `npm run test:short` runs all Cypress tests from the top level direc
 | Cypress test name  | Purpose                                                                                                                 |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | app_to_web         | Checks that all links to the website used by the Android and iOS apps are working.                                      |
-| applink_spec       | Detects broken links or missing OS badges to download mobile app in home page.                                          |
 | blog_spec          | Checks if the blog archive is accessible.                                                                               |
 | check_anchor_links | Detects broken anchor links throughout the website.                                                                     |
 | check_videos       | Detects broken videos throughout the website.                                                                           |

--- a/src/partials/page-index.html
+++ b/src/partials/page-index.html
@@ -51,9 +51,12 @@
         </div>
     </div>
 </section>
-{{> section-get-app section-contents=page-contents.section-join-project.content
+
+<!-- 
+    {{> section-get-app section-contents=page-contents.section-join-project.content
 section-class='section-sticky section_bg-white hidden js-section-sticky'
 section-cancelable=true}}
+-->
 
 <section class="section_bg-white comment" {{#if page-contents.section-works-best.id}}
     id="{{page-contents.section-works-best.id}}" {{/if}}>

--- a/src/partials/page-index.html
+++ b/src/partials/page-index.html
@@ -273,7 +273,8 @@ section-cancelable=true}}
         </div>
     </div>
 </section>
-{{> section-get-app section-contents=page-contents.section-join-project.content
+<!--
+    {{> section-get-app section-contents=page-contents.section-join-project.content
 section-class='section-intersect section_bg-white'}}
 {{#unless @root.get-app-enabled}}
 {{#if page-contents.section-soon-available}}
@@ -285,3 +286,4 @@ section-class='section-intersect section_bg-white'}}
 {{/if}}
 {{/unless}}
 {{/if}}
+-->


### PR DESCRIPTION
- remove from documentation "testing.md":
| applink_spec       | Detects broken links or missing OS badges to download mobile app in home page.                                          |
- remove cypress test app link 
- Update page-index.html: remove last section on main page: "Download the app":

**OLD**

<img width="712" alt="image" src="https://github.com/corona-warn-app/cwa-website/assets/1409741/52ea0d04-7ec6-4ddb-aace-9eb3dad79632">

**NEW**

<img width="707" alt="image" src="https://github.com/corona-warn-app/cwa-website/assets/1409741/fc952ac4-ba2e-4d01-b48d-33e5da1704ad">


